### PR TITLE
Discordへの通知機能を修正

### DIFF
--- a/src/nyxpy/framework/core/api/discord_notification.py
+++ b/src/nyxpy/framework/core/api/discord_notification.py
@@ -1,7 +1,9 @@
 import requests
 from typing import Optional
 import cv2
+import io
 from .notification_interface import NotificationInterface
+from nyxpy.framework.core.logger.log_manager import log_manager
 
 class DiscordNotification(NotificationInterface):
     def __init__(self, webhook_url: str):
@@ -10,21 +12,17 @@ class DiscordNotification(NotificationInterface):
     def notify(self, text: str, img: Optional[cv2.Mat] = None) -> None:
         try:
             if img is not None:
-                # 画像がある場合は一時ファイルとして保存して送信
-                import tempfile
-                import numpy as np
-                import os
-                _, tmp_path = tempfile.mkstemp(suffix='.png')
-                cv2.imwrite(tmp_path, img)
-                with open(tmp_path, 'rb') as f:
-                    files = {'file': f}
-                    data = {'content': text}
-                    requests.post(self.webhook_url, data=data, files=files, timeout=5)
-                os.remove(tmp_path)
+                # 画像をメモリ上でエンコードし、そのまま送信
+                ret, buf = cv2.imencode('.png', img)
+                if not ret:
+                    raise ValueError('画像のエンコードに失敗しました')
+                file_obj = io.BytesIO(buf.tobytes())
+                file_obj.name = 'image.png'  # Discordはファイル名が必要
+                files = {'file': (file_obj.name, file_obj, 'image/png')}
+                data = {'content': text}
+                requests.post(self.webhook_url, data=data, files=files, timeout=5)
             else:
                 data = {'content': text}
                 requests.post(self.webhook_url, data=data, timeout=5)
         except Exception as e:
-            # エラーはログ出力のみ
-            import logging
-            logging.getLogger(__name__).error(f"Discord通知失敗: {e}")
+            log_manager.log("ERROR", f"Discord通知失敗: {e}", component="DiscordNotification")


### PR DESCRIPTION
一時ファイルを作らずに生の画像データを用いて通知を行うように変更