### PR TITLE
refactor(framework): settings解決を明示パスに限定

### DIFF
--- a/src/nyxpy/framework/core/utils/helper.py
+++ b/src/nyxpy/framework/core/utils/helper.py
@@ -1,7 +1,14 @@
 import inspect
+from dataclasses import dataclass
 from pathlib import Path
 
 import tomlkit
+
+
+@dataclass(frozen=True)
+class _SettingsDefinition:
+    settings_path: Path | str | None
+    macro_root: Path
 
 
 def get_caller_class_name():
@@ -20,31 +27,19 @@ def get_caller_class_name():
 
 def load_macro_settings(macro_cls) -> dict:
     """
-    指定されたマクロクラスに対応する設定ファイルを読み込み、辞書型のオブジェクトとして返却します。
-    設定ファイルは、<current_working_directory>/static/<macro_name>/settings.toml に存在することを想定します。
+    マクロクラスが明示した settings_path を読み込みます。
 
-    マクロの特定方法:
-    - パッケージマクロ (macros/<pkg>/macro.py): パッケージディレクトリ名を使用
-    - 単一ファイルマクロ (macros/sample.py): ファイル名（拡張子なし）を使用
+    旧 static/<macro_name>/settings.toml fallback は Runtime の settings 契約に含めない。
 
     :param macro_cls: マクロクラス（例: DummyTestMacro）
-    :return: マージされた設定辞書
+    :return: 設定辞書。settings_path が未指定なら空 dict
     """
     macro_file = Path(inspect.getfile(macro_cls))
+    settings_path = getattr(macro_cls, "settings_path", None)
+    definition = _SettingsDefinition(settings_path=settings_path, macro_root=macro_file.parent)
+    from nyxpy.framework.core.macro.settings_resolver import MacroSettingsResolver
 
-    # パッケージマクロ判定: 親ディレクトリに __init__.py があればパッケージ
-    if (macro_file.parent / "__init__.py").exists():
-        macro_name = macro_file.parent.name
-    else:
-        macro_name = macro_file.stem
-
-    settings_file = Path.cwd() / "static" / macro_name / "settings.toml"
-    file_params = {}
-    if settings_file.exists():
-        text = settings_file.read_text(encoding="utf-8")
-        file_params = tomlkit.loads(text)
-
-    return file_params
+    return MacroSettingsResolver(Path.cwd()).load(definition)
 
 
 def parse_define_args(defines: list[str]) -> dict:

--- a/tests/integration/test_migrated_macro_compat.py
+++ b/tests/integration/test_migrated_macro_compat.py
@@ -171,6 +171,8 @@ def test_file_settings_and_exec_args_are_merged_with_exec_args_precedence(
 
 
             class SettingsProbeMacro(MacroBase):
+                settings_path = "settings_probe.toml"
+
                 def initialize(self, cmd: Command, args: dict) -> None:
                     self.args = dict(args)
 
@@ -183,9 +185,7 @@ def test_file_settings_and_exec_args_are_merged_with_exec_args_precedence(
         ),
         encoding="utf-8",
     )
-    settings_dir = tmp_path / "static" / "settings_probe"
-    settings_dir.mkdir(parents=True)
-    (settings_dir / "settings.toml").write_text(
+    (macros_dir / "settings_probe.toml").write_text(
         'value = "file"\nkeep = "file"\n',
         encoding="utf-8",
     )

--- a/tests/unit/executor/test_helper.py
+++ b/tests/unit/executor/test_helper.py
@@ -21,18 +21,15 @@ from nyxpy.framework.core.utils.helper import (
     validate_keyboard_text,
 )
 
-# ============================================================
-# load_macro_settings テスト
-# ============================================================
-
 
 # --- テスト用ダミーマクロ構造の構築ヘルパー ---
-
-
-def _write_single_file_macro(macros_dir: Path, name: str) -> Path:
+def _write_single_file_macro(macros_dir: Path, name: str, body: str = "") -> Path:
     """macros/<name>.py を作成し、ダミーマクロクラスを定義する。"""
+    body_block = textwrap.indent(textwrap.dedent(body).strip(), "    ")
+    body_section = f"{body_block}\n" if body_block else ""
     src = textwrap.dedent(f"""\
         class {name.title().replace("_", "")}Macro:
+        {body_section}
             pass
     """)
     path = macros_dir / f"{name}.py"
@@ -40,7 +37,7 @@ def _write_single_file_macro(macros_dir: Path, name: str) -> Path:
     return path
 
 
-def _write_package_macro(macros_dir: Path, pkg_name: str) -> Path:
+def _write_package_macro(macros_dir: Path, pkg_name: str, body: str = "") -> Path:
     """macros/<pkg_name>/ パッケージを作成し、macro.py にダミークラスを定義する。"""
     pkg_dir = macros_dir / pkg_name
     pkg_dir.mkdir(parents=True, exist_ok=True)
@@ -48,8 +45,11 @@ def _write_package_macro(macros_dir: Path, pkg_name: str) -> Path:
         f"from .macro import {pkg_name.title().replace('_', '')}Macro\n",
         encoding="utf-8",
     )
+    body_block = textwrap.indent(textwrap.dedent(body).strip(), "    ")
+    body_section = f"{body_block}\n" if body_block else ""
     src = textwrap.dedent(f"""\
         class {pkg_name.title().replace("_", "")}Macro:
+        {body_section}
             pass
     """)
     (pkg_dir / "macro.py").write_text(src, encoding="utf-8")
@@ -82,96 +82,42 @@ def _import_class_from_file(path: Path, class_name: str):
 
 
 class TestLoadMacroSettings:
-    """load_macro_settings のテスト"""
-
-    def test_single_file_macro(self, tmp_path, monkeypatch):
-        """単一ファイルマクロで settings.toml が正しく読み込まれる"""
+    def test_explicit_class_settings_path(self, tmp_path, monkeypatch):
         macros_dir = tmp_path / "macros"
         macros_dir.mkdir()
-        py_path = _write_single_file_macro(macros_dir, "my_sample")
-
-        static_dir = tmp_path / "static"
-        _write_settings_toml(static_dir, "my_sample", 'key1 = "hello"\nkey2 = 42\n')
+        py_path = _write_single_file_macro(
+            macros_dir, "my_sample", 'settings_path = "settings.toml"'
+        )
+        (macros_dir / "settings.toml").write_text('key1 = "hello"\nkey2 = 42\n')
 
         monkeypatch.chdir(tmp_path)
         cls = _import_class_from_file(py_path, "MySampleMacro")
 
-        result = load_macro_settings(cls)
-        assert result["key1"] == "hello"
-        assert result["key2"] == 42
+        assert load_macro_settings(cls) == {"key1": "hello", "key2": 42}
 
-    def test_package_macro(self, tmp_path, monkeypatch):
-        """パッケージマクロで settings.toml が正しく読み込まれる"""
+    def test_project_settings_path(self, tmp_path, monkeypatch):
         macros_dir = tmp_path / "macros"
         macros_dir.mkdir()
-        py_path = _write_package_macro(macros_dir, "my_pkg")
-
-        static_dir = tmp_path / "static"
-        _write_settings_toml(static_dir, "my_pkg", 'name = "test"\nvalue = 100\n')
+        py_path = _write_package_macro(
+            macros_dir, "my_pkg", 'settings_path = "project:project_settings.toml"'
+        )
+        (tmp_path / "project_settings.toml").write_text("value = 100\n")
 
         monkeypatch.chdir(tmp_path)
         cls = _import_class_from_file(py_path, "MyPkgMacro")
 
-        result = load_macro_settings(cls)
-        assert result["name"] == "test"
-        assert result["value"] == 100
+        assert load_macro_settings(cls) == {"value": 100}
 
-    def test_package_macro_does_not_use_file_stem(self, tmp_path, monkeypatch):
-        """パッケージマクロで stem (= 'macro') のパスを参照しないこと"""
+    def test_static_fallback_is_not_supported(self, tmp_path, monkeypatch):
         macros_dir = tmp_path / "macros"
         macros_dir.mkdir()
-        py_path = _write_package_macro(macros_dir, "my_pkg")
-
-        static_dir = tmp_path / "static"
-        # stem 名 'macro' のディレクトリに罠を仕掛ける
-        _write_settings_toml(static_dir, "macro", "wrong = true\n")
-        # 正しいパッケージ名には設定を置かない
+        py_path = _write_single_file_macro(macros_dir, "legacy")
+        _write_settings_toml(tmp_path / "static", "legacy", "wrong = true\n")
 
         monkeypatch.chdir(tmp_path)
-        cls = _import_class_from_file(py_path, "MyPkgMacro")
+        cls = _import_class_from_file(py_path, "LegacyMacro")
 
-        result = load_macro_settings(cls)
-        # "macro" の方を読んでいないこと
-        assert "wrong" not in result
-        assert result == {}
-
-    def test_missing_settings_returns_empty(self, tmp_path, monkeypatch):
-        """settings.toml が存在しない場合、空 dict が返る"""
-        macros_dir = tmp_path / "macros"
-        macros_dir.mkdir()
-        py_path = _write_single_file_macro(macros_dir, "no_settings")
-
-        monkeypatch.chdir(tmp_path)
-        cls = _import_class_from_file(py_path, "NoSettingsMacro")
-
-        result = load_macro_settings(cls)
-        assert result == {}
-
-    def test_toml_types_preserved(self, tmp_path, monkeypatch):
-        """TOML のデータ型（文字列, 整数, 浮動小数点, 配列, bool）が保持される"""
-        macros_dir = tmp_path / "macros"
-        macros_dir.mkdir()
-        py_path = _write_single_file_macro(macros_dir, "typed")
-
-        static_dir = tmp_path / "static"
-        toml_content = textwrap.dedent("""\
-            str_val = "hello"
-            int_val = 42
-            float_val = 3.14
-            bool_val = true
-            arr_val = [1, 2, 3]
-        """)
-        _write_settings_toml(static_dir, "typed", toml_content)
-
-        monkeypatch.chdir(tmp_path)
-        cls = _import_class_from_file(py_path, "TypedMacro")
-
-        result = load_macro_settings(cls)
-        assert result["str_val"] == "hello"
-        assert result["int_val"] == 42
-        assert result["float_val"] == pytest.approx(3.14)
-        assert result["bool_val"] is True
-        assert list(result["arr_val"]) == [1, 2, 3]
+        assert load_macro_settings(cls) == {}
 
 
 # ============================================================

--- a/tests/unit/framework/io/test_fake_ports.py
+++ b/tests/unit/framework/io/test_fake_ports.py
@@ -86,6 +86,21 @@ def test_resource_store_raises_for_missing_asset(tmp_path: Path) -> None:
         FakeResourceStore(scope).resolve_asset_path("missing.png")
 
 
+def test_macro_settings_resolver_is_separate_from_resource_store(tmp_path: Path) -> None:
+    settings_dir = tmp_path / "resources" / "sample" / "assets"
+    settings_dir.mkdir(parents=True)
+    (settings_dir / "settings.toml").write_text("value = 'not an image'\n", encoding="utf-8")
+    scope = MacroResourceScope(
+        project_root=tmp_path,
+        macro_id="sample",
+        macro_root=None,
+        assets_roots=(settings_dir,),
+    )
+
+    with pytest.raises(ResourceNotFoundError):
+        FakeResourceStore(scope).resolve_asset_path("missing.png")
+
+
 def test_run_artifact_store_contract(tmp_path: Path) -> None:
     store = FakeRunArtifactStore(
         tmp_path / "runs" / "run-1" / "outputs", macro_id="sample", run_id="run-1"

--- a/tests/unit/framework/runtime/test_execution_context.py
+++ b/tests/unit/framework/runtime/test_execution_context.py
@@ -1,8 +1,30 @@
+from pathlib import Path
 from types import MappingProxyType
 
 import pytest
 
+from nyxpy.framework.core.macro.registry import MacroDefinition
+from nyxpy.framework.core.runtime.builder import MacroRuntimeBuilder
+from nyxpy.framework.core.runtime.context import RuntimeBuildRequest
 from tests.support.fake_execution_context import make_fake_execution_context
+from tests.support.fakes import (
+    FakeControllerOutputPort,
+    FakeFrameSourcePort,
+    FakeLoggerPort,
+    FakeNotificationPort,
+)
+
+
+class Registry:
+    def __init__(self, definition: MacroDefinition, settings: dict) -> None:
+        self.definition = definition
+        self.settings = settings
+
+    def resolve(self, name_or_id: str) -> MacroDefinition:
+        return self.definition
+
+    def get_settings(self, definition: MacroDefinition) -> dict:
+        return dict(self.settings)
 
 
 def test_execution_context_shallow_copies_args_and_metadata(tmp_path) -> None:
@@ -27,3 +49,36 @@ def test_execution_context_does_not_hold_command(tmp_path) -> None:
     context = make_fake_execution_context(tmp_path)
 
     assert not hasattr(context, "command")
+
+
+def test_exec_args_override_file_settings(tmp_path) -> None:
+    definition = MacroDefinition(
+        id="sample",
+        aliases=("sample",),
+        display_name="Sample",
+        class_name="SampleMacro",
+        module_name="tests.sample",
+        macro_root=Path(__file__).parent,
+        source_path=Path(__file__),
+        settings_path=None,
+        description="",
+        tags=(),
+        factory=object(),
+    )
+    base_context = make_fake_execution_context(tmp_path)
+    builder = MacroRuntimeBuilder(
+        project_root=tmp_path,
+        registry=Registry(definition, {"value": "file", "keep": "file"}),
+        controller_factory=lambda _request, _definition: FakeControllerOutputPort(),
+        frame_source_factory=lambda _request, _definition: FakeFrameSourcePort(),
+        resource_store_factory=lambda _request, _definition: base_context.resources,
+        artifact_store_factory=lambda _request, _definition: base_context.artifacts,
+        notification_factory=lambda _request, _definition: FakeNotificationPort(),
+        logger_factory=lambda _request, _definition: FakeLoggerPort(),
+    )
+
+    context = builder.build(
+        RuntimeBuildRequest(macro_id="sample", exec_args={"value": "exec", "other": 3})
+    )
+
+    assert context.exec_args == {"value": "exec", "keep": "file", "other": 3}


### PR DESCRIPTION
## Summary
フレームワーク再設計フェーズ6として、settings 解決を manifest / class metadata の明示パスに限定しました。
旧 static\<macro>\settings.toml fallback を helper から外し、ResourceStore が settings TOML 探索を担当しないことをテストで固定しました。

## Related
- spec\framework\rearchitecture\IMPLEMENTATION_PLAN.md
- spec\framework\rearchitecture\MACRO_COMPATIBILITY_AND_REGISTRY.md
- spec\framework\rearchitecture\RESOURCE_FILE_IO.md

## Changes
- load_macro_settings() を MacroSettingsResolver 経由の明示 settings_path 読み込みに変更
- 旧 static fallback 前提の helper テストを class metadata / project: settings 契約へ移行
- exec_args が file settings より優先される builder 契約をテスト追加
- ResourceStore が settings TOML を探索しないことを fake port テストに追加
- settings merge 互換テストを明示 settings_path 配置へ更新

## Commit Log
```
0e1c070 refactor(framework): settings解決を明示パスに限定
```

## Testing
```
uv run pytest tests\unit\ tests\integration\
# 361 passed, 1 xfailed

uv run ruff check .
# All checks passed

uv run ruff format src\nyxpy\framework\core\utils\helper.py tests\unit\executor\test_helper.py tests\unit\framework\runtime\test_execution_context.py tests\unit\framework\io\test_fake_ports.py tests\integration\test_migrated_macro_compat.py --check
# 5 files already formatted
```

## Checklist
- [x] lint / format チェック通過
- [x] 既存テスト通過
- [x] コミット prefix (feat/fix 等) が変更の動機と一致している
- [x] 新規・変更コードに対するテスト追加（該当する場合）
- [x] 型チェック通過
