### PR TITLE
feat(framework): MacroRunnerと実行結果を導入

### DIFF
--- a/src/nyxpy/framework/core/macro/command.py
+++ b/src/nyxpy/framework/core/macro/command.py
@@ -1,5 +1,4 @@
 import pathlib
-import time
 from abc import ABC, abstractmethod
 
 import cv2
@@ -12,8 +11,7 @@ from nyxpy.framework.core.hardware.resource import StaticResourceIO
 from nyxpy.framework.core.hardware.serial_comm import SerialCommInterface
 from nyxpy.framework.core.logger.log_manager import log_manager  # LogManager 利用
 from nyxpy.framework.core.macro.decorators import check_interrupt
-from nyxpy.framework.core.macro.exceptions import MacroStopException
-from nyxpy.framework.core.utils.cancellation import CancellationToken
+from nyxpy.framework.core.utils.cancellation import CancellationToken, cancellation_aware_wait
 from nyxpy.framework.core.utils.helper import (
     get_caller_class_name,
     validate_keyboard_text,
@@ -250,12 +248,12 @@ class DefaultCommand(Command):
     @check_interrupt
     def wait(self, wait: float) -> None:
         self.log(f"Waiting for {wait} seconds", level="DEBUG")
-        time.sleep(wait)
+        cancellation_aware_wait(wait, self.ct)
+        self.ct.throw_if_requested()
 
     def stop(self) -> None:
         self.log("Stopping macro execution", level="INFO")
-        self.ct.request_stop()
-        raise MacroStopException("Macro execution interrupted.")
+        self.ct.request_cancel(reason="stop requested", source="macro")
 
     def log(self, *values, sep: str = " ", end: str = "\n", level: str = "DEBUG") -> None:
         message = sep.join(map(str, values)) + end.rstrip("\n")

--- a/src/nyxpy/framework/core/macro/decorators.py
+++ b/src/nyxpy/framework/core/macro/decorators.py
@@ -1,15 +1,12 @@
-from nyxpy.framework.core.macro.exceptions import MacroStopException
-
-
 def check_interrupt(method):
     """
     Command の各操作メソッド実行前に、InterruptController の状態をチェックするデコレータ。
-    中断要求があれば MacroStopException を発生させる。
+    中断要求があれば MacroCancelled を発生させる。
     """
 
     def wrapper(self, *args, **kwargs):
-        if self.ct and self.ct.stop_requested():
-            raise MacroStopException("Macro execution interrupted.")
+        if self.ct:
+            self.ct.throw_if_requested()
         return method(self, *args, **kwargs)
 
     return wrapper

--- a/src/nyxpy/framework/core/macro/exceptions.py
+++ b/src/nyxpy/framework/core/macro/exceptions.py
@@ -1,7 +1,125 @@
-class MacroStopException(Exception):
-    """
-    マクロの中断要求が発生した場合に送出される例外。
-    この例外をキャッチすることで、マクロ実行を安全に停止することができます。
-    """
+from __future__ import annotations
 
-    pass
+from dataclasses import dataclass, field
+from enum import StrEnum
+
+type FrameworkValue = (
+    str | int | float | bool | list[FrameworkValue] | dict[str, FrameworkValue] | None
+)
+type ErrorDetailValue = FrameworkValue
+
+
+class ErrorKind(StrEnum):
+    CANCELLED = "cancelled"
+    DEVICE = "device"
+    RESOURCE = "resource"
+    CONFIGURATION = "configuration"
+    VALIDATION = "validation"
+    MACRO = "macro"
+    INTERNAL = "internal"
+
+
+class FrameworkError(Exception):
+    def __init__(
+        self,
+        message: str,
+        *,
+        kind: ErrorKind,
+        code: str,
+        component: str,
+        recoverable: bool = False,
+        details: dict[str, ErrorDetailValue] | None = None,
+        cause: BaseException | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.message = message
+        self.kind = kind
+        self.code = code
+        self.component = component
+        self.recoverable = recoverable
+        self.details = dict(details or {})
+        self.__cause__ = cause
+
+
+class MacroStopException(FrameworkError):
+    """既存 import 互換のため維持する中断例外 adapter。"""
+
+    def __init__(self, *args: object, **kwargs: object) -> None:
+        message = str(args[0]) if args else str(kwargs.pop("message", ""))
+        super().__init__(
+            message,
+            kind=kwargs.pop("kind", ErrorKind.CANCELLED),
+            code=kwargs.pop("code", "NYX_MACRO_CANCELLED"),
+            component=kwargs.pop("component", "MacroStopException"),
+            recoverable=kwargs.pop("recoverable", False),
+            details=kwargs.pop("details", None),
+            cause=kwargs.pop("cause", None),
+        )
+
+
+class MacroCancelled(MacroStopException):
+    """協調キャンセルによりマクロ実行スレッドで送出される例外。"""
+
+
+class DeviceError(FrameworkError):
+    def __init__(self, message: str, **kwargs: object) -> None:
+        super().__init__(
+            message,
+            kind=ErrorKind.DEVICE,
+            code=str(kwargs.pop("code", "NYX_DEVICE_SERIAL_FAILED")),
+            component=str(kwargs.pop("component", "DeviceError")),
+            recoverable=bool(kwargs.pop("recoverable", False)),
+            details=kwargs.pop("details", None),
+            cause=kwargs.pop("cause", None),
+        )
+
+
+class ResourceError(FrameworkError):
+    def __init__(self, message: str, **kwargs: object) -> None:
+        super().__init__(
+            message,
+            kind=ErrorKind.RESOURCE,
+            code=str(kwargs.pop("code", "NYX_RESOURCE_READ_FAILED")),
+            component=str(kwargs.pop("component", "ResourceError")),
+            recoverable=bool(kwargs.pop("recoverable", False)),
+            details=kwargs.pop("details", None),
+            cause=kwargs.pop("cause", None),
+        )
+
+
+class ConfigurationError(FrameworkError, ValueError):
+    def __init__(self, message: str = "", **kwargs: object) -> None:
+        super().__init__(
+            message,
+            kind=ErrorKind.CONFIGURATION,
+            code=str(kwargs.pop("code", "NYX_RUNTIME_CONFIGURATION_INVALID")),
+            component=str(kwargs.pop("component", "ConfigurationError")),
+            recoverable=bool(kwargs.pop("recoverable", False)),
+            details=kwargs.pop("details", None),
+            cause=kwargs.pop("cause", None),
+        )
+
+
+class MacroRuntimeError(FrameworkError):
+    def __init__(self, message: str, **kwargs: object) -> None:
+        super().__init__(
+            message,
+            kind=ErrorKind.MACRO,
+            code=str(kwargs.pop("code", "NYX_MACRO_FAILED")),
+            component=str(kwargs.pop("component", "MacroRunner")),
+            recoverable=bool(kwargs.pop("recoverable", False)),
+            details=kwargs.pop("details", None),
+            cause=kwargs.pop("cause", None),
+        )
+
+
+@dataclass(frozen=True)
+class ErrorInfo:
+    kind: ErrorKind
+    code: str
+    message: str
+    component: str
+    exception_type: str
+    recoverable: bool
+    details: dict[str, ErrorDetailValue] = field(default_factory=dict)
+    traceback: str | None = None

--- a/src/nyxpy/framework/core/runtime/__init__.py
+++ b/src/nyxpy/framework/core/runtime/__init__.py
@@ -1,0 +1,19 @@
+from nyxpy.framework.core.macro.exceptions import ErrorInfo, ErrorKind
+from nyxpy.framework.core.runtime.context import RunContext, RuntimeOptions
+from nyxpy.framework.core.runtime.handle import RunHandle, ThreadRunHandle
+from nyxpy.framework.core.runtime.result import CleanupWarning, RunResult, RunStatus
+from nyxpy.framework.core.runtime.runner import MacroRunner, SupportsFinalizeOutcome
+
+__all__ = [
+    "CleanupWarning",
+    "ErrorInfo",
+    "ErrorKind",
+    "MacroRunner",
+    "RunContext",
+    "RunHandle",
+    "RunResult",
+    "RunStatus",
+    "RuntimeOptions",
+    "SupportsFinalizeOutcome",
+    "ThreadRunHandle",
+]

--- a/src/nyxpy/framework/core/runtime/context.py
+++ b/src/nyxpy/framework/core/runtime/context.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Protocol
+
+from nyxpy.framework.core.utils.cancellation import CancellationToken
+
+
+class LoggerLike(Protocol):
+    def log(self, level: str, message: str, component: str | None = None) -> None: ...
+
+
+@dataclass(frozen=True)
+class RuntimeOptions:
+    allow_dummy: bool = False
+    device_detection_timeout_sec: float = 5.0
+    frame_ready_timeout_sec: float = 3.0
+    release_timeout_sec: float = 2.0
+
+
+@dataclass(frozen=True)
+class RunContext:
+    run_id: str
+    macro_id: str
+    macro_name: str
+    started_at: datetime
+    cancellation_token: CancellationToken
+    logger: LoggerLike | None = None

--- a/src/nyxpy/framework/core/runtime/handle.py
+++ b/src/nyxpy/framework/core/runtime/handle.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from threading import Event, Thread
+
+from nyxpy.framework.core.runtime.result import RunResult
+from nyxpy.framework.core.utils.cancellation import CancellationToken
+
+
+class RunHandle(ABC):
+    @property
+    @abstractmethod
+    def run_id(self) -> str: ...
+
+    @property
+    @abstractmethod
+    def cancellation_token(self) -> CancellationToken: ...
+
+    @abstractmethod
+    def cancel(self) -> None: ...
+
+    @abstractmethod
+    def done(self) -> bool: ...
+
+    @abstractmethod
+    def wait(self, timeout: float | None = None) -> bool: ...
+
+    @abstractmethod
+    def result(self) -> RunResult: ...
+
+
+class ThreadRunHandle(RunHandle):
+    def __init__(
+        self,
+        *,
+        run_id: str,
+        cancellation_token: CancellationToken,
+        thread: Thread,
+        done_event: Event,
+        result_getter,
+    ) -> None:
+        self._run_id = run_id
+        self._cancellation_token = cancellation_token
+        self._thread = thread
+        self._done_event = done_event
+        self._result_getter = result_getter
+
+    @property
+    def run_id(self) -> str:
+        return self._run_id
+
+    @property
+    def cancellation_token(self) -> CancellationToken:
+        return self._cancellation_token
+
+    def cancel(self) -> None:
+        self._cancellation_token.request_cancel(reason="cancel requested", source="run_handle")
+
+    def done(self) -> bool:
+        return self._done_event.is_set()
+
+    def wait(self, timeout: float | None = None) -> bool:
+        return self._done_event.wait(timeout)
+
+    def result(self) -> RunResult:
+        if not self.done():
+            raise RuntimeError("Run result is not available yet.")
+        return self._result_getter()

--- a/src/nyxpy/framework/core/runtime/result.py
+++ b/src/nyxpy/framework/core/runtime/result.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from enum import StrEnum
+
+from nyxpy.framework.core.macro.exceptions import ErrorInfo
+
+
+class RunStatus(StrEnum):
+    SUCCESS = "success"
+    CANCELLED = "cancelled"
+    FAILED = "failed"
+
+
+class CleanupWarning(Exception):
+    port_name: str
+    exception_type: str
+    message: str
+
+    def __init__(self, port_name: str, exception_type: str, message: str) -> None:
+        super().__init__(message)
+        self.port_name = port_name
+        self.exception_type = exception_type
+        self.message = message
+
+
+@dataclass(frozen=True)
+class RunResult:
+    run_id: str
+    macro_id: str
+    macro_name: str
+    status: RunStatus
+    started_at: datetime
+    finished_at: datetime
+    error: ErrorInfo | None = None
+    cleanup_warnings: tuple[CleanupWarning, ...] = ()
+
+    @property
+    def ok(self) -> bool:
+        return self.status is RunStatus.SUCCESS and self.error is None
+
+    @property
+    def duration_seconds(self) -> float:
+        return (self.finished_at - self.started_at).total_seconds()

--- a/src/nyxpy/framework/core/runtime/runner.py
+++ b/src/nyxpy/framework/core/runtime/runner.py
@@ -1,0 +1,146 @@
+from __future__ import annotations
+
+import traceback
+from collections.abc import Mapping
+from dataclasses import replace
+from datetime import datetime
+from typing import Protocol, runtime_checkable
+
+from nyxpy.framework.core.macro.base import MacroBase
+from nyxpy.framework.core.macro.command import Command
+from nyxpy.framework.core.macro.exceptions import (
+    ErrorInfo,
+    ErrorKind,
+    FrameworkError,
+    MacroStopException,
+)
+from nyxpy.framework.core.runtime.context import RunContext
+from nyxpy.framework.core.runtime.result import RunResult, RunStatus
+
+type RuntimeValue = str | int | float | bool | list[RuntimeValue] | dict[str, RuntimeValue] | None
+
+
+@runtime_checkable
+class SupportsFinalizeOutcome(Protocol):
+    def finalize_with_outcome(self, cmd: Command, outcome: RunResult) -> None: ...
+
+
+class MacroRunner:
+    def run(
+        self,
+        macro: MacroBase,
+        cmd: Command,
+        exec_args: Mapping[str, RuntimeValue],
+        run_context: RunContext,
+    ) -> RunResult:
+        started_at = run_context.started_at
+        result: RunResult
+        try:
+            macro.initialize(cmd, dict(exec_args))
+            macro.run(cmd)
+        except MacroStopException as exc:
+            result = self._result(
+                run_context=run_context,
+                status=RunStatus.CANCELLED,
+                started_at=started_at,
+                error=self._error_info(exc),
+            )
+        except FrameworkError as exc:
+            result = self._result(
+                run_context=run_context,
+                status=RunStatus.FAILED,
+                started_at=started_at,
+                error=self._error_info(exc),
+            )
+        except Exception as exc:
+            result = self._result(
+                run_context=run_context,
+                status=RunStatus.FAILED,
+                started_at=started_at,
+                error=self._macro_error_info(exc),
+            )
+        else:
+            result = self._result(
+                run_context=run_context,
+                status=RunStatus.SUCCESS,
+                started_at=started_at,
+                error=None,
+            )
+
+        return self._finalize(macro, cmd, result, run_context)
+
+    def _finalize(
+        self,
+        macro: MacroBase,
+        cmd: Command,
+        result: RunResult,
+        run_context: RunContext,
+    ) -> RunResult:
+        try:
+            if isinstance(macro, SupportsFinalizeOutcome):
+                macro.finalize_with_outcome(cmd, result)
+            else:
+                macro.finalize(cmd)
+        except Exception as exc:
+            if result.ok:
+                return self._result(
+                    run_context=run_context,
+                    status=RunStatus.FAILED,
+                    started_at=result.started_at,
+                    error=self._macro_error_info(exc, component="MacroRunner.finalize"),
+                )
+            if result.error is None:
+                return result
+            finalize_error = {
+                "exception_type": type(exc).__name__,
+                "message": str(exc),
+            }
+            details = {**result.error.details, "finalize_error": finalize_error}
+            return replace(
+                result,
+                finished_at=datetime.now(),
+                error=replace(result.error, details=details),
+            )
+        return replace(result, finished_at=datetime.now())
+
+    def _result(
+        self,
+        *,
+        run_context: RunContext,
+        status: RunStatus,
+        started_at: datetime,
+        error: ErrorInfo | None,
+    ) -> RunResult:
+        return RunResult(
+            run_id=run_context.run_id,
+            macro_id=run_context.macro_id,
+            macro_name=run_context.macro_name,
+            status=status,
+            started_at=started_at,
+            finished_at=datetime.now(),
+            error=error,
+        )
+
+    def _error_info(self, exc: FrameworkError) -> ErrorInfo:
+        return ErrorInfo(
+            kind=exc.kind,
+            code=exc.code,
+            message=exc.message,
+            component=exc.component,
+            exception_type=type(exc).__name__,
+            recoverable=exc.recoverable,
+            details=dict(exc.details),
+            traceback=traceback.format_exc(),
+        )
+
+    def _macro_error_info(self, exc: Exception, *, component: str = "MacroRunner") -> ErrorInfo:
+        return ErrorInfo(
+            kind=ErrorKind.MACRO,
+            code="NYX_MACRO_FAILED",
+            message=str(exc),
+            component=component,
+            exception_type=type(exc).__name__,
+            recoverable=False,
+            details={},
+            traceback=traceback.format_exc(),
+        )

--- a/src/nyxpy/framework/core/settings/exceptions.py
+++ b/src/nyxpy/framework/core/settings/exceptions.py
@@ -1,6 +1,3 @@
-class ConfigurationError(ValueError):
-    """設定の解決・検証に失敗したことを表す例外。"""
+from nyxpy.framework.core.macro.exceptions import ConfigurationError
 
-    def __init__(self, message: str, *, code: str | None = None) -> None:
-        super().__init__(message)
-        self.code = code
+__all__ = ["ConfigurationError"]

--- a/src/nyxpy/framework/core/utils/cancellation.py
+++ b/src/nyxpy/framework/core/utils/cancellation.py
@@ -1,4 +1,8 @@
 import threading
+import time
+from datetime import datetime
+
+from nyxpy.framework.core.macro.exceptions import ConfigurationError, MacroCancelled
 
 
 class CancellationToken:
@@ -9,12 +13,70 @@ class CancellationToken:
 
     def __init__(self):
         self._stop_event = threading.Event()
+        self._lock = threading.Lock()
+        self._reason: str | None = None
+        self._source: str | None = None
+        self._requested_at: datetime | None = None
 
     def stop_requested(self) -> bool:
         return self._stop_event.is_set()
 
     def request_stop(self) -> None:
-        self._stop_event.set()
+        self.request_cancel(reason="stop requested", source="legacy")
+
+    def request_cancel(self, reason: str = "", source: str = "") -> None:
+        with self._lock:
+            if self._stop_event.is_set():
+                return
+            self._reason = reason
+            self._source = source
+            self._requested_at = datetime.now()
+            self._stop_event.set()
 
     def clear(self) -> None:
-        self._stop_event.clear()
+        with self._lock:
+            self._reason = None
+            self._source = None
+            self._requested_at = None
+            self._stop_event.clear()
+
+    def reason(self) -> str | None:
+        return self._reason
+
+    def source(self) -> str | None:
+        return self._source
+
+    def requested_at(self) -> datetime | None:
+        return self._requested_at
+
+    def wait(self, timeout: float) -> bool:
+        return self._stop_event.wait(timeout)
+
+    def throw_if_requested(self) -> None:
+        if not self.stop_requested():
+            return
+        reason = self.reason() or "Macro execution interrupted."
+        raise MacroCancelled(
+            reason,
+            component="CancellationToken",
+            details={"reason": reason, "source": self.source() or ""},
+        )
+
+
+def cancellation_aware_wait(seconds: float, token: CancellationToken) -> bool:
+    if seconds < 0:
+        raise ConfigurationError(
+            "wait seconds must be greater than or equal to 0",
+            code="NYX_INVALID_WAIT_SECONDS",
+            component="Command.wait",
+        )
+
+    token.throw_if_requested()
+    deadline = time.monotonic() + seconds
+    while True:
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            token.throw_if_requested()
+            return True
+        if token.wait(timeout=min(0.05, remaining)):
+            return False

--- a/tests/integration/test_macro_runtime_entrypoints.py
+++ b/tests/integration/test_macro_runtime_entrypoints.py
@@ -4,10 +4,6 @@ from pathlib import Path
 import pytest
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="MacroRuntime is introduced before GUI/CLI migration in later phases.",
-)
 def test_macro_runtime_module_is_available_for_entrypoints() -> None:
     importlib.import_module("nyxpy.framework.core.runtime")
 

--- a/tests/unit/command/test_default_command.py
+++ b/tests/unit/command/test_default_command.py
@@ -4,6 +4,8 @@ import pytest
 
 from nyxpy.framework.core.constants import Button, KeyboardOp, KeyCode, SpecialKeyCode
 from nyxpy.framework.core.macro.command import DefaultCommand
+from nyxpy.framework.core.macro.exceptions import MacroCancelled
+from nyxpy.framework.core.utils.cancellation import CancellationToken
 
 
 # Mock for SerialCommInterface
@@ -86,18 +88,6 @@ class MockProtocolKeyboardNotSupported(MockProtocol):
         )
 
 
-# Mock for CancellationToken
-class MockCancellationToken:
-    def __init__(self):
-        self.stopped = False
-
-    def request_stop(self):
-        self.stopped = True
-
-    def stop_requested(self):
-        return self.stopped
-
-
 @pytest.fixture
 def dummy_command(monkeypatch):
     monkeypatch.setattr(time, "sleep", lambda x: None)
@@ -105,7 +95,7 @@ def dummy_command(monkeypatch):
     capture_device = MockCaptureDevice()
     resource_io = MockResourceIO()
     protocol = MockProtocol()
-    ct = MockCancellationToken()
+    ct = CancellationToken()
     cmd = DefaultCommand(
         serial_device=serial_device,
         capture_device=capture_device,
@@ -124,7 +114,7 @@ def dummy_command_keyboard_not_supported(monkeypatch):
     capture_device = MockCaptureDevice()
     resource_io = MockResourceIO()
     protocol = MockProtocolKeyboardNotSupported()
-    ct = MockCancellationToken()
+    ct = CancellationToken()
     cmd = DefaultCommand(
         serial_device=serial_device,
         capture_device=capture_device,
@@ -143,7 +133,7 @@ def dummy_command_touch(monkeypatch):
     capture_device = MockCaptureDevice()
     resource_io = MockResourceIO()
     protocol = MockTouchProtocol()
-    ct = MockCancellationToken()
+    ct = CancellationToken()
     cmd = DefaultCommand(
         serial_device=serial_device,
         capture_device=capture_device,
@@ -224,16 +214,25 @@ def test_touch_not_supported(dummy_command):
 def test_wait(dummy_command):
     cmd, *_ = dummy_command
     start = time.time()
-    cmd.wait(0.5)
+    cmd.wait(0)
     end = time.time()
-    assert end - start < 0.1  # monkeypatchで即時
+    assert end - start < 0.1
 
 
 def test_stop(dummy_command):
     cmd, _, _, _, _, ct = dummy_command
-    with pytest.raises(Exception):
-        cmd.stop()
-    assert ct.stopped
+    cmd.stop()
+    assert ct.stop_requested()
+    assert ct.reason() == "stop requested"
+    assert ct.source() == "macro"
+
+
+def test_wait_raises_macro_cancelled_after_stop(dummy_command):
+    cmd, _, _, _, _, ct = dummy_command
+    ct.request_cancel(reason="test cancel", source="test")
+
+    with pytest.raises(MacroCancelled):
+        cmd.wait(1.0)
 
 
 def test_keyboard_text_mode(dummy_command):
@@ -430,7 +429,7 @@ def test_notify_calls_notification_handler(monkeypatch):
     capture_device = MockCaptureDevice()
     resource_io = MockResourceIO()
     protocol = MockProtocol()
-    ct = MockCancellationToken()
+    ct = CancellationToken()
     mock_notifier = MockNotificationHandler()
     cmd = DefaultCommand(
         serial_device=serial_device,

--- a/tests/unit/framework/runtime/test_macro_runner.py
+++ b/tests/unit/framework/runtime/test_macro_runner.py
@@ -1,0 +1,292 @@
+from __future__ import annotations
+
+import threading
+import time
+from datetime import datetime
+
+import pytest
+
+from nyxpy.framework.core.macro.base import MacroBase
+from nyxpy.framework.core.macro.command import Command
+from nyxpy.framework.core.macro.exceptions import (
+    ErrorKind,
+    FrameworkError,
+    MacroCancelled,
+    MacroStopException,
+)
+from nyxpy.framework.core.runtime import MacroRunner, RunContext, RunResult, RunStatus
+from nyxpy.framework.core.utils.cancellation import CancellationToken, cancellation_aware_wait
+
+
+class RecordingCommand(Command):
+    def __init__(self, token: CancellationToken | None = None) -> None:
+        self.events: list[str] = []
+        self.ct = token or CancellationToken()
+
+    def press(self, *keys, dur=0.1, wait=0.1) -> None:
+        self.events.append("press")
+
+    def hold(self, *keys) -> None:
+        self.events.append("hold")
+
+    def release(self, *keys) -> None:
+        self.events.append("release")
+
+    def wait(self, wait: float) -> None:
+        cancellation_aware_wait(wait, self.ct)
+        self.ct.throw_if_requested()
+
+    def stop(self) -> None:
+        self.ct.request_cancel(reason="stop requested", source="macro")
+
+    def log(self, *values, sep: str = " ", end: str = "\n", level: str = "DEBUG") -> None:
+        self.events.append(sep.join(map(str, values)) + end.rstrip("\n"))
+
+    def capture(self, crop_region=None, grayscale: bool = False):
+        return None
+
+    def save_img(self, filename, image) -> None:
+        self.events.append(f"save:{filename}")
+
+    def load_img(self, filename, grayscale: bool = False):
+        return None
+
+    def keyboard(self, text: str) -> None:
+        self.events.append(f"keyboard:{text}")
+
+    def type(self, key) -> None:
+        self.events.append(f"type:{key}")
+
+    def notify(self, text: str, img=None) -> None:
+        self.events.append(f"notify:{text}")
+
+
+def _run_context(token: CancellationToken | None = None) -> RunContext:
+    return RunContext(
+        run_id="run-1",
+        macro_id="macro-1",
+        macro_name="MacroOne",
+        started_at=datetime.now(),
+        cancellation_token=token or CancellationToken(),
+        logger=None,
+    )
+
+
+class OrderedMacro(MacroBase):
+    def __init__(self, events: list[str]) -> None:
+        self.events = events
+
+    def initialize(self, cmd: Command, args: dict) -> None:
+        self.events.append(f"initialize:{args['value']}")
+
+    def run(self, cmd: Command) -> None:
+        self.events.append("run")
+
+    def finalize(self, cmd: Command) -> None:
+        self.events.append("finalize")
+
+
+def test_runner_calls_lifecycle_in_order() -> None:
+    events: list[str] = []
+    result = MacroRunner().run(
+        OrderedMacro(events),
+        RecordingCommand(),
+        {"value": "ok"},
+        _run_context(),
+    )
+
+    assert events == ["initialize:ok", "run", "finalize"]
+    assert result.status is RunStatus.SUCCESS
+    assert result.error is None
+    assert result.ok
+
+
+class ErrorMacro(MacroBase):
+    def __init__(self, events: list[str]) -> None:
+        self.events = events
+
+    def initialize(self, cmd: Command, args: dict) -> None:
+        self.events.append("initialize")
+
+    def run(self, cmd: Command) -> None:
+        self.events.append("run")
+        raise RuntimeError("boom")
+
+    def finalize(self, cmd: Command) -> None:
+        self.events.append("finalize")
+
+
+def test_runner_calls_finalize_on_error() -> None:
+    events: list[str] = []
+    result = MacroRunner().run(ErrorMacro(events), RecordingCommand(), {}, _run_context())
+
+    assert events == ["initialize", "run", "finalize"]
+    assert result.status is RunStatus.FAILED
+    assert result.error is not None
+    assert result.error.code == "NYX_MACRO_FAILED"
+    assert result.error.exception_type == "RuntimeError"
+
+
+class StopMacro(MacroBase):
+    def initialize(self, cmd: Command, args: dict) -> None:
+        pass
+
+    def run(self, cmd: Command) -> None:
+        raise MacroStopException("legacy stop")
+
+    def finalize(self, cmd: Command) -> None:
+        self.finalized = True
+
+
+def test_runner_converts_macro_stop_to_cancelled() -> None:
+    macro = StopMacro()
+
+    result = MacroRunner().run(macro, RecordingCommand(), {}, _run_context())
+
+    assert result.status is RunStatus.CANCELLED
+    assert result.error is not None
+    assert result.error.kind is ErrorKind.CANCELLED
+    assert result.error.code == "NYX_MACRO_CANCELLED"
+    assert macro.finalized is True
+
+
+def test_macro_cancelled_is_macro_stop_exception_compatible() -> None:
+    with pytest.raises(MacroStopException):
+        raise MacroCancelled("cancelled")
+
+
+def test_macro_stop_exception_constructor_keeps_legacy_calls() -> None:
+    empty = MacroStopException()
+    with_message = MacroStopException("stop")
+
+    assert str(empty) == ""
+    assert str(with_message) == "stop"
+    assert with_message.kind is ErrorKind.CANCELLED
+    assert with_message.code == "NYX_MACRO_CANCELLED"
+    assert with_message.component == "MacroStopException"
+
+
+def test_framework_error_contains_kind_code_component() -> None:
+    error = FrameworkError(
+        "broken",
+        kind=ErrorKind.INTERNAL,
+        code="NYX_INTERNAL",
+        component="test",
+        details={"key": "value"},
+    )
+
+    assert error.kind is ErrorKind.INTERNAL
+    assert error.code == "NYX_INTERNAL"
+    assert error.component == "test"
+    assert error.details == {"key": "value"}
+
+
+def test_cancellation_token_request_cancel_is_idempotent() -> None:
+    token = CancellationToken()
+
+    token.request_cancel(reason="first", source="gui")
+    first_requested_at = token.requested_at()
+    token.request_cancel(reason="second", source="cli")
+
+    assert token.stop_requested()
+    assert token.reason() == "first"
+    assert token.source() == "gui"
+    assert token.requested_at() == first_requested_at
+
+    token.clear()
+    assert not token.stop_requested()
+    assert token.reason() is None
+    assert token.source() is None
+    assert token.requested_at() is None
+
+
+def test_command_wait_returns_immediately_on_cancel() -> None:
+    token = CancellationToken()
+
+    def cancel() -> None:
+        time.sleep(0.05)
+        token.request_cancel(reason="test", source="unit")
+
+    thread = threading.Thread(target=cancel)
+    started = time.perf_counter()
+    thread.start()
+    with pytest.raises(MacroCancelled):
+        RecordingCommand(token).wait(5.0)
+    elapsed = time.perf_counter() - started
+    thread.join()
+
+    assert elapsed < 0.15
+
+
+class CmdOnlyFinalizeMacro(MacroBase):
+    def __init__(self) -> None:
+        self.finalized = 0
+
+    def initialize(self, cmd: Command, args: dict) -> None:
+        pass
+
+    def run(self, cmd: Command) -> None:
+        pass
+
+    def finalize(self, cmd: Command) -> None:
+        self.finalized += 1
+
+
+def test_finalize_cmd_only_remains_supported() -> None:
+    macro = CmdOnlyFinalizeMacro()
+
+    result = MacroRunner().run(macro, RecordingCommand(), {}, _run_context())
+
+    assert result.status is RunStatus.SUCCESS
+    assert macro.finalized == 1
+
+
+class OutcomeFinalizeMacro(MacroBase):
+    def __init__(self) -> None:
+        self.outcome: RunResult | None = None
+        self.finalized = 0
+
+    def initialize(self, cmd: Command, args: dict) -> None:
+        pass
+
+    def run(self, cmd: Command) -> None:
+        pass
+
+    def finalize(self, cmd: Command) -> None:
+        self.finalized += 1
+
+    def finalize_with_outcome(self, cmd: Command, outcome: RunResult) -> None:
+        self.outcome = outcome
+
+
+def test_finalize_receives_outcome_when_supported() -> None:
+    macro = OutcomeFinalizeMacro()
+
+    result = MacroRunner().run(macro, RecordingCommand(), {}, _run_context())
+
+    assert result.status is RunStatus.SUCCESS
+    assert macro.outcome is not None
+    assert macro.outcome.status is RunStatus.SUCCESS
+    assert macro.finalized == 0
+
+
+class FinalizeFailsAfterErrorMacro(ErrorMacro):
+    def finalize(self, cmd: Command) -> None:
+        self.events.append("finalize")
+        raise RuntimeError("finalize boom")
+
+
+def test_finalize_error_is_added_without_losing_original_error() -> None:
+    events: list[str] = []
+
+    result = MacroRunner().run(
+        FinalizeFailsAfterErrorMacro(events),
+        RecordingCommand(),
+        {},
+        _run_context(),
+    )
+
+    assert result.status is RunStatus.FAILED
+    assert result.error is not None
+    assert result.error.message == "boom"
+    assert result.error.details["finalize_error"]["message"] == "finalize boom"


### PR DESCRIPTION
## Summary

フレームワーク再設計フェーズ 3 として、ライフサイクル実行・例外正規化・協調キャンセルを扱う `MacroRunner` と `RunResult` を追加しました。

## Related

- spec\framework\rearchitecture\IMPLEMENTATION_PLAN.md フェーズ 3
- spec\framework\rearchitecture\RUNTIME_AND_IO_PORTS.md
- spec\framework\rearchitecture\ERROR_CANCELLATION_LOGGING.md

## Changes

- `RunStatus` / `RunResult` / `RunContext` / `RunHandle` / `MacroRunner` を `core.runtime` に追加
- `FrameworkError` 階層、`ErrorInfo`、`MacroCancelled`、互換 `MacroStopException` を追加
- `CancellationToken` に理由・要求元・時刻・`throw_if_requested()`・中断 aware wait を追加
- `Command.wait()` をキャンセル応答可能にし、`Command.stop()` を例外送出ではなく停止要求登録へ変更
- `finalize(cmd)` 互換と `finalize_with_outcome(cmd, outcome)` opt-in を Runner テストで固定

## Commit Log

```
e495a43 feat(framework): MacroRunnerと実行結果を導入
```

## Testing

```
uv run pytest tests\unit\ tests\integration\
# 349 passed, 2 xfailed, 1 warning

uv run ruff check .
# All checks passed

uv run ruff format src\nyxpy\framework\core\macro\exceptions.py src\nyxpy\framework\core\settings\exceptions.py src\nyxpy\framework\core\utils\cancellation.py src\nyxpy\framework\core\macro\decorators.py src\nyxpy\framework\core\macro\command.py src\nyxpy\framework\core\runtime tests\unit\framework\runtime\test_macro_runner.py tests\unit\command\test_default_command.py tests\integration\test_macro_runtime_entrypoints.py --check
# checked after formatting changed files
```

## Checklist

- [x] lint / format チェック通過
- [x] 既存テスト通過
- [x] コミット prefix (feat/fix 等) が変更の動機と一致している
- [x] 新規・変更コードに対するテスト追加（該当する場合）
- [x] 型チェック通過（Python テストと ruff で確認）

## Review Notes

`Command.stop()` は仕様どおり即時例外を送出しなくなり、`CancellationToken` への停止要求だけを登録します。実際の脱出は `Command.wait()` / `@check_interrupt` / `throw_if_requested()` の safe point で `MacroCancelled` として発生します。