### PR TITLE
feat(framework): Resource File I/Oをruns出力へ移行

### DIFF
--- a/src/nyxpy/cli/run_cli.py
+++ b/src/nyxpy/cli/run_cli.py
@@ -7,7 +7,6 @@ from nyxpy.framework.core.api.notification_handler import (
 )
 from nyxpy.framework.core.hardware.protocol import SerialProtocolInterface
 from nyxpy.framework.core.hardware.protocol_factory import ProtocolFactory
-from nyxpy.framework.core.hardware.resource import StaticResourceIO
 from nyxpy.framework.core.logger.log_manager import log_manager
 from nyxpy.framework.core.macro.registry import MacroRegistry
 from nyxpy.framework.core.runtime.builder import MacroRuntimeBuilder, create_legacy_runtime_builder
@@ -61,27 +60,23 @@ def create_runtime_builder(
 
     Args:
         protocol: 使用するプロトコル実装
-        resources_dir: リソースI/O用のディレクトリ（デフォルトは'./static'）
+        resources_dir: 旧互換引数。指定時はプロジェクトルートとして扱います。
 
     Returns:
         設定済みの Runtime builder
     """
-    if resources_dir is None:
-        resources_dir = pathlib.Path.cwd() / "static"
-
-    resource_io = StaticResourceIO(resources_dir)
-    registry = MacroRegistry(project_root=pathlib.Path.cwd())
+    project_root = pathlib.Path.cwd() if resources_dir is None else resources_dir
+    registry = MacroRegistry(project_root=project_root)
     registry.reload()
     serial_device = serial_manager.get_active_device()
     capture_device = capture_manager.get_active_device()
     global_settings = GlobalSettings()
     notification_handler = create_notification_handler_from_settings(global_settings)
     return create_legacy_runtime_builder(
-        project_root=pathlib.Path.cwd(),
+        project_root=project_root,
         registry=registry,
         serial_device=serial_device,
         capture_device=capture_device,
-        resource_io=resource_io,
         protocol=protocol,
         notification_handler=notification_handler,
         log_manager=log_manager,

--- a/src/nyxpy/framework/core/io/__init__.py
+++ b/src/nyxpy/framework/core/io/__init__.py
@@ -8,6 +8,8 @@ from nyxpy.framework.core.io.ports import (
 )
 from nyxpy.framework.core.io.resources import (
     DefaultResourcePathGuard,
+    LocalResourceStore,
+    LocalRunArtifactStore,
     MacroResourceScope,
     OverwritePolicy,
     ResourceAlreadyExistsError,
@@ -28,6 +30,8 @@ __all__ = [
     "ControllerOutputPort",
     "DefaultResourcePathGuard",
     "FrameNotReadyError",
+    "LocalResourceStore",
+    "LocalRunArtifactStore",
     "FrameSourcePort",
     "MacroResourceScope",
     "NotificationPort",

--- a/src/nyxpy/framework/core/io/resources.py
+++ b/src/nyxpy/framework/core/io/resources.py
@@ -1,9 +1,13 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+from collections.abc import Iterator
+from contextlib import AbstractContextManager
 from dataclasses import dataclass
 from enum import StrEnum
+from os import PathLike
 from pathlib import Path
+from tempfile import NamedTemporaryFile
 from typing import BinaryIO, Protocol
 
 import cv2
@@ -30,23 +34,47 @@ class OverwritePolicy(StrEnum):
 
 
 class ResourcePathError(ResourceError):
-    def __init__(self, message: str) -> None:
-        super().__init__(message, code="NYX_RESOURCE_PATH_INVALID", component="ResourcePathGuard")
+    def __init__(self, message: str, **kwargs: object) -> None:
+        super().__init__(
+            message,
+            code=str(kwargs.pop("code", "NYX_RESOURCE_PATH_INVALID")),
+            component=str(kwargs.pop("component", "ResourcePathGuard")),
+            details=kwargs.pop("details", None),
+            cause=kwargs.pop("cause", None),
+        )
 
 
 class ResourceNotFoundError(ResourceError):
-    def __init__(self, message: str) -> None:
-        super().__init__(message, code="NYX_RESOURCE_READ_FAILED", component="ResourceStorePort")
+    def __init__(self, message: str, **kwargs: object) -> None:
+        super().__init__(
+            message,
+            code=str(kwargs.pop("code", "NYX_RESOURCE_READ_FAILED")),
+            component=str(kwargs.pop("component", "ResourceStorePort")),
+            details=kwargs.pop("details", None),
+            cause=kwargs.pop("cause", None),
+        )
 
 
 class ResourceReadError(ResourceError):
-    def __init__(self, message: str) -> None:
-        super().__init__(message, code="NYX_RESOURCE_READ_FAILED", component="ResourceStorePort")
+    def __init__(self, message: str, **kwargs: object) -> None:
+        super().__init__(
+            message,
+            code=str(kwargs.pop("code", "NYX_RESOURCE_READ_FAILED")),
+            component=str(kwargs.pop("component", "ResourceStorePort")),
+            details=kwargs.pop("details", None),
+            cause=kwargs.pop("cause", None),
+        )
 
 
 class ResourceWriteError(ResourceError):
-    def __init__(self, message: str) -> None:
-        super().__init__(message, code="NYX_RESOURCE_WRITE_FAILED", component="RunArtifactStore")
+    def __init__(self, message: str, **kwargs: object) -> None:
+        super().__init__(
+            message,
+            code=str(kwargs.pop("code", "NYX_RESOURCE_WRITE_FAILED")),
+            component=str(kwargs.pop("component", "RunArtifactStore")),
+            details=kwargs.pop("details", None),
+            cause=kwargs.pop("cause", None),
+        )
 
 
 class ResourceAlreadyExistsError(ResourceWriteError):
@@ -68,6 +96,24 @@ class MacroResourceScope:
     macro_id: str
     macro_root: Path | None
     assets_roots: tuple[Path, ...]
+
+    @classmethod
+    def from_definition(cls, definition, project_root: Path) -> MacroResourceScope:
+        project_root = Path(project_root).resolve()
+        macro_id = str(definition.id)
+        _validate_resource_identifier(macro_id)
+        assets_roots = [project_root / "resources" / macro_id / "assets"]
+        macro_root = (
+            Path(definition.macro_root).resolve() if definition.macro_root is not None else None
+        )
+        if macro_root is not None:
+            assets_roots.append(macro_root / "assets")
+        return cls(
+            project_root=project_root,
+            macro_id=macro_id,
+            macro_root=macro_root,
+            assets_roots=tuple(assets_roots),
+        )
 
     def candidate_asset_paths(
         self, name: str | Path, guard: ResourcePathGuard | None = None
@@ -91,9 +137,20 @@ class ResourcePathGuard(Protocol):
 
 
 class DefaultResourcePathGuard:
+    _RESERVED_WINDOWS_NAMES = {
+        "CON",
+        "PRN",
+        "AUX",
+        "NUL",
+        *(f"COM{i}" for i in range(1, 10)),
+        *(f"LPT{i}" for i in range(1, 10)),
+    }
+
     def resolve_under_root(self, root: Path, name: str | Path) -> Path:
+        if not isinstance(name, (str, PathLike)):
+            raise ResourcePathError("resource path must be str or Path")
         root_path = Path(root)
-        root_resolved = root_path.resolve(strict=False)
+        root_resolved = root_path.resolve(strict=root_path.exists())
         name_text = str(name)
         if not name_text or name_text in {".", ""}:
             raise ResourcePathError("resource path is empty")
@@ -102,11 +159,13 @@ class DefaultResourcePathGuard:
         if len(name_text) >= 2 and name_text[1] == ":":
             raise ResourcePathError("resource path must not contain a drive")
 
-        parts = tuple(part for part in name_text.replace("\\", "/").split("/") if part)
-        if not parts or any(part == ".." for part in parts):
+        raw_parts = tuple(name_text.replace("\\", "/").split("/"))
+        if not raw_parts or any(part in {"", ".", ".."} for part in raw_parts):
             raise ResourcePathError("resource path must not escape the resource root")
+        if any(self._is_reserved_windows_name(part) for part in raw_parts):
+            raise ResourcePathError("resource path contains a reserved name")
 
-        relative_path = Path(*parts)
+        relative_path = Path(*raw_parts)
         if relative_path.is_absolute():
             raise ResourcePathError("resource path must be relative")
 
@@ -116,6 +175,9 @@ class DefaultResourcePathGuard:
         except ValueError as exc:
             raise ResourcePathError("resource path escapes the resource root") from exc
         return candidate
+
+    def _is_reserved_windows_name(self, part: str) -> bool:
+        return part.split(".", maxsplit=1)[0].upper() in self._RESERVED_WINDOWS_NAMES
 
 
 class ResourceStorePort(ABC):
@@ -155,3 +217,227 @@ class RunArtifactStore(ABC):
 
     def close(self) -> None:
         pass
+
+
+class LocalResourceStore(ResourceStorePort):
+    def __init__(
+        self,
+        scope: MacroResourceScope,
+        guard: ResourcePathGuard | None = None,
+    ) -> None:
+        self.scope = scope
+        self.guard = guard or DefaultResourcePathGuard()
+
+    def resolve_asset_path(self, name: str | Path) -> ResourceRef:
+        for index, root in enumerate(self.scope.assets_roots):
+            candidate = self.guard.resolve_under_root(root, name)
+            if candidate.exists():
+                return ResourceRef(
+                    kind=ResourceKind.ASSET,
+                    source=(
+                        ResourceSource.STANDARD_ASSETS
+                        if index == 0
+                        else ResourceSource.MACRO_PACKAGE
+                    ),
+                    path=candidate,
+                    relative_path=candidate.relative_to(
+                        Path(root).resolve(strict=Path(root).exists())
+                    ),
+                    macro_id=self.scope.macro_id,
+                )
+        raise ResourceNotFoundError(f"resource not found: {name}")
+
+    def load_image(self, name: str | Path, grayscale: bool = False) -> cv2.typing.MatLike:
+        ref = self.resolve_asset_path(name)
+        flag = cv2.IMREAD_GRAYSCALE if grayscale else cv2.IMREAD_COLOR
+        image = cv2.imread(str(ref.path), flag)
+        if image is None:
+            raise ResourceReadError(f"failed to read image: {ref.relative_path}")
+        return image
+
+
+class LocalRunArtifactStore(RunArtifactStore):
+    def __init__(
+        self,
+        output_root: Path,
+        *,
+        macro_id: str,
+        run_id: str,
+        overwrite: OverwritePolicy = OverwritePolicy.REPLACE,
+        atomic: bool = True,
+        guard: ResourcePathGuard | None = None,
+    ) -> None:
+        self.output_root = Path(output_root).resolve(strict=False)
+        self.macro_id = macro_id
+        self.run_id = run_id
+        self.overwrite = overwrite
+        self.atomic = atomic
+        self.guard = guard or DefaultResourcePathGuard()
+
+    def resolve_output_path(self, name: str | Path) -> ResourceRef:
+        path = self.guard.resolve_under_root(self.output_root, name)
+        return self._ref(path)
+
+    def save_image(
+        self,
+        name: str | Path,
+        image: cv2.typing.MatLike,
+        *,
+        overwrite: OverwritePolicy | None = None,
+        atomic: bool | None = None,
+    ) -> ResourceRef:
+        final_ref = self._prepare_output(name, overwrite or self.overwrite)
+        use_atomic = self.atomic if atomic is None else atomic
+        if use_atomic:
+            self._write_image_atomic(final_ref.path, image)
+        else:
+            self._write_image(final_ref.path, image)
+        return final_ref
+
+    def open_output(
+        self,
+        name: str | Path,
+        mode: str = "xb",
+        *,
+        overwrite: OverwritePolicy | None = None,
+        atomic: bool | None = None,
+    ) -> BinaryIO:
+        if "b" not in mode:
+            raise ResourceConfigurationError("open_output requires a binary mode")
+        if not any(flag in mode for flag in ("w", "x", "a")):
+            raise ResourceConfigurationError("open_output requires a writable mode")
+
+        policy = overwrite or OverwritePolicy.ERROR
+        final_ref = self._prepare_output(name, policy)
+        use_atomic = self.atomic if atomic is None else atomic
+        if not use_atomic:
+            open_mode = mode
+            if "x" in open_mode and policy is OverwritePolicy.REPLACE:
+                open_mode = open_mode.replace("x", "w")
+            if "x" in open_mode and final_ref.path.exists():
+                raise ResourceAlreadyExistsError(
+                    f"output already exists: {final_ref.relative_path}"
+                )
+            return final_ref.path.open(open_mode)
+
+        if "a" in mode:
+            raise ResourceConfigurationError("atomic append output is not supported")
+        temp_path = self._create_temp_path(final_ref.path)
+        temp_mode = "w+b" if "+" in mode else "wb"
+        return _AtomicOutputFile(temp_path.open(temp_mode), temp_path, final_ref.path)
+
+    def _prepare_output(self, name: str | Path, policy: OverwritePolicy) -> ResourceRef:
+        ref = self.resolve_output_path(name)
+        ref.path.parent.mkdir(parents=True, exist_ok=True)
+        guarded_path = self.guard.resolve_under_root(self.output_root, ref.relative_path)
+        if policy is OverwritePolicy.ERROR and guarded_path.exists():
+            raise ResourceAlreadyExistsError(f"output already exists: {ref.relative_path}")
+        if policy is OverwritePolicy.UNIQUE:
+            guarded_path = self._unique_path(guarded_path)
+        return self._ref(guarded_path)
+
+    def _write_image_atomic(self, final_path: Path, image: cv2.typing.MatLike) -> None:
+        temp_path = self._create_temp_path(final_path)
+        try:
+            self._write_image(temp_path, image)
+            temp_path.replace(final_path)
+            if not final_path.exists():
+                raise ResourceWriteError(f"output was not created: {final_path.name}")
+        except Exception as exc:
+            self._cleanup_temp(temp_path)
+            if isinstance(exc, ResourceWriteError):
+                raise
+            raise ResourceWriteError(
+                f"failed to write output: {final_path.name}", cause=exc
+            ) from exc
+
+    def _write_image(self, path: Path, image: cv2.typing.MatLike) -> None:
+        if not cv2.imwrite(str(path), image):
+            raise ResourceWriteError(f"failed to write output: {path.name}")
+        if not path.exists():
+            raise ResourceWriteError(f"output was not created: {path.name}")
+
+    def _create_temp_path(self, final_path: Path) -> Path:
+        final_path.parent.mkdir(parents=True, exist_ok=True)
+        with NamedTemporaryFile(
+            dir=final_path.parent,
+            prefix=f".{final_path.stem}.",
+            suffix=final_path.suffix,
+            delete=False,
+        ) as temp:
+            return Path(temp.name)
+
+    def _unique_path(self, path: Path) -> Path:
+        if not path.exists():
+            return path
+        for index in range(1, 10_000):
+            candidate = path.with_name(f"{path.stem}_{index}{path.suffix}")
+            if not candidate.exists():
+                return candidate
+        raise ResourceWriteError(f"failed to find unique output path: {path.name}")
+
+    def _cleanup_temp(self, temp_path: Path) -> None:
+        try:
+            if temp_path.exists():
+                temp_path.unlink()
+        except OSError:
+            pass
+
+    def _ref(self, path: Path) -> ResourceRef:
+        output_root = self.output_root.resolve(strict=self.output_root.exists())
+        return ResourceRef(
+            kind=ResourceKind.OUTPUT,
+            source=ResourceSource.RUN_OUTPUTS,
+            path=path,
+            relative_path=path.relative_to(output_root),
+            macro_id=self.macro_id,
+            run_id=self.run_id,
+        )
+
+
+class _AtomicOutputFile(AbstractContextManager):
+    def __init__(self, file: BinaryIO, temp_path: Path, final_path: Path) -> None:
+        self._file = file
+        self._temp_path = temp_path
+        self._final_path = final_path
+        self._closed = False
+
+    def __getattr__(self, name: str):
+        return getattr(self._file, name)
+
+    def __iter__(self) -> Iterator[bytes]:
+        return iter(self._file)
+
+    def close(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+        try:
+            self._file.close()
+            self._temp_path.replace(self._final_path)
+        except Exception:
+            if self._temp_path.exists():
+                self._temp_path.unlink()
+            raise
+
+    @property
+    def closed(self) -> bool:
+        return self._closed
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback) -> bool:
+        if exc_type is not None:
+            self._closed = True
+            self._file.close()
+            if self._temp_path.exists():
+                self._temp_path.unlink()
+            return False
+        self.close()
+        return False
+
+
+def _validate_resource_identifier(value: str) -> None:
+    if not value or any(separator in value for separator in ("\\", "/", ":")):
+        raise ResourceConfigurationError(f"invalid macro resource id: {value!r}")

--- a/src/nyxpy/framework/core/macro/command.py
+++ b/src/nyxpy/framework/core/macro/command.py
@@ -16,6 +16,7 @@ from nyxpy.framework.core.utils.helper import (
 )
 
 if TYPE_CHECKING:
+    from nyxpy.framework.core.io.resources import RunArtifactStore
     from nyxpy.framework.core.runtime.context import ExecutionContext
 
 
@@ -180,6 +181,10 @@ class DefaultCommand(Command):
             raise TypeError("DefaultCommand requires context=ExecutionContext")
         self.context = context
         self.ct: CancellationToken = context.cancellation_token
+
+    @property
+    def artifacts(self) -> RunArtifactStore:
+        return self.context.artifacts
 
     @check_interrupt
     def press(self, *keys: KeyType, dur: float = 0.1, wait: float = 0.1) -> None:

--- a/src/nyxpy/framework/core/runtime/builder.py
+++ b/src/nyxpy/framework/core/runtime/builder.py
@@ -4,14 +4,12 @@ import time
 from collections.abc import Callable
 from datetime import datetime
 from pathlib import Path
-from typing import BinaryIO
 from uuid import uuid4
 
 import cv2
 
 from nyxpy.framework.core.constants import KeyboardOp, KeyCode, KeyType, SpecialKeyCode
 from nyxpy.framework.core.hardware.protocol import SerialProtocolInterface
-from nyxpy.framework.core.hardware.resource import StaticResourceIO
 from nyxpy.framework.core.io.ports import (
     ControllerOutputPort,
     FrameNotReadyError,
@@ -19,12 +17,9 @@ from nyxpy.framework.core.io.ports import (
     NotificationPort,
 )
 from nyxpy.framework.core.io.resources import (
-    DefaultResourcePathGuard,
-    OverwritePolicy,
-    ResourceKind,
-    ResourceNotFoundError,
-    ResourceRef,
-    ResourceSource,
+    LocalResourceStore,
+    LocalRunArtifactStore,
+    MacroResourceScope,
     ResourceStorePort,
     RunArtifactStore,
 )
@@ -47,6 +42,7 @@ from nyxpy.framework.core.utils.cancellation import CancellationToken
 from nyxpy.framework.core.utils.helper import validate_keyboard_text
 
 type PortFactory[T] = Callable[[RuntimeBuildRequest, MacroDefinition], T]
+type ArtifactStoreFactory = Callable[[RuntimeBuildRequest, MacroDefinition, str], RunArtifactStore]
 
 
 class MacroRuntimeBuilder:
@@ -60,7 +56,7 @@ class MacroRuntimeBuilder:
         controller_factory: PortFactory[ControllerOutputPort],
         frame_source_factory: PortFactory[FrameSourcePort],
         resource_store_factory: PortFactory[ResourceStorePort],
-        artifact_store_factory: PortFactory[RunArtifactStore],
+        artifact_store_factory: ArtifactStoreFactory,
         notification_factory: PortFactory[NotificationPort],
         logger_factory: PortFactory[LoggerPort],
     ) -> None:
@@ -101,7 +97,7 @@ class MacroRuntimeBuilder:
             controller=self._controller_factory(request, definition),
             frame_source=self._frame_source_factory(request, definition),
             resources=self._resource_store_factory(request, definition),
-            artifacts=self._artifact_store_factory(request, definition),
+            artifacts=self._artifact_store_factory(request, definition, run_id),
             notifications=self._notification_factory(request, definition),
             logger=logger,
             options=RuntimeOptions(allow_dummy=self._allow_dummy(request)),
@@ -125,7 +121,6 @@ def create_legacy_runtime_builder(
     registry: MacroRegistry,
     serial_device,
     capture_device,
-    resource_io: StaticResourceIO,
     protocol: SerialProtocolInterface,
     notification_handler,
     log_manager,
@@ -139,11 +134,13 @@ def create_legacy_runtime_builder(
             serial_device, protocol
         ),
         frame_source_factory=lambda _request, _definition: _LegacyFrameSourcePort(capture_device),
-        resource_store_factory=lambda _request, definition: _LegacyResourceStore(
-            resource_io, definition
+        resource_store_factory=lambda _request, definition: LocalResourceStore(
+            MacroResourceScope.from_definition(definition, project_root)
         ),
-        artifact_store_factory=lambda _request, definition: _LegacyRunArtifactStore(
-            resource_io, definition
+        artifact_store_factory=lambda _request, definition, run_id: LocalRunArtifactStore(
+            Path(project_root) / "runs" / run_id / "outputs",
+            macro_id=definition.id,
+            run_id=run_id,
         ),
         notification_factory=lambda _request, _definition: _LegacyNotificationPort(
             notification_handler
@@ -225,67 +222,6 @@ class _LegacyFrameSourcePort(FrameSourcePort):
 
     def close(self) -> None:
         pass
-
-
-class _LegacyResourceStore(ResourceStorePort):
-    def __init__(self, resource_io: StaticResourceIO, definition: MacroDefinition) -> None:
-        self.resource_io = resource_io
-        self.definition = definition
-
-    def resolve_asset_path(self, name: str | Path) -> ResourceRef:
-        path = Path(self.resource_io.root_dir_path) / name
-        if not path.exists():
-            raise ResourceNotFoundError(f"resource not found: {name}")
-        return ResourceRef(
-            kind=ResourceKind.ASSET,
-            source=ResourceSource.STANDARD_ASSETS,
-            path=path,
-            relative_path=Path(name),
-            macro_id=self.definition.id,
-        )
-
-    def load_image(self, name: str | Path, grayscale: bool = False) -> cv2.typing.MatLike:
-        return self.resource_io.load_image(name, grayscale=grayscale)
-
-
-class _LegacyRunArtifactStore(RunArtifactStore):
-    def __init__(self, resource_io: StaticResourceIO, definition: MacroDefinition) -> None:
-        self.resource_io = resource_io
-        self.definition = definition
-        self.guard = DefaultResourcePathGuard()
-
-    def resolve_output_path(self, name: str | Path) -> ResourceRef:
-        path = self.guard.resolve_under_root(Path(self.resource_io.root_dir_path), name)
-        return ResourceRef(
-            kind=ResourceKind.OUTPUT,
-            source=ResourceSource.RUN_OUTPUTS,
-            path=path,
-            relative_path=Path(name),
-            macro_id=self.definition.id,
-        )
-
-    def save_image(
-        self,
-        name: str | Path,
-        image: cv2.typing.MatLike,
-        *,
-        overwrite: OverwritePolicy = OverwritePolicy.REPLACE,
-        atomic: bool = True,
-    ) -> ResourceRef:
-        self.resource_io.save_image(name, image)
-        return self.resolve_output_path(name)
-
-    def open_output(
-        self,
-        name: str | Path,
-        mode: str = "xb",
-        *,
-        overwrite: OverwritePolicy = OverwritePolicy.ERROR,
-        atomic: bool = True,
-    ) -> BinaryIO:
-        ref = self.resolve_output_path(name)
-        ref.path.parent.mkdir(parents=True, exist_ok=True)
-        return ref.path.open(mode)
 
 
 class _LegacyNotificationPort(NotificationPort):

--- a/src/nyxpy/gui/main_window.py
+++ b/src/nyxpy/gui/main_window.py
@@ -15,7 +15,6 @@ from PySide6.QtWidgets import (
 
 from nyxpy.framework.core.api.notification_handler import create_notification_handler_from_settings
 from nyxpy.framework.core.hardware.protocol_factory import ProtocolFactory
-from nyxpy.framework.core.hardware.resource import StaticResourceIO
 from nyxpy.framework.core.logger.log_manager import log_manager
 from nyxpy.framework.core.macro.registry import MacroRegistry
 from nyxpy.framework.core.runtime.builder import create_legacy_runtime_builder
@@ -267,7 +266,6 @@ class MainWindow(QMainWindow):
         self.worker.start()
 
     def _create_runtime_builder(self):
-        resource_io = StaticResourceIO(Path.cwd() / "static")
         protocol = ProtocolFactory.create_protocol(global_settings.get("serial_protocol", "CH552"))
         notification_handler = create_notification_handler_from_settings(secrets_settings)
         return create_legacy_runtime_builder(
@@ -275,7 +273,6 @@ class MainWindow(QMainWindow):
             registry=self.registry,
             serial_device=serial_manager.get_active_device(),
             capture_device=capture_manager.get_active_device(),
-            resource_io=resource_io,
             protocol=protocol,
             notification_handler=notification_handler,
             log_manager=log_manager,

--- a/tests/integration/test_resource_file_io_migration.py
+++ b/tests/integration/test_resource_file_io_migration.py
@@ -1,0 +1,145 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+
+from macros.sample_turbo_a_macro import SampleTurboAMacro
+from nyxpy.framework.core.io.resources import (
+    LocalResourceStore,
+    LocalRunArtifactStore,
+    MacroResourceScope,
+)
+from nyxpy.framework.core.macro.base import MacroBase
+from nyxpy.framework.core.macro.command import Command
+from nyxpy.framework.core.macro.registry import MacroDefinition
+from nyxpy.framework.core.runtime.builder import MacroRuntimeBuilder
+from nyxpy.framework.core.runtime.context import RuntimeBuildRequest
+from nyxpy.framework.core.runtime.result import RunStatus
+from tests.support.fakes import (
+    FakeControllerOutputPort,
+    FakeFrameSourcePort,
+    FakeLoggerPort,
+    FakeNotificationPort,
+)
+
+
+class SavingMacro(MacroBase):
+    def initialize(self, cmd: Command, args: dict) -> None:
+        pass
+
+    def run(self, cmd: Command) -> None:
+        image = np.zeros((2, 2, 3), dtype=np.uint8)
+        cmd.save_img("sample/img/out.png", image)
+
+    def finalize(self, cmd: Command) -> None:
+        pass
+
+
+class Factory:
+    def __init__(self, macro_cls: type[MacroBase] = SavingMacro) -> None:
+        self.macro_cls = macro_cls
+
+    def create(self) -> MacroBase:
+        return self.macro_cls()
+
+
+class Registry:
+    def __init__(self, definition: MacroDefinition) -> None:
+        self.definition = definition
+
+    def resolve(self, name_or_id: str) -> MacroDefinition:
+        return self.definition
+
+    def get_settings(self, definition: MacroDefinition) -> dict:
+        return {}
+
+
+def make_definition(
+    tmp_path: Path,
+    *,
+    macro_id: str = "sample",
+    class_name: str = "SavingMacro",
+    factory: Factory | None = None,
+) -> MacroDefinition:
+    macro_root = tmp_path / "macros" / macro_id
+    macro_root.mkdir(parents=True)
+    return MacroDefinition(
+        id=macro_id,
+        aliases=(macro_id,),
+        display_name="Sample",
+        class_name=class_name,
+        module_name=f"macros.{macro_id}.macro",
+        macro_root=macro_root,
+        source_path=macro_root / "macro.py",
+        settings_path=None,
+        description="",
+        tags=(),
+        factory=factory or Factory(),
+    )
+
+
+def make_builder(tmp_path: Path, definition: MacroDefinition) -> MacroRuntimeBuilder:
+    builder = MacroRuntimeBuilder(
+        project_root=tmp_path,
+        registry=Registry(definition),
+        controller_factory=lambda _request, _definition: FakeControllerOutputPort(),
+        frame_source_factory=lambda _request, _definition: FakeFrameSourcePort(),
+        resource_store_factory=lambda _request, macro_definition: LocalResourceStore(
+            MacroResourceScope.from_definition(macro_definition, tmp_path)
+        ),
+        artifact_store_factory=lambda _request, _definition, run_id: LocalRunArtifactStore(
+            tmp_path / "runs" / run_id / "outputs",
+            macro_id="sample",
+            run_id=run_id,
+        ),
+        notification_factory=lambda _request, _definition: FakeNotificationPort(),
+        logger_factory=lambda _request, _definition: FakeLoggerPort(),
+    )
+    return builder
+
+
+def test_runtime_saves_command_images_to_run_outputs(tmp_path: Path) -> None:
+    builder = make_builder(tmp_path, make_definition(tmp_path))
+
+    result = builder.run(RuntimeBuildRequest(macro_id="sample", entrypoint="test"))
+
+    assert result.status is RunStatus.SUCCESS
+    assert (tmp_path / "runs" / result.run_id / "outputs" / "sample" / "img" / "out.png").exists()
+
+
+def test_sample_turbo_macro_saves_capture_to_run_outputs_without_prefix_stripping(
+    tmp_path: Path,
+) -> None:
+    definition = make_definition(
+        tmp_path,
+        macro_id="sample_turbo_a_macro",
+        class_name="SampleTurboAMacro",
+        factory=Factory(SampleTurboAMacro),
+    )
+    builder = make_builder(tmp_path, definition)
+
+    result = builder.run(
+        RuntimeBuildRequest(
+            macro_id="sample_turbo_a_macro",
+            entrypoint="test",
+            exec_args={
+                "count": 1,
+                "press_dur": 0,
+                "wait_dur": 0,
+                "capture_after": True,
+                "capture_name": "sample_turbo_a_macro/img/result.png",
+            },
+        )
+    )
+
+    assert result.status is RunStatus.SUCCESS
+    assert (
+        tmp_path
+        / "runs"
+        / result.run_id
+        / "outputs"
+        / "sample_turbo_a_macro"
+        / "img"
+        / "result.png"
+    ).exists()

--- a/tests/unit/cli/test_main.py
+++ b/tests/unit/cli/test_main.py
@@ -152,12 +152,10 @@ def test_create_protocol_unknown():
 
 
 def test_create_runtime_builder_uses_active_devices(monkeypatch, tmp_path):
-    mock_resource_io = MagicMock()
     mock_registry = MagicMock()
     registry = MagicMock()
     mock_registry.return_value = registry
     mock_builder = MagicMock()
-    monkeypatch.setattr("nyxpy.cli.run_cli.StaticResourceIO", lambda path: mock_resource_io)
     monkeypatch.setattr("nyxpy.cli.run_cli.MacroRegistry", mock_registry)
     monkeypatch.setattr(
         "nyxpy.cli.run_cli.serial_manager",
@@ -175,7 +173,7 @@ def test_create_runtime_builder_uses_active_devices(monkeypatch, tmp_path):
 
     create_runtime_builder(MagicMock(), resources_dir=tmp_path)
 
-    mock_registry.assert_called_once()
+    mock_registry.assert_called_once_with(project_root=tmp_path)
     registry.reload.assert_called_once()
     mock_builder.assert_called_once()
 

--- a/tests/unit/framework/io/test_resource_file_io.py
+++ b/tests/unit/framework/io/test_resource_file_io.py
@@ -1,0 +1,216 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import cv2
+import numpy as np
+import pytest
+
+from nyxpy.framework.core.io.resources import (
+    DefaultResourcePathGuard,
+    LocalResourceStore,
+    LocalRunArtifactStore,
+    MacroResourceScope,
+    OverwritePolicy,
+    ResourceAlreadyExistsError,
+    ResourceConfigurationError,
+    ResourceNotFoundError,
+    ResourcePathError,
+    ResourceReadError,
+    ResourceSource,
+    ResourceWriteError,
+)
+from nyxpy.framework.core.macro.registry import MacroDefinition
+
+
+class Factory:
+    def create(self):
+        raise NotImplementedError
+
+
+def make_definition(tmp_path: Path, macro_id: str = "sample") -> MacroDefinition:
+    macro_root = tmp_path / "macros" / macro_id
+    macro_root.mkdir(parents=True)
+    return MacroDefinition(
+        id=macro_id,
+        aliases=(macro_id,),
+        display_name="Sample",
+        class_name="SampleMacro",
+        module_name=f"macros.{macro_id}.macro",
+        macro_root=macro_root,
+        source_path=macro_root / "macro.py",
+        settings_path=None,
+        description="",
+        tags=(),
+        factory=Factory(),
+    )
+
+
+def write_image(path: Path) -> np.ndarray:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    image = np.full((4, 4, 3), 127, dtype=np.uint8)
+    assert cv2.imwrite(str(path), image)
+    return image
+
+
+def test_macro_resource_scope_from_definition(tmp_path: Path) -> None:
+    definition = make_definition(tmp_path, "sample")
+
+    scope = MacroResourceScope.from_definition(definition, tmp_path)
+
+    assert scope.macro_id == "sample"
+    assert scope.assets_roots == (
+        tmp_path.resolve() / "resources" / "sample" / "assets",
+        definition.macro_root.resolve() / "assets",
+    )
+
+
+@pytest.mark.parametrize(
+    "name", ["..\\escape.png", "nested/../escape.png", "C:\\x.png", "/x.png", "CON"]
+)
+def test_resource_path_guard_rejects_unsafe_paths(tmp_path: Path, name: str) -> None:
+    guard = DefaultResourcePathGuard()
+
+    with pytest.raises(ResourcePathError):
+        guard.resolve_under_root(tmp_path, name)
+
+
+def test_resource_path_guard_rejects_symlink_escape(tmp_path: Path) -> None:
+    root = tmp_path / "root"
+    outside = tmp_path / "outside"
+    root.mkdir()
+    outside.mkdir()
+    outside_file = outside / "image.png"
+    outside_file.write_bytes(b"not an image")
+    link_path = root / "link.png"
+    try:
+        os.symlink(outside_file, link_path)
+    except OSError as exc:
+        pytest.skip(f"symlink creation is not available: {exc}")
+
+    with pytest.raises(ResourcePathError):
+        DefaultResourcePathGuard().resolve_under_root(root, "link.png")
+
+
+def test_local_resource_store_prefers_standard_assets(tmp_path: Path) -> None:
+    definition = make_definition(tmp_path, "sample")
+    scope = MacroResourceScope.from_definition(definition, tmp_path)
+    standard = tmp_path / "resources" / "sample" / "assets" / "icon.png"
+    package = definition.macro_root / "assets" / "icon.png"
+    write_image(standard)
+    write_image(package)
+
+    ref = LocalResourceStore(scope).resolve_asset_path("icon.png")
+
+    assert ref.source is ResourceSource.STANDARD_ASSETS
+    assert ref.path == standard.resolve()
+
+
+def test_local_resource_store_falls_back_to_macro_package_assets(tmp_path: Path) -> None:
+    definition = make_definition(tmp_path, "sample")
+    scope = MacroResourceScope.from_definition(definition, tmp_path)
+    package = definition.macro_root / "assets" / "icon.png"
+    write_image(package)
+
+    ref = LocalResourceStore(scope).resolve_asset_path("icon.png")
+
+    assert ref.source is ResourceSource.MACRO_PACKAGE
+    assert ref.path == package.resolve()
+
+
+def test_local_resource_store_reports_missing_and_corrupt_images(tmp_path: Path) -> None:
+    definition = make_definition(tmp_path, "sample")
+    scope = MacroResourceScope.from_definition(definition, tmp_path)
+    store = LocalResourceStore(scope)
+
+    with pytest.raises(ResourceNotFoundError):
+        store.resolve_asset_path("missing.png")
+
+    corrupt = tmp_path / "resources" / "sample" / "assets" / "corrupt.png"
+    corrupt.parent.mkdir(parents=True)
+    corrupt.write_text("not an image")
+    with pytest.raises(ResourceReadError):
+        store.load_image("corrupt.png")
+
+
+def test_local_run_artifact_store_saves_outputs_without_stripping_macro_prefix(
+    tmp_path: Path,
+) -> None:
+    store = LocalRunArtifactStore(
+        tmp_path / "runs" / "run-1" / "outputs", macro_id="sample", run_id="run-1"
+    )
+    image = np.zeros((2, 2, 3), dtype=np.uint8)
+
+    ref = store.save_image("sample/img/out.png", image)
+
+    assert ref.relative_path == Path("sample") / "img" / "out.png"
+    assert ref.path.exists()
+    assert (
+        ref.path
+        == (tmp_path / "runs" / "run-1" / "outputs" / "sample" / "img" / "out.png").resolve()
+    )
+
+
+def test_local_run_artifact_store_reports_imwrite_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store = LocalRunArtifactStore(tmp_path / "outputs", macro_id="sample", run_id="run-1")
+    image = np.zeros((2, 2, 3), dtype=np.uint8)
+    monkeypatch.setattr(cv2, "imwrite", lambda *_args, **_kwargs: False)
+
+    with pytest.raises(ResourceWriteError):
+        store.save_image("out.png", image)
+
+
+def test_local_run_artifact_store_overwrite_policies(tmp_path: Path) -> None:
+    store = LocalRunArtifactStore(tmp_path / "outputs", macro_id="sample", run_id="run-1")
+    image = np.zeros((2, 2, 3), dtype=np.uint8)
+    store.save_image("out.png", image)
+
+    with pytest.raises(ResourceAlreadyExistsError):
+        store.save_image("out.png", image, overwrite=OverwritePolicy.ERROR)
+
+    ref = store.save_image("out.png", image, overwrite=OverwritePolicy.UNIQUE)
+
+    assert ref.relative_path == Path("out_1.png")
+    assert ref.path.exists()
+
+
+def test_local_run_artifact_store_open_output_atomic(tmp_path: Path) -> None:
+    store = LocalRunArtifactStore(tmp_path / "outputs", macro_id="sample", run_id="run-1")
+
+    with store.open_output("data.bin", mode="wb", atomic=True) as file:
+        file.write(b"payload")
+
+    assert (tmp_path / "outputs" / "data.bin").read_bytes() == b"payload"
+    assert not list((tmp_path / "outputs").glob(".data.*"))
+
+    with pytest.raises(ResourceAlreadyExistsError):
+        store.open_output("data.bin", mode="xb", atomic=True)
+
+
+def test_local_run_artifact_store_rejects_text_and_atomic_append(tmp_path: Path) -> None:
+    store = LocalRunArtifactStore(tmp_path / "outputs", macro_id="sample", run_id="run-1")
+
+    with pytest.raises(ResourceConfigurationError):
+        store.open_output("data.txt", mode="w")
+    with pytest.raises(ResourceConfigurationError):
+        store.open_output("data.bin", mode="ab", atomic=True)
+
+
+def test_local_run_artifact_store_open_output_replace_non_atomic(tmp_path: Path) -> None:
+    store = LocalRunArtifactStore(tmp_path / "outputs", macro_id="sample", run_id="run-1")
+    output = tmp_path / "outputs" / "data.bin"
+    output.parent.mkdir()
+    output.write_bytes(b"old")
+
+    with store.open_output(
+        "data.bin",
+        mode="xb",
+        overwrite=OverwritePolicy.REPLACE,
+        atomic=False,
+    ) as file:
+        file.write(b"new")
+
+    assert output.read_bytes() == b"new"

--- a/tests/unit/framework/runtime/test_execution_context.py
+++ b/tests/unit/framework/runtime/test_execution_context.py
@@ -72,7 +72,7 @@ def test_exec_args_override_file_settings(tmp_path) -> None:
         controller_factory=lambda _request, _definition: FakeControllerOutputPort(),
         frame_source_factory=lambda _request, _definition: FakeFrameSourcePort(),
         resource_store_factory=lambda _request, _definition: base_context.resources,
-        artifact_store_factory=lambda _request, _definition: base_context.artifacts,
+        artifact_store_factory=lambda _request, _definition, _run_id: base_context.artifacts,
         notification_factory=lambda _request, _definition: FakeNotificationPort(),
         logger_factory=lambda _request, _definition: FakeLoggerPort(),
     )


### PR DESCRIPTION
## Summary

Phase 6.1 として Resource File I/O を再設計し、Runtime のリソース読み込みと成果物出力を `resources\<macro_id>\assets` / `runs\<run_id>\outputs` へ移行しました。

## Related

- spec\framework\rearchitecture\IMPLEMENTATION_PLAN.md
- spec\framework\rearchitecture\RESOURCE_FILE_IO.md

## Changes

- `LocalResourceStore` / `LocalRunArtifactStore` と `MacroResourceScope.from_definition()` を追加し、asset lookup と run output 保存を具象化
- path traversal、Windows drive / UNC、symlink escape、予約名を拒否する path guard と、OpenCV 読み書き失敗の ResourceError 変換を追加
- `save_image()` の atomic write、`open_output()`、overwrite policy を実装
- Runtime builder / CLI / GUI から `StaticResourceIO` bridge 依存を削除し、run ごとの outputs store を生成
- `DefaultCommand.artifacts` を追加し、代表マクロの `cmd.save_img()` が prefix を除去せず run outputs へ保存されることをテスト

## Commit Log

```
489fca2 feat(framework): Resource File I/Oをruns出力へ移行
```

## Testing

```
uv run pytest tests\unit\ tests\integration\
uv run ruff check .
```

## Checklist

- [x] lint / format チェック通過
- [x] 既存テスト通過
- [x] コミット prefix (feat/fix 等) が変更の動機と一致している
- [x] 新規・変更コードに対するテスト追加（該当する場合）
- [x] 型チェック通過（Python 型チェッカー設定なし。ruff と pytest で検証）