### PR TITLE
test(framework): フェーズ1の互換テストを追加

### DIFF
--- a/tests/integration/test_macro_runtime_entrypoints.py
+++ b/tests/integration/test_macro_runtime_entrypoints.py
@@ -1,0 +1,27 @@
+import importlib
+from pathlib import Path
+
+import pytest
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason="MacroRuntime is introduced before GUI/CLI migration in later phases.",
+)
+def test_macro_runtime_module_is_available_for_entrypoints() -> None:
+    importlib.import_module("nyxpy.framework.core.runtime")
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason="CLI and GUI stop importing MacroExecutor after runtime adapter migration.",
+)
+def test_gui_cli_entrypoints_do_not_import_macro_executor() -> None:
+    repo_root = Path(__file__).resolve().parents[2]
+    entrypoint_sources = [
+        repo_root / "src" / "nyxpy" / "cli" / "run_cli.py",
+        repo_root / "src" / "nyxpy" / "gui" / "main_window.py",
+    ]
+
+    for source_path in entrypoint_sources:
+        assert "MacroExecutor" not in source_path.read_text(encoding="utf-8")

--- a/tests/integration/test_migrated_macro_compat.py
+++ b/tests/integration/test_migrated_macro_compat.py
@@ -1,0 +1,222 @@
+import importlib
+import inspect
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from nyxpy.framework.core.macro.base import MacroBase
+from nyxpy.framework.core.macro.command import Command
+from nyxpy.framework.core.macro.executor import MacroExecutor
+
+
+def _clear_macro_modules() -> None:
+    for module_name in list(sys.modules):
+        if module_name == "macros" or module_name.startswith("macros."):
+            del sys.modules[module_name]
+
+
+class RecordingCommand(Command):
+    def __init__(self) -> None:
+        self.logs: list[str] = []
+
+    def press(self, *keys, dur=0.1, wait=0.1) -> None:
+        self.logs.append(f"press:{keys}:{dur}:{wait}")
+
+    def hold(self, *keys) -> None:
+        self.logs.append(f"hold:{keys}")
+
+    def release(self, *keys) -> None:
+        self.logs.append(f"release:{keys}")
+
+    def wait(self, wait: float) -> None:
+        self.logs.append(f"wait:{wait}")
+
+    def stop(self) -> None:
+        self.logs.append("stop")
+
+    def log(self, *values, sep: str = " ", end: str = "\n", level: str = "DEBUG") -> None:
+        self.logs.append(sep.join(map(str, values)) + end.rstrip("\n"))
+
+    def capture(self, crop_region=None, grayscale: bool = False):
+        self.logs.append(f"capture:{crop_region}:{grayscale}")
+        return None
+
+    def save_img(self, filename: str | Path, image) -> None:
+        self.logs.append(f"save_img:{filename}:{image}")
+
+    def load_img(self, filename: str | Path, grayscale: bool = False):
+        self.logs.append(f"load_img:{filename}:{grayscale}")
+        return None
+
+    def keyboard(self, text: str) -> None:
+        self.logs.append(f"keyboard:{text}")
+
+    def type(self, key) -> None:
+        self.logs.append(f"type:{key}")
+
+    def notify(self, text: str, img=None) -> None:
+        self.logs.append(f"notify:{text}:{img}")
+
+
+def _write_macro_package(macros_dir: Path, package_name: str, class_name: str) -> None:
+    package_dir = macros_dir / package_name
+    package_dir.mkdir()
+    (package_dir / "__init__.py").write_text(
+        f"from .macro import {class_name}\n__all__ = ['{class_name}']\n",
+        encoding="utf-8",
+    )
+    (package_dir / "macro.py").write_text(
+        textwrap.dedent(
+            f"""
+            from nyxpy.framework.core.macro.base import MacroBase
+            from nyxpy.framework.core.macro.command import Command
+
+
+            class {class_name}(MacroBase):
+                description = "{package_name}"
+                tags = ["test"]
+
+                def initialize(self, cmd: Command, args: dict) -> None:
+                    self.args = dict(args)
+
+                def run(self, cmd: Command) -> None:
+                    cmd.log("{class_name}.run")
+
+                def finalize(self, cmd: Command) -> None:
+                    cmd.log("{class_name}.finalize")
+            """
+        ),
+        encoding="utf-8",
+    )
+
+
+def _prepare_temp_project(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    macros_dir = tmp_path / "macros"
+    macros_dir.mkdir()
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.syspath_prepend(tmp_path)
+    _clear_macro_modules()
+    return macros_dir
+
+
+def test_convention_package_and_single_file_macros_load_without_manifest(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    macros_dir = _prepare_temp_project(tmp_path, monkeypatch)
+    _write_macro_package(macros_dir, "convention_package", "ConventionPackageMacro")
+    (macros_dir / "convention_single_file.py").write_text(
+        textwrap.dedent(
+            """
+            from nyxpy.framework.core.macro.base import MacroBase
+            from nyxpy.framework.core.macro.command import Command
+
+
+            class ConventionSingleFileMacro(MacroBase):
+                def initialize(self, cmd: Command, args: dict) -> None:
+                    self.args = dict(args)
+
+                def run(self, cmd: Command) -> None:
+                    cmd.log("single.run")
+
+                def finalize(self, cmd: Command) -> None:
+                    cmd.log("single.finalize")
+            """
+        ),
+        encoding="utf-8",
+    )
+
+    executor = MacroExecutor()
+
+    assert "ConventionPackageMacro" in executor.macros
+    assert "ConventionSingleFileMacro" in executor.macros
+    assert isinstance(executor.macros["ConventionPackageMacro"], MacroBase)
+    assert isinstance(executor.macros["ConventionSingleFileMacro"], MacroBase)
+
+
+def test_optional_manifest_file_does_not_break_package_macro_load(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    macros_dir = _prepare_temp_project(tmp_path, monkeypatch)
+    _write_macro_package(macros_dir, "manifest_package", "ManifestPackageMacro")
+    (macros_dir / "manifest_package" / "macro.toml").write_text(
+        textwrap.dedent(
+            """
+            [macro]
+            id = "manifest_package"
+            entrypoint = "macros.manifest_package.macro:ManifestPackageMacro"
+            display_name = "Manifest Package"
+            settings = "settings.toml"
+            """
+        ),
+        encoding="utf-8",
+    )
+
+    executor = MacroExecutor()
+
+    assert "ManifestPackageMacro" in executor.macros
+    assert isinstance(executor.macros["ManifestPackageMacro"], MacroBase)
+
+
+def test_file_settings_and_exec_args_are_merged_with_exec_args_precedence(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    macros_dir = _prepare_temp_project(tmp_path, monkeypatch)
+    (macros_dir / "settings_probe.py").write_text(
+        textwrap.dedent(
+            """
+            from nyxpy.framework.core.macro.base import MacroBase
+            from nyxpy.framework.core.macro.command import Command
+
+
+            class SettingsProbeMacro(MacroBase):
+                def initialize(self, cmd: Command, args: dict) -> None:
+                    self.args = dict(args)
+
+                def run(self, cmd: Command) -> None:
+                    cmd.log("settings_probe.run")
+
+                def finalize(self, cmd: Command) -> None:
+                    cmd.log("settings_probe.finalize")
+            """
+        ),
+        encoding="utf-8",
+    )
+    settings_dir = tmp_path / "static" / "settings_probe"
+    settings_dir.mkdir(parents=True)
+    (settings_dir / "settings.toml").write_text(
+        'value = "file"\nkeep = "file"\n',
+        encoding="utf-8",
+    )
+
+    executor = MacroExecutor()
+    executor.set_active_macro("SettingsProbeMacro")
+    executor.execute(RecordingCommand(), {"value": "exec", "other": 3})
+
+    assert executor.macro.args == {"value": "exec", "keep": "file", "other": 3}
+
+
+@pytest.mark.parametrize(
+    ("module_name", "class_name"),
+    [
+        ("macros.frlg_id_rng.macro", "FrlgIdRngMacro"),
+        ("macros.frlg_initial_seed.macro", "FrlgInitialSeedMacro"),
+        ("macros.frlg_gorgeous_resort.macro", "FrlgGorgeousResortMacro"),
+        ("macros.frlg_wild_rng.macro", "FrlgWildRngMacro"),
+    ],
+)
+def test_repository_representative_macros_keep_lifecycle_contract(
+    module_name: str, class_name: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo_root = Path(__file__).resolve().parents[2]
+    monkeypatch.syspath_prepend(repo_root)
+    _clear_macro_modules()
+
+    module = importlib.import_module(module_name)
+    macro_cls = getattr(module, class_name)
+
+    assert issubclass(macro_cls, MacroBase)
+    assert list(inspect.signature(macro_cls.initialize).parameters) == ["self", "cmd", "args"]
+    assert list(inspect.signature(macro_cls.run).parameters) == ["self", "cmd"]
+    assert list(inspect.signature(macro_cls.finalize).parameters) == ["self", "cmd"]

--- a/tests/unit/framework/macro/test_import_contract.py
+++ b/tests/unit/framework/macro/test_import_contract.py
@@ -1,0 +1,132 @@
+import importlib
+import inspect
+
+import pytest
+
+
+def _parameter_names(obj) -> list[str]:
+    return list(inspect.signature(obj).parameters)
+
+
+def test_macro_public_import_paths_are_stable() -> None:
+    from nyxpy.framework.core.constants import Button, Hat, KeyType, LStick, RStick
+    from nyxpy.framework.core.macro.base import MacroBase
+    from nyxpy.framework.core.macro.command import Command, DefaultCommand
+    from nyxpy.framework.core.macro.exceptions import MacroStopException
+
+    assert MacroBase.__module__ == "nyxpy.framework.core.macro.base"
+    assert Command.__module__ == "nyxpy.framework.core.macro.command"
+    assert DefaultCommand.__module__ == "nyxpy.framework.core.macro.command"
+    assert MacroStopException.__module__ == "nyxpy.framework.core.macro.exceptions"
+    assert all(value is not None for value in (Button, Hat, LStick, RStick, KeyType))
+
+
+def test_macrobase_lifecycle_signature_is_stable() -> None:
+    from nyxpy.framework.core.macro.base import MacroBase
+
+    assert _parameter_names(MacroBase.initialize) == ["self", "cmd", "args"]
+    assert _parameter_names(MacroBase.run) == ["self", "cmd"]
+    assert _parameter_names(MacroBase.finalize) == ["self", "cmd"]
+
+    assert inspect.signature(MacroBase.initialize).return_annotation is None
+    assert inspect.signature(MacroBase.run).return_annotation is None
+    assert inspect.signature(MacroBase.finalize).return_annotation is None
+
+
+def test_macro_metadata_defaults_are_stable() -> None:
+    from nyxpy.framework.core.macro.base import MacroBase
+
+    assert MacroBase.description == ""
+    assert MacroBase.tags == []
+
+
+def test_command_public_method_names_are_stable() -> None:
+    from nyxpy.framework.core.macro.command import Command
+
+    expected_methods = {
+        "press",
+        "hold",
+        "release",
+        "wait",
+        "stop",
+        "log",
+        "capture",
+        "save_img",
+        "load_img",
+        "keyboard",
+        "type",
+        "notify",
+        "touch",
+        "touch_down",
+        "touch_up",
+        "disable_sleep",
+    }
+
+    missing = {name for name in expected_methods if not hasattr(Command, name)}
+    assert missing == set()
+
+
+def test_command_core_signatures_are_stable() -> None:
+    from nyxpy.framework.core.macro.command import Command
+
+    press = inspect.signature(Command.press)
+    assert _parameter_names(Command.press) == ["self", "keys", "dur", "wait"]
+    assert press.parameters["keys"].kind is inspect.Parameter.VAR_POSITIONAL
+    assert press.parameters["dur"].default == 0.1
+    assert press.parameters["wait"].default == 0.1
+
+    log = inspect.signature(Command.log)
+    assert _parameter_names(Command.log) == ["self", "values", "sep", "end", "level"]
+    assert log.parameters["values"].kind is inspect.Parameter.VAR_POSITIONAL
+    assert log.parameters["sep"].default == " "
+    assert log.parameters["end"].default == "\n"
+    assert log.parameters["level"].default == "DEBUG"
+
+    capture = inspect.signature(Command.capture)
+    assert _parameter_names(Command.capture) == ["self", "crop_region", "grayscale"]
+    assert capture.parameters["crop_region"].default is None
+    assert capture.parameters["grayscale"].default is False
+
+    save_img = inspect.signature(Command.save_img)
+    assert _parameter_names(Command.save_img) == ["self", "filename", "image"]
+    assert save_img.parameters["filename"].default is inspect.Parameter.empty
+    assert save_img.parameters["image"].default is inspect.Parameter.empty
+
+    load_img = inspect.signature(Command.load_img)
+    assert _parameter_names(Command.load_img) == ["self", "filename", "grayscale"]
+    assert load_img.parameters["filename"].default is inspect.Parameter.empty
+    assert load_img.parameters["grayscale"].default is False
+
+
+def test_command_optional_capability_signatures_are_stable() -> None:
+    from nyxpy.framework.core.macro.command import Command
+
+    touch = inspect.signature(Command.touch)
+    assert _parameter_names(Command.touch) == ["self", "x", "y", "dur", "wait"]
+    assert touch.parameters["dur"].default == 0.1
+    assert touch.parameters["wait"].default == 0.1
+
+    assert _parameter_names(Command.touch_down) == ["self", "x", "y"]
+    assert _parameter_names(Command.touch_up) == ["self"]
+
+    disable_sleep = inspect.signature(Command.disable_sleep)
+    assert _parameter_names(Command.disable_sleep) == ["self", "enabled"]
+    assert disable_sleep.parameters["enabled"].default is True
+
+
+def test_macro_stop_exception_constructor_and_catch_are_stable() -> None:
+    from nyxpy.framework.core.macro.exceptions import MacroStopException
+
+    try:
+        raise MacroStopException("stop requested")
+    except MacroStopException as exc:
+        assert str(exc) == "stop requested"
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason="MacroExecutor is removed in phase 11 after GUI/CLI/runtime migration.",
+)
+def test_macro_executor_module_is_removed_from_final_contract() -> None:
+    with pytest.raises(ModuleNotFoundError):
+        importlib.import_module("nyxpy.framework.core.macro.executor")


### PR DESCRIPTION
## Summary

フレームワーク再設計フェーズ 1 として、既存マクロが依存する公開互換面をテストで固定しました。

## Related

- spec\framework\rearchitecture\IMPLEMENTATION_PLAN.md フェーズ 1

## Changes

- MacroBase / Command / DefaultCommand / constants / MacroStopException の import と主要シグネチャを固定する単体テストを追加
- settings.toml と exec_args のマージ優先順位、manifest 併存時の現行ロード、代表マクロの lifecycle 互換を確認する結合テストを追加
- 後続フェーズで満たす Runtime entrypoint / MacroExecutor 削除ゲートを xfail で追加

## Commit Log

```
ec6afdd test(framework): フェーズ1の互換テストを追加
```

## Testing

```
uv run pytest tests\unit\
# 304 passed, 1 xfailed, 1 warning

uv run pytest tests\integration\
# 11 passed, 2 xfailed

uv run ruff check .
# All checks passed

uv run ruff format tests\unit\framework\macro\test_import_contract.py tests\integration\test_migrated_macro_compat.py tests\integration\test_macro_runtime_entrypoints.py --check
# 3 files already formatted
```

## Checklist

- [x] lint 通過
- [x] 変更ファイルの format チェック通過
- [x] 既存テスト通過
- [x] コミット prefix (feat/fix 等) が変更の動機と一致している
- [x] 新規・変更コードに対するテスト追加（該当する場合）
- [x] 型チェック通過（Python テストと ruff で確認）

## Review Notes

`uv run ruff format . --check` は既存の未整形ファイル 12 件で失敗するため、この PR では変更ファイルに限定して format を確認しています。