### PR TITLE
feat(framework): MacroRegistryとFactoryを導入

### DIFF
--- a/src/nyxpy/framework/core/macro/entrypoint_loader.py
+++ b/src/nyxpy/framework/core/macro/entrypoint_loader.py
@@ -1,0 +1,278 @@
+from __future__ import annotations
+
+import importlib
+import inspect
+import sys
+from collections.abc import Iterator
+from contextlib import contextmanager
+from pathlib import Path
+from types import ModuleType
+
+import tomlkit
+
+from nyxpy.framework.core.macro.base import MacroBase
+from nyxpy.framework.core.macro.registry import (
+    ClassMacroFactory,
+    MacroDefinition,
+    MacroLoadError,
+)
+
+
+class EntryPointLoader:
+    def __init__(self, project_root: Path, macros_dir: Path) -> None:
+        self.project_root = Path(project_root).resolve()
+        self.macros_dir = Path(macros_dir).resolve()
+        self.import_root = self.macros_dir.parent
+        self.module_prefix = self.macros_dir.name
+
+    def load_definition(self, manifest_path: Path) -> MacroDefinition:
+        manifest_path = manifest_path.resolve()
+        try:
+            manifest = tomlkit.loads(manifest_path.read_text(encoding="utf-8"))
+        except Exception as exc:
+            raise MacroLoadError(
+                f"Failed to parse manifest: {exc}",
+                error_type="manifest_parse_error",
+                module_name="",
+            ) from exc
+
+        macro_table = manifest.get("macro")
+        if not isinstance(macro_table, dict):
+            raise MacroLoadError(
+                "macro.toml must contain [macro]",
+                error_type="manifest_parse_error",
+                module_name="",
+            )
+
+        entrypoint = macro_table.get("entrypoint")
+        macro_id = str(macro_table.get("id") or self._default_id_for_manifest(manifest_path))
+        if not entrypoint:
+            raise MacroLoadError(
+                "macro.toml [macro].entrypoint is required",
+                error_type="entrypoint_not_found",
+                macro_id=macro_id,
+                module_name="",
+            )
+
+        module_name, class_name = self._parse_entrypoint(str(entrypoint))
+        module = self._import_module(module_name)
+        macro_cls = self._get_macro_class(module, class_name, str(entrypoint), macro_id)
+        return self._definition_from_class(
+            macro_cls=macro_cls,
+            macro_id=macro_id,
+            module_name=module_name,
+            macro_root=manifest_path.parent,
+            source_path=Path(inspect.getfile(macro_cls)).resolve(),
+            manifest_path=manifest_path,
+            entrypoint_kind="manifest",
+            settings_path=macro_table.get("settings"),
+            display_name=macro_table.get("display_name"),
+            description=macro_table.get("description"),
+            tags=macro_table.get("tags"),
+        )
+
+    def load_convention_definition(self, source_path: Path) -> MacroDefinition:
+        source_path = source_path.resolve()
+        if source_path.is_file():
+            module_name = f"{self.module_prefix}.{source_path.stem}"
+            module = self._import_module(module_name)
+            macro_cls = self._single_local_macro_class(module, source_path)
+            macro_root = source_path.parent
+            default_id = source_path.stem
+        elif source_path.is_dir():
+            macro_py = source_path / "macro.py"
+            init_py = source_path / "__init__.py"
+            macro_candidates = self._module_candidates(macro_py) if macro_py.exists() else []
+            init_candidates = self._module_candidates(init_py) if init_py.exists() else []
+            if macro_candidates and init_candidates:
+                raise MacroLoadError(
+                    "Convention discovery found MacroBase classes in both macro.py and __init__.py",
+                    error_type="ambiguous_entrypoint",
+                    module_name=f"{self.module_prefix}.{source_path.name}",
+                )
+            candidates = macro_candidates or init_candidates
+            if len(candidates) != 1:
+                raise MacroLoadError(
+                    f"Convention discovery requires exactly one local MacroBase subclass, found {len(candidates)}",
+                    error_type="ambiguous_entrypoint",
+                    module_name=f"{self.module_prefix}.{source_path.name}",
+                )
+            macro_cls, module_name = candidates[0]
+            macro_root = source_path
+            default_id = source_path.name
+        else:
+            raise MacroLoadError(
+                f"Macro source does not exist: {source_path}",
+                error_type="entrypoint_not_found",
+            )
+
+        return self._definition_from_class(
+            macro_cls=macro_cls,
+            macro_id=str(getattr(macro_cls, "macro_id", default_id)),
+            module_name=module_name,
+            macro_root=macro_root,
+            source_path=Path(inspect.getfile(macro_cls)).resolve(),
+            manifest_path=None,
+            entrypoint_kind="convention",
+            settings_path=getattr(macro_cls, "settings_path", None),
+            display_name=getattr(macro_cls, "display_name", None),
+            description=getattr(macro_cls, "description", None),
+            tags=getattr(macro_cls, "tags", None),
+        )
+
+    def _module_candidates(self, module_path: Path) -> list[tuple[type[MacroBase], str]]:
+        module_name = self._module_name_for_file(module_path)
+        module = self._import_module(module_name)
+        return [(macro_cls, module_name) for macro_cls in self._local_macro_classes(module)]
+
+    def _single_local_macro_class(self, module: ModuleType, source_path: Path) -> type[MacroBase]:
+        candidates = self._local_macro_classes(module)
+        if len(candidates) != 1:
+            raise MacroLoadError(
+                f"Convention discovery requires exactly one local MacroBase subclass, found {len(candidates)}",
+                error_type="ambiguous_entrypoint",
+                module_name=module.__name__,
+            )
+        return candidates[0]
+
+    def _local_macro_classes(self, module: ModuleType) -> list[type[MacroBase]]:
+        result: list[type[MacroBase]] = []
+        for _name, obj in inspect.getmembers(module, inspect.isclass):
+            if obj is MacroBase or obj.__module__ != module.__name__:
+                continue
+            if issubclass(obj, MacroBase):
+                result.append(obj)
+        return result
+
+    def _import_module(self, module_name: str) -> ModuleType:
+        with self._temporary_sys_path(self.import_root):
+            self._clear_stale_module(module_name)
+            importlib.invalidate_caches()
+            try:
+                return importlib.import_module(module_name)
+            except Exception as exc:
+                raise MacroLoadError(
+                    f"Failed to import {module_name}: {exc}",
+                    error_type="module_import_error",
+                    module_name=module_name,
+                ) from exc
+
+    def _get_macro_class(
+        self, module: ModuleType, class_name: str, entrypoint: str, macro_id: str
+    ) -> type[MacroBase]:
+        obj = getattr(module, class_name, None)
+        if obj is None:
+            raise MacroLoadError(
+                f"Entrypoint class not found: {entrypoint}",
+                error_type="entrypoint_not_found",
+                macro_id=macro_id,
+                entrypoint=entrypoint,
+                module_name=module.__name__,
+            )
+        if not inspect.isclass(obj) or not issubclass(obj, MacroBase) or obj is MacroBase:
+            raise MacroLoadError(
+                f"Entrypoint is not a MacroBase subclass: {entrypoint}",
+                error_type="invalid_macro_class",
+                macro_id=macro_id,
+                entrypoint=entrypoint,
+                module_name=module.__name__,
+            )
+        return obj
+
+    def _definition_from_class(
+        self,
+        *,
+        macro_cls: type[MacroBase],
+        macro_id: str,
+        module_name: str,
+        macro_root: Path,
+        source_path: Path,
+        manifest_path: Path | None,
+        entrypoint_kind: str,
+        settings_path,
+        display_name,
+        description,
+        tags,
+    ) -> MacroDefinition:
+        class_name = macro_cls.__name__
+        description_value = self._description(macro_cls, description)
+        tags_value = tuple(
+            str(tag) for tag in (tags if tags is not None else getattr(macro_cls, "tags", ()))
+        )
+        return MacroDefinition(
+            id=macro_id,
+            aliases=(class_name,),
+            display_name=str(
+                display_name or getattr(macro_cls, "display_name", None) or class_name
+            ),
+            class_name=class_name,
+            module_name=module_name,
+            macro_root=macro_root.resolve(),
+            source_path=source_path.resolve(),
+            settings_path=settings_path,
+            description=description_value,
+            tags=tags_value,
+            factory=ClassMacroFactory(macro_cls),
+            manifest_path=manifest_path.resolve() if manifest_path is not None else None,
+            entrypoint_kind=entrypoint_kind,
+        )
+
+    def _description(self, macro_cls: type[MacroBase], explicit_description) -> str:
+        if explicit_description is not None:
+            return str(explicit_description)
+        class_description = getattr(macro_cls, "description", None)
+        if class_description:
+            return str(class_description)
+        return inspect.cleandoc(macro_cls.__doc__ or "")
+
+    def _module_name_for_file(self, source_path: Path) -> str:
+        relative_path = source_path.resolve().relative_to(self.import_root)
+        return ".".join(relative_path.with_suffix("").parts)
+
+    def _parse_entrypoint(self, entrypoint: str) -> tuple[str, str]:
+        if ":" not in entrypoint:
+            raise MacroLoadError(
+                f"Entrypoint must be 'module:ClassName': {entrypoint}",
+                error_type="entrypoint_not_found",
+                entrypoint=entrypoint,
+                module_name="",
+            )
+        module_name, class_name = entrypoint.split(":", 1)
+        if not module_name or not class_name:
+            raise MacroLoadError(
+                f"Entrypoint must be 'module:ClassName': {entrypoint}",
+                error_type="entrypoint_not_found",
+                entrypoint=entrypoint,
+                module_name=module_name,
+            )
+        return module_name, class_name
+
+    def _default_id_for_manifest(self, manifest_path: Path) -> str:
+        return (
+            manifest_path.parent.name if manifest_path.name == "macro.toml" else manifest_path.stem
+        )
+
+    def _clear_stale_module(self, module_name: str) -> None:
+        stale_keys = [
+            key for key in sys.modules if key == module_name or key.startswith(module_name + ".")
+        ]
+        for key in stale_keys:
+            del sys.modules[key]
+
+    @contextmanager
+    def _temporary_sys_path(self, path: Path) -> Iterator[None]:
+        path_text = str(path)
+        added = path_text not in sys.path
+        if added:
+            sys.path.insert(0, path_text)
+        try:
+            yield
+        finally:
+            if added:
+                try:
+                    sys.path.remove(path_text)
+                except ValueError as exc:
+                    raise MacroLoadError(
+                        f"Failed to restore sys.path: {path_text}",
+                        error_type="sys_path_restore_error",
+                    ) from exc

--- a/src/nyxpy/framework/core/macro/registry.py
+++ b/src/nyxpy/framework/core/macro/registry.py
@@ -1,0 +1,266 @@
+from __future__ import annotations
+
+from collections import defaultdict
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from threading import RLock
+from typing import TYPE_CHECKING, Any, Protocol
+
+from nyxpy.framework.core.macro.base import MacroBase
+
+if TYPE_CHECKING:
+    from nyxpy.framework.core.macro.settings_resolver import MacroSettingsResolver
+
+
+class MacroLoadError(Exception):
+    """マクロロードに失敗したことを表す例外。"""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        error_type: str = "module_import_error",
+        macro_id: str | None = None,
+        entrypoint: str | None = None,
+        module_name: str = "",
+    ) -> None:
+        super().__init__(message)
+        self.error_type = error_type
+        self.macro_id = macro_id
+        self.entrypoint = entrypoint
+        self.module_name = module_name
+
+
+class AmbiguousMacroError(ValueError):
+    """互換名が複数マクロへ解決される場合に送出する。"""
+
+    def __init__(self, requested_name: str, candidates: Sequence[str]) -> None:
+        self.requested_name = requested_name
+        self.candidates = tuple(candidates)
+        candidate_text = ", ".join(self.candidates)
+        super().__init__(f"Ambiguous class name '{requested_name}'. Use macro id: {candidate_text}")
+
+
+class RegistryLockTimeoutError(TimeoutError):
+    """registry reload lock の取得がタイムアウトしたことを表す例外。"""
+
+
+@dataclass(frozen=True)
+class MacroLoadDiagnostic:
+    macro_id: str | None
+    entrypoint: str | None
+    source_path: Path
+    module_name: str
+    error_type: str
+    exception_type: str
+    message: str
+    traceback_path: Path | None = None
+
+
+@dataclass(frozen=True)
+class MacroSettingsSource:
+    path: Path
+    source: str
+
+
+class MacroFactory(Protocol):
+    def create(self) -> MacroBase:
+        """実行ごとに新しい MacroBase インスタンスを返す。"""
+
+
+@dataclass(frozen=True)
+class ClassMacroFactory:
+    macro_cls: type[MacroBase]
+
+    def create(self) -> MacroBase:
+        return self.macro_cls()
+
+
+@dataclass(frozen=True)
+class MacroDefinition:
+    id: str
+    aliases: tuple[str, ...]
+    display_name: str
+    class_name: str
+    module_name: str
+    macro_root: Path
+    source_path: Path
+    settings_path: Path | str | None
+    description: str
+    tags: tuple[str, ...]
+    factory: MacroFactory
+    manifest_path: Path | None = None
+    entrypoint_kind: str = "convention"
+
+
+class MacroRegistry:
+    def __init__(
+        self,
+        project_root: Path | None = None,
+        macros_dir: Path | None = None,
+        settings_resolver: MacroSettingsResolver | None = None,
+    ) -> None:
+        if project_root is None:
+            raise ValueError("project_root is required")
+        self.project_root = Path(project_root).resolve()
+        self.macros_dir = (
+            Path(macros_dir).resolve() if macros_dir is not None else self.project_root / "macros"
+        )
+        self.settings_resolver = settings_resolver or self._create_settings_resolver()
+        self._lock = RLock()
+        self._definitions: dict[str, MacroDefinition] = {}
+        self._diagnostics: tuple[MacroLoadDiagnostic, ...] = ()
+        self._alias_map: dict[str, str] = {}
+        self._ambiguous_aliases: dict[str, tuple[str, ...]] = {}
+
+    @property
+    def definitions(self) -> Mapping[str, MacroDefinition]:
+        with self._lock:
+            return dict(self._definitions)
+
+    @property
+    def diagnostics(self) -> Sequence[MacroLoadDiagnostic]:
+        with self._lock:
+            return tuple(self._diagnostics)
+
+    def reload(self) -> None:
+        from nyxpy.framework.core.macro.entrypoint_loader import EntryPointLoader
+
+        loader = EntryPointLoader(project_root=self.project_root, macros_dir=self.macros_dir)
+        definitions: dict[str, MacroDefinition] = {}
+        diagnostics: list[MacroLoadDiagnostic] = []
+
+        if self.macros_dir.is_dir():
+            manifest_stems = {
+                path.stem for path in self.macros_dir.glob("*.toml") if path.name != "macro.toml"
+            }
+            for entry in sorted(self.macros_dir.iterdir(), key=lambda path: path.name):
+                if entry.is_dir():
+                    manifest_path = entry / "macro.toml"
+                    self._load_entry(
+                        loader=loader,
+                        source_path=manifest_path if manifest_path.exists() else entry,
+                        definitions=definitions,
+                        diagnostics=diagnostics,
+                        manifest=manifest_path.exists(),
+                    )
+                elif entry.is_file() and entry.suffix == ".toml" and entry.name != "macro.toml":
+                    self._load_entry(
+                        loader=loader,
+                        source_path=entry,
+                        definitions=definitions,
+                        diagnostics=diagnostics,
+                        manifest=True,
+                    )
+                elif (
+                    entry.is_file()
+                    and entry.suffix == ".py"
+                    and entry.name != "__init__.py"
+                    and entry.stem not in manifest_stems
+                ):
+                    self._load_entry(
+                        loader=loader,
+                        source_path=entry,
+                        definitions=definitions,
+                        diagnostics=diagnostics,
+                        manifest=False,
+                    )
+
+        alias_map, ambiguous_aliases = self._build_alias_maps(definitions)
+        with self._lock:
+            self._definitions = dict(definitions)
+            self._diagnostics = tuple(diagnostics)
+            self._alias_map = alias_map
+            self._ambiguous_aliases = ambiguous_aliases
+
+    def resolve(self, name_or_id: str) -> MacroDefinition:
+        with self._lock:
+            if name_or_id in self._definitions:
+                return self._definitions[name_or_id]
+            if name_or_id in self._ambiguous_aliases:
+                raise AmbiguousMacroError(name_or_id, self._ambiguous_aliases[name_or_id])
+            definition_id = self._alias_map.get(name_or_id)
+            if definition_id is not None:
+                return self._definitions[definition_id]
+            raise ValueError(
+                f"Macro '{name_or_id}' not found. Available macros: {list(self._definitions.keys())}"
+            )
+
+    def create(self, name_or_id: str) -> MacroBase:
+        return self.resolve(name_or_id).factory.create()
+
+    def list(self, include_failed: bool = False) -> Sequence[MacroDefinition]:
+        with self._lock:
+            return tuple(self._definitions.values())
+
+    def get_settings(self, definition: MacroDefinition) -> dict[str, Any]:
+        return self.settings_resolver.load(definition)
+
+    def _create_settings_resolver(self) -> MacroSettingsResolver:
+        from nyxpy.framework.core.macro.settings_resolver import MacroSettingsResolver
+
+        return MacroSettingsResolver(self.project_root)
+
+    def _load_entry(
+        self,
+        *,
+        loader,
+        source_path: Path,
+        definitions: dict[str, MacroDefinition],
+        diagnostics: list[MacroLoadDiagnostic],
+        manifest: bool,
+    ) -> None:
+        try:
+            definition = (
+                loader.load_definition(source_path)
+                if manifest
+                else loader.load_convention_definition(source_path)
+            )
+            if definition.id in definitions:
+                diagnostics.append(
+                    MacroLoadDiagnostic(
+                        macro_id=definition.id,
+                        entrypoint=None,
+                        source_path=source_path,
+                        module_name=definition.module_name,
+                        error_type="ambiguous_entrypoint",
+                        exception_type="MacroLoadError",
+                        message=f"Duplicate macro id: {definition.id}",
+                    )
+                )
+                return
+            definitions[definition.id] = definition
+        except Exception as exc:
+            diagnostics.append(self._diagnostic_from_exception(source_path, exc))
+
+    def _diagnostic_from_exception(self, source_path: Path, exc: Exception) -> MacroLoadDiagnostic:
+        return MacroLoadDiagnostic(
+            macro_id=getattr(exc, "macro_id", None),
+            entrypoint=getattr(exc, "entrypoint", None),
+            source_path=source_path,
+            module_name=getattr(exc, "module_name", ""),
+            error_type=getattr(exc, "error_type", "module_import_error"),
+            exception_type=type(exc).__name__,
+            message=str(exc),
+        )
+
+    def _build_alias_maps(
+        self, definitions: Mapping[str, MacroDefinition]
+    ) -> tuple[dict[str, str], dict[str, tuple[str, ...]]]:
+        alias_map: dict[str, str] = {}
+        grouped_aliases: dict[str, list[str]] = defaultdict(list)
+
+        for definition in definitions.values():
+            for alias in definition.aliases:
+                if alias != definition.id:
+                    grouped_aliases[alias].append(definition.id)
+
+        ambiguous_aliases = {
+            alias: tuple(sorted(ids)) for alias, ids in grouped_aliases.items() if len(ids) > 1
+        }
+        for alias, ids in grouped_aliases.items():
+            if alias not in ambiguous_aliases:
+                alias_map[alias] = ids[0]
+
+        return alias_map, ambiguous_aliases

--- a/src/nyxpy/framework/core/macro/settings_resolver.py
+++ b/src/nyxpy/framework/core/macro/settings_resolver.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import tomlkit
+
+from nyxpy.framework.core.macro.registry import MacroDefinition, MacroSettingsSource
+from nyxpy.framework.core.settings.exceptions import ConfigurationError
+
+
+class MacroSettingsResolver:
+    def __init__(self, project_root: Path) -> None:
+        self.project_root = Path(project_root).resolve()
+
+    def resolve(self, definition: MacroDefinition) -> MacroSettingsSource | None:
+        if definition.settings_path is None:
+            return None
+
+        path = definition.settings_path
+        if isinstance(path, Path):
+            candidate = path if path.is_absolute() else definition.macro_root / path
+            return self._source(candidate, definition.macro_root, "path")
+
+        path_text = str(path)
+        self._validate_portable_path(path_text)
+        if path_text.startswith("project:"):
+            relative_path = path_text.removeprefix("project:")
+            self._validate_portable_path(relative_path)
+            return self._source(self.project_root / relative_path, self.project_root, "manifest")
+
+        return self._source(definition.macro_root / path_text, definition.macro_root, "manifest")
+
+    def load(self, definition: MacroDefinition) -> dict[str, Any]:
+        source = self.resolve(definition)
+        if source is None:
+            return {}
+        try:
+            return dict(tomlkit.loads(source.path.read_text(encoding="utf-8")))
+        except tomlkit.exceptions.ParseError as exc:
+            raise ConfigurationError(
+                f"Failed to parse macro settings: {source.path}",
+                code="NYX_SETTINGS_PARSE_FAILED",
+            ) from exc
+
+    def _source(self, candidate: Path, root: Path, source: str) -> MacroSettingsSource:
+        resolved_root = root.resolve()
+        resolved_candidate = candidate.resolve(strict=False)
+        try:
+            resolved_candidate.relative_to(resolved_root)
+        except ValueError as exc:
+            raise ConfigurationError(
+                f"settings path escapes allowed root: {candidate}",
+                code="NYX_SETTINGS_PATH_INVALID",
+            ) from exc
+        return MacroSettingsSource(path=resolved_candidate, source=source)
+
+    def _validate_portable_path(self, path_text: str) -> None:
+        if not path_text or "\\" in path_text:
+            raise ConfigurationError(
+                f"invalid portable settings path: {path_text!r}",
+                code="NYX_SETTINGS_PATH_INVALID",
+            )
+        path = Path(path_text)
+        if path.is_absolute() or ".." in path.parts:
+            raise ConfigurationError(
+                f"invalid portable settings path: {path_text!r}",
+                code="NYX_SETTINGS_PATH_INVALID",
+            )

--- a/src/nyxpy/framework/core/settings/exceptions.py
+++ b/src/nyxpy/framework/core/settings/exceptions.py
@@ -1,0 +1,6 @@
+class ConfigurationError(ValueError):
+    """設定の解決・検証に失敗したことを表す例外。"""
+
+    def __init__(self, message: str, *, code: str | None = None) -> None:
+        super().__init__(message)
+        self.code = code

--- a/tests/unit/framework/macro/test_registry.py
+++ b/tests/unit/framework/macro/test_registry.py
@@ -1,0 +1,341 @@
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from nyxpy.framework.core.macro.registry import AmbiguousMacroError, MacroRegistry
+from nyxpy.framework.core.settings.exceptions import ConfigurationError
+
+
+def _prepare_project(tmp_path: Path) -> Path:
+    macros_dir = tmp_path / "macros"
+    macros_dir.mkdir()
+    return macros_dir
+
+
+def _write_macro_file(path: Path, class_name: str, *, body: str = "") -> None:
+    body_block = textwrap.indent(textwrap.dedent(body).strip(), "    ")
+    body_section = f"{body_block}\n" if body_block else ""
+    path.write_text(
+        f"""from nyxpy.framework.core.macro.base import MacroBase
+from nyxpy.framework.core.macro.command import Command
+
+
+class {class_name}(MacroBase):
+    description = "class description"
+    tags = ["class-tag"]
+{body_section}
+    def initialize(self, cmd: Command, args: dict) -> None:
+        self.args = dict(args)
+
+    def run(self, cmd: Command) -> None:
+        pass
+
+    def finalize(self, cmd: Command) -> None:
+        pass
+""",
+        encoding="utf-8",
+    )
+
+
+def _write_package(macros_dir: Path, package_name: str, class_name: str, *, body: str = "") -> Path:
+    package_dir = macros_dir / package_name
+    package_dir.mkdir()
+    _write_macro_file(package_dir / "macro.py", class_name, body=body)
+    return package_dir
+
+
+def test_registry_requires_explicit_project_root() -> None:
+    with pytest.raises(ValueError, match="project_root is required"):
+        MacroRegistry()
+
+
+def test_registry_loads_manifest_package_macro(tmp_path: Path) -> None:
+    macros_dir = _prepare_project(tmp_path)
+    package_dir = _write_package(macros_dir, "manifest_package", "ManifestPackageMacro")
+    (package_dir / "macro.toml").write_text(
+        textwrap.dedent(
+            """
+            [macro]
+            id = "manifest_package"
+            entrypoint = "macros.manifest_package.macro:ManifestPackageMacro"
+            display_name = "Manifest Package"
+            description = "manifest description"
+            tags = ["manifest", "package"]
+            settings = "settings.toml"
+            """
+        ),
+        encoding="utf-8",
+    )
+
+    registry = MacroRegistry(project_root=tmp_path)
+    registry.reload()
+
+    definition = registry.resolve("manifest_package")
+    assert definition.id == "manifest_package"
+    assert definition.display_name == "Manifest Package"
+    assert definition.description == "manifest description"
+    assert definition.tags == ("manifest", "package")
+    assert definition.settings_path == "settings.toml"
+    assert definition.manifest_path == package_dir / "macro.toml"
+    assert definition.entrypoint_kind == "manifest"
+    assert registry.diagnostics == ()
+
+
+def test_registry_loads_manifest_single_file_macro(tmp_path: Path) -> None:
+    macros_dir = _prepare_project(tmp_path)
+    _write_macro_file(macros_dir / "manifest_single.py", "ManifestSingleMacro")
+    (macros_dir / "manifest_single.toml").write_text(
+        textwrap.dedent(
+            """
+            [macro]
+            id = "manifest_single"
+            entrypoint = "macros.manifest_single:ManifestSingleMacro"
+            """
+        ),
+        encoding="utf-8",
+    )
+
+    registry = MacroRegistry(project_root=tmp_path)
+    registry.reload()
+
+    definition = registry.resolve("manifest_single")
+    assert definition.class_name == "ManifestSingleMacro"
+    assert definition.entrypoint_kind == "manifest"
+    assert len(registry.definitions) == 1
+
+
+def test_registry_rejects_missing_entrypoint(tmp_path: Path) -> None:
+    macros_dir = _prepare_project(tmp_path)
+    package_dir = _write_package(macros_dir, "missing_entrypoint", "MissingEntrypointMacro")
+    (package_dir / "macro.toml").write_text(
+        '[macro]\nid = "missing_entrypoint"\n',
+        encoding="utf-8",
+    )
+    _write_macro_file(macros_dir / "valid_macro.py", "ValidMacro")
+
+    registry = MacroRegistry(project_root=tmp_path)
+    registry.reload()
+
+    assert "valid_macro" in registry.definitions
+    assert "missing_entrypoint" not in registry.definitions
+    assert registry.diagnostics[0].error_type == "entrypoint_not_found"
+    assert registry.diagnostics[0].macro_id == "missing_entrypoint"
+
+
+def test_registry_loads_convention_package_macro(tmp_path: Path) -> None:
+    macros_dir = _prepare_project(tmp_path)
+    _write_package(macros_dir, "convention_package", "ConventionPackageMacro")
+
+    registry = MacroRegistry(project_root=tmp_path)
+    registry.reload()
+
+    definition = registry.resolve("convention_package")
+    assert definition.class_name == "ConventionPackageMacro"
+    assert definition.display_name == "ConventionPackageMacro"
+    assert definition.description == "class description"
+    assert definition.tags == ("class-tag",)
+    assert definition.entrypoint_kind == "convention"
+
+
+def test_registry_loads_convention_single_file_macro(tmp_path: Path) -> None:
+    macros_dir = _prepare_project(tmp_path)
+    _write_macro_file(macros_dir / "single_file.py", "SingleFileMacro")
+
+    registry = MacroRegistry(project_root=tmp_path)
+    registry.reload()
+
+    definition = registry.resolve("single_file")
+    assert definition.class_name == "SingleFileMacro"
+    assert definition.macro_root == macros_dir
+    assert registry.resolve("SingleFileMacro") == definition
+
+
+def test_registry_uses_class_metadata_when_manifest_absent(tmp_path: Path) -> None:
+    macros_dir = _prepare_project(tmp_path)
+    _write_macro_file(
+        macros_dir / "metadata_macro.py",
+        "MetadataMacro",
+        body=textwrap.dedent(
+            """
+            macro_id = "metadata-id"
+            display_name = "Metadata Display"
+            settings_path = "settings.toml"
+            """
+        ),
+    )
+
+    registry = MacroRegistry(project_root=tmp_path)
+    registry.reload()
+
+    definition = registry.resolve("metadata-id")
+    assert definition.display_name == "Metadata Display"
+    assert definition.settings_path == "settings.toml"
+
+
+def test_registry_requires_manifest_when_convention_is_ambiguous(tmp_path: Path) -> None:
+    macros_dir = _prepare_project(tmp_path)
+    (macros_dir / "ambiguous.py").write_text(
+        textwrap.dedent(
+            """
+            from nyxpy.framework.core.macro.base import MacroBase
+
+
+            class FirstMacro(MacroBase):
+                def initialize(self, cmd, args): pass
+                def run(self, cmd): pass
+                def finalize(self, cmd): pass
+
+
+            class SecondMacro(MacroBase):
+                def initialize(self, cmd, args): pass
+                def run(self, cmd): pass
+                def finalize(self, cmd): pass
+            """
+        ),
+        encoding="utf-8",
+    )
+
+    registry = MacroRegistry(project_root=tmp_path)
+    registry.reload()
+
+    assert registry.definitions == {}
+    assert registry.diagnostics[0].error_type == "ambiguous_entrypoint"
+
+
+def test_class_name_alias_is_available_when_unique(tmp_path: Path) -> None:
+    macros_dir = _prepare_project(tmp_path)
+    _write_macro_file(macros_dir / "unique.py", "UniqueMacro")
+
+    registry = MacroRegistry(project_root=tmp_path)
+    registry.reload()
+
+    assert registry.resolve("UniqueMacro").id == "unique"
+
+
+def test_class_name_collision_requires_qualified_id(tmp_path: Path) -> None:
+    macros_dir = _prepare_project(tmp_path)
+    _write_macro_file(macros_dir / "first.py", "DuplicatedMacro")
+    _write_macro_file(macros_dir / "second.py", "DuplicatedMacro")
+
+    registry = MacroRegistry(project_root=tmp_path)
+    registry.reload()
+
+    assert registry.resolve("first").class_name == "DuplicatedMacro"
+    assert registry.resolve("second").class_name == "DuplicatedMacro"
+    with pytest.raises(AmbiguousMacroError) as exc_info:
+        registry.resolve("DuplicatedMacro")
+    assert exc_info.value.candidates == ("first", "second")
+
+
+def test_load_failure_is_reported_without_stopping_reload(tmp_path: Path) -> None:
+    macros_dir = _prepare_project(tmp_path)
+    _write_macro_file(macros_dir / "valid.py", "ValidMacro")
+    (macros_dir / "broken.py").write_text("raise RuntimeError('broken import')\n", encoding="utf-8")
+
+    registry = MacroRegistry(project_root=tmp_path)
+    registry.reload()
+
+    assert "valid" in registry.definitions
+    assert len(registry.diagnostics) == 1
+    assert registry.diagnostics[0].error_type == "module_import_error"
+    assert "broken import" in registry.diagnostics[0].message
+
+
+def test_registry_reload_restores_sys_path_even_on_import_error(tmp_path: Path) -> None:
+    macros_dir = _prepare_project(tmp_path)
+    (macros_dir / "broken.py").write_text("raise RuntimeError('broken import')\n", encoding="utf-8")
+    before = list(sys.path)
+
+    registry = MacroRegistry(project_root=tmp_path)
+    registry.reload()
+
+    assert sys.path == before
+
+
+def test_registry_reload_preserves_preexisting_sys_path_entry(tmp_path: Path) -> None:
+    macros_dir = _prepare_project(tmp_path)
+    _write_macro_file(macros_dir / "valid.py", "ValidMacro")
+    sys.path.insert(0, str(tmp_path))
+    try:
+        registry = MacroRegistry(project_root=tmp_path)
+        registry.reload()
+        assert str(tmp_path) in sys.path
+    finally:
+        sys.path.remove(str(tmp_path))
+
+
+def test_settings_without_explicit_source_returns_empty_dict(tmp_path: Path) -> None:
+    macros_dir = _prepare_project(tmp_path)
+    _write_macro_file(macros_dir / "no_settings.py", "NoSettingsMacro")
+
+    registry = MacroRegistry(project_root=tmp_path)
+    registry.reload()
+
+    assert registry.get_settings(registry.resolve("no_settings")) == {}
+
+
+def test_settings_static_lookup_is_not_supported(tmp_path: Path) -> None:
+    macros_dir = _prepare_project(tmp_path)
+    _write_macro_file(macros_dir / "legacy_settings.py", "LegacySettingsMacro")
+    settings_dir = tmp_path / "static" / "legacy_settings"
+    settings_dir.mkdir(parents=True)
+    (settings_dir / "settings.toml").write_text("value = 'legacy'\n", encoding="utf-8")
+
+    registry = MacroRegistry(project_root=tmp_path)
+    registry.reload()
+
+    assert registry.get_settings(registry.resolve("legacy_settings")) == {}
+
+
+def test_explicit_settings_path_resolution(tmp_path: Path) -> None:
+    macros_dir = _prepare_project(tmp_path)
+    package_dir = _write_package(macros_dir, "settings_macro", "SettingsMacro")
+    (package_dir / "settings.toml").write_text("value = 'macro-root'\n", encoding="utf-8")
+    (tmp_path / "project_settings.toml").write_text("value = 'project-root'\n", encoding="utf-8")
+    (package_dir / "macro.toml").write_text(
+        textwrap.dedent(
+            """
+            [macro]
+            id = "settings_macro"
+            entrypoint = "macros.settings_macro.macro:SettingsMacro"
+            settings = "settings.toml"
+            """
+        ),
+        encoding="utf-8",
+    )
+
+    registry = MacroRegistry(project_root=tmp_path)
+    registry.reload()
+
+    definition = registry.resolve("settings_macro")
+    assert registry.settings_resolver.resolve(definition).path == package_dir / "settings.toml"
+    assert registry.get_settings(definition) == {"value": "macro-root"}
+
+    project_definition = type(definition)(
+        **{**definition.__dict__, "settings_path": "project:project_settings.toml"}
+    )
+    assert registry.settings_resolver.resolve(project_definition).path == (
+        tmp_path / "project_settings.toml"
+    )
+    assert registry.get_settings(project_definition) == {"value": "project-root"}
+
+
+@pytest.mark.parametrize("settings_path", [".. /bad.toml", "../bad.toml", "bad\\settings.toml", ""])
+def test_settings_resolver_rejects_invalid_portable_path(
+    tmp_path: Path, settings_path: str
+) -> None:
+    macros_dir = _prepare_project(tmp_path)
+    _write_macro_file(
+        macros_dir / "invalid_settings.py",
+        "InvalidSettingsMacro",
+        body=f"settings_path = {settings_path!r}",
+    )
+
+    registry = MacroRegistry(project_root=tmp_path)
+    registry.reload()
+
+    with pytest.raises(ConfigurationError) as exc_info:
+        registry.get_settings(registry.resolve("invalid_settings"))
+    assert exc_info.value.code == "NYX_SETTINGS_PATH_INVALID"

--- a/tests/unit/framework/runtime/test_macro_factory.py
+++ b/tests/unit/framework/runtime/test_macro_factory.py
@@ -1,0 +1,30 @@
+from nyxpy.framework.core.macro.base import MacroBase
+from nyxpy.framework.core.macro.command import Command
+from nyxpy.framework.core.macro.registry import ClassMacroFactory
+
+
+class StatefulMacro(MacroBase):
+    def __init__(self) -> None:
+        self.counter = 0
+
+    def initialize(self, cmd: Command, args: dict) -> None:
+        self.counter += 1
+
+    def run(self, cmd: Command) -> None:
+        pass
+
+    def finalize(self, cmd: Command) -> None:
+        pass
+
+
+def test_execute_creates_new_instance_each_time() -> None:
+    factory = ClassMacroFactory(StatefulMacro)
+
+    first = factory.create()
+    second = factory.create()
+
+    assert isinstance(first, StatefulMacro)
+    assert isinstance(second, StatefulMacro)
+    assert first is not second
+    first.counter = 10
+    assert second.counter == 0


### PR DESCRIPTION
## Summary

フレームワーク再設計フェーズ 2 として、マクロ発見と実行インスタンス生成を担う `MacroRegistry` / `MacroDefinition` / `ClassMacroFactory` を追加しました。

## Related

- spec\framework\rearchitecture\IMPLEMENTATION_PLAN.md フェーズ 2
- spec\framework\rearchitecture\MACRO_COMPATIBILITY_AND_REGISTRY.md
- spec\framework\rearchitecture\CONFIGURATION_AND_RESOURCES.md

## Changes

- manifest / convention discovery を `MacroDefinition` へ正規化する `EntryPointLoader` を追加
- 安定 ID、クラス名 alias、衝突時の `AmbiguousMacroError`、ロード診断、snapshot 管理を持つ `MacroRegistry` を追加
- 実行ごとに新しい `MacroBase` インスタンスを返す `ClassMacroFactory` を追加
- 明示 settings path のみを扱う `MacroSettingsResolver` と `ConfigurationError` を追加
- manifest package / single-file、convention discovery、class metadata、診断、settings resolver、factory の単体テストを追加

## Commit Log

```
bff851d feat(framework): MacroRegistryとFactoryを導入
```

## Testing

```
uv run pytest tests\unit\
# 325 passed, 1 xfailed, 1 warning

uv run pytest tests\integration\
# 11 passed, 2 xfailed

uv run ruff check .
# All checks passed

uv run ruff format src\nyxpy\framework\core\macro\registry.py src\nyxpy\framework\core\macro\entrypoint_loader.py src\nyxpy\framework\core\macro\settings_resolver.py src\nyxpy\framework\core\settings\exceptions.py tests\unit\framework\macro\test_registry.py tests\unit\framework\runtime\test_macro_factory.py --check
# 6 files already formatted
```

## Checklist

- [x] lint / format チェック通過
- [x] 既存テスト通過
- [x] コミット prefix (feat/fix 等) が変更の動機と一致している
- [x] 新規・変更コードに対するテスト追加（該当する場合）
- [x] 型チェック通過（Python テストと ruff で確認）

## Review Notes

Phase 2 では GUI/CLI と `MacroExecutor` はまだ移行していません。旧 `load_macro_settings()` の `static` lookup も既存経路保護のため残し、新しい `MacroSettingsResolver` だけが明示 settings source を扱います。