### PR TITLE
feat(framework): I/OアダプターをPort層へ分離

### DIFF
--- a/src/nyxpy/framework/core/io/__init__.py
+++ b/src/nyxpy/framework/core/io/__init__.py
@@ -1,3 +1,8 @@
+from nyxpy.framework.core.io.adapters import (
+    CaptureFrameSourcePort,
+    NotificationHandlerPort,
+    SerialControllerOutputPort,
+)
 from nyxpy.framework.core.io.ports import (
     ControllerOutputPort,
     FrameNotReadyError,
@@ -28,6 +33,7 @@ from nyxpy.framework.core.io.resources import (
 
 __all__ = [
     "ControllerOutputPort",
+    "CaptureFrameSourcePort",
     "DefaultResourcePathGuard",
     "FrameNotReadyError",
     "LocalResourceStore",
@@ -35,6 +41,7 @@ __all__ = [
     "FrameSourcePort",
     "MacroResourceScope",
     "NotificationPort",
+    "NotificationHandlerPort",
     "OverwritePolicy",
     "ResourceAlreadyExistsError",
     "ResourceConfigurationError",
@@ -48,6 +55,7 @@ __all__ = [
     "ResourceStorePort",
     "ResourceWriteError",
     "RunArtifactStore",
+    "SerialControllerOutputPort",
     "SleepControlCapability",
     "TouchInputCapability",
 ]

--- a/src/nyxpy/framework/core/io/adapters.py
+++ b/src/nyxpy/framework/core/io/adapters.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+import time
+
+import cv2
+
+from nyxpy.framework.core.constants import KeyboardOp, KeyCode, KeyType, SpecialKeyCode
+from nyxpy.framework.core.hardware.protocol import SerialProtocolInterface
+from nyxpy.framework.core.io.ports import (
+    ControllerOutputPort,
+    FrameNotReadyError,
+    FrameSourcePort,
+    NotificationPort,
+)
+from nyxpy.framework.core.utils.helper import validate_keyboard_text
+
+
+class SerialControllerOutputPort(ControllerOutputPort):
+    def __init__(self, serial_device, protocol: SerialProtocolInterface) -> None:
+        self.serial_device = serial_device
+        self.protocol = protocol
+
+    def press(self, keys: tuple[KeyType, ...]) -> None:
+        self.serial_device.send(self.protocol.build_press_command(keys))
+
+    def hold(self, keys: tuple[KeyType, ...]) -> None:
+        self.serial_device.send(self.protocol.build_hold_command(keys))
+
+    def release(self, keys: tuple[KeyType, ...] = ()) -> None:
+        self.serial_device.send(self.protocol.build_release_command(keys))
+
+    def keyboard(self, text: str) -> None:
+        text = validate_keyboard_text(text)
+        try:
+            self.serial_device.send(self.protocol.build_keyboard_command(text))
+        except (ValueError, NotImplementedError):
+            for char in text:
+                self.type_key(KeyCode(char))
+        try:
+            self.serial_device.send(
+                self.protocol.build_keytype_command(KeyCode(""), KeyboardOp.ALL_RELEASE)
+            )
+        except NotImplementedError:
+            pass
+
+    def type_key(self, key: KeyCode | SpecialKeyCode) -> None:
+        match key:
+            case KeyCode():
+                press_op = KeyboardOp.PRESS
+                release_op = KeyboardOp.RELEASE
+            case SpecialKeyCode():
+                press_op = KeyboardOp.SPECIAL_PRESS
+                release_op = KeyboardOp.SPECIAL_RELEASE
+            case _:
+                raise ValueError(f"Invalid key type: {type(key)}")
+        self.serial_device.send(self.protocol.build_keytype_command(key, press_op))
+        self.serial_device.send(self.protocol.build_keytype_command(key, release_op))
+
+    def close(self) -> None:
+        pass
+
+
+class CaptureFrameSourcePort(FrameSourcePort):
+    def __init__(self, capture_device) -> None:
+        self.capture_device = capture_device
+
+    def initialize(self) -> None:
+        initialize = getattr(self.capture_device, "initialize", None)
+        if initialize is not None:
+            initialize()
+
+    def await_ready(self, timeout: float) -> bool:
+        if timeout is None or timeout < 0:
+            raise ValueError("timeout must be greater than or equal to 0")
+        deadline = time.monotonic() + timeout
+        while True:
+            try:
+                if self.capture_device.get_frame() is not None:
+                    return True
+            except RuntimeError:
+                pass
+            if time.monotonic() >= deadline:
+                return False
+            time.sleep(0.01)
+
+    def latest_frame(self) -> cv2.typing.MatLike:
+        try:
+            frame = self.capture_device.get_frame()
+        except RuntimeError as exc:
+            raise FrameNotReadyError() from exc
+        if frame is None:
+            raise FrameNotReadyError()
+        return frame.copy()
+
+    def close(self) -> None:
+        pass
+
+
+class NotificationHandlerPort(NotificationPort):
+    def __init__(self, notification_handler) -> None:
+        self.notification_handler = notification_handler
+
+    def publish(self, text: str, img: cv2.typing.MatLike | None = None) -> None:
+        if self.notification_handler is not None:
+            self.notification_handler.publish(text, img)

--- a/src/nyxpy/framework/core/runtime/builder.py
+++ b/src/nyxpy/framework/core/runtime/builder.py
@@ -1,18 +1,18 @@
 from __future__ import annotations
 
-import time
 from collections.abc import Callable
 from datetime import datetime
 from pathlib import Path
 from uuid import uuid4
 
-import cv2
-
-from nyxpy.framework.core.constants import KeyboardOp, KeyCode, KeyType, SpecialKeyCode
 from nyxpy.framework.core.hardware.protocol import SerialProtocolInterface
+from nyxpy.framework.core.io.adapters import (
+    CaptureFrameSourcePort,
+    NotificationHandlerPort,
+    SerialControllerOutputPort,
+)
 from nyxpy.framework.core.io.ports import (
     ControllerOutputPort,
-    FrameNotReadyError,
     FrameSourcePort,
     NotificationPort,
 )
@@ -38,7 +38,6 @@ from nyxpy.framework.core.runtime.handle import RunHandle
 from nyxpy.framework.core.runtime.result import RunResult
 from nyxpy.framework.core.runtime.runtime import MacroRuntime
 from nyxpy.framework.core.utils.cancellation import CancellationToken
-from nyxpy.framework.core.utils.helper import validate_keyboard_text
 
 type PortFactory[T] = Callable[[RuntimeBuildRequest, MacroDefinition], T]
 type ArtifactStoreFactory = Callable[[RuntimeBuildRequest, MacroDefinition, str], RunArtifactStore]
@@ -124,15 +123,15 @@ def create_legacy_runtime_builder(
     notification_handler,
     logger: LoggerPort,
 ) -> MacroRuntimeBuilder:
-    """Phase 8 まで既存具象実装を Port 契約へ閉じ込める最小 adapter。"""
+    """既存具象実装を Port 契約へ接続する Runtime builder。"""
 
     return MacroRuntimeBuilder(
         project_root=project_root,
         registry=registry,
-        controller_factory=lambda _request, _definition: _LegacyControllerOutputPort(
+        controller_factory=lambda _request, _definition: SerialControllerOutputPort(
             serial_device, protocol
         ),
-        frame_source_factory=lambda _request, _definition: _LegacyFrameSourcePort(capture_device),
+        frame_source_factory=lambda _request, _definition: CaptureFrameSourcePort(capture_device),
         resource_store_factory=lambda _request, definition: LocalResourceStore(
             MacroResourceScope.from_definition(definition, project_root)
         ),
@@ -141,92 +140,8 @@ def create_legacy_runtime_builder(
             macro_id=definition.id,
             run_id=run_id,
         ),
-        notification_factory=lambda _request, _definition: _LegacyNotificationPort(
+        notification_factory=lambda _request, _definition: NotificationHandlerPort(
             notification_handler
         ),
         logger_factory=lambda _request, _definition: logger,
     )
-
-
-class _LegacyControllerOutputPort(ControllerOutputPort):
-    def __init__(self, serial_device, protocol: SerialProtocolInterface) -> None:
-        self.serial_device = serial_device
-        self.protocol = protocol
-
-    def press(self, keys: tuple[KeyType, ...]) -> None:
-        self.serial_device.send(self.protocol.build_press_command(keys))
-
-    def hold(self, keys: tuple[KeyType, ...]) -> None:
-        self.serial_device.send(self.protocol.build_hold_command(keys))
-
-    def release(self, keys: tuple[KeyType, ...] = ()) -> None:
-        self.serial_device.send(self.protocol.build_release_command(keys))
-
-    def keyboard(self, text: str) -> None:
-        text = validate_keyboard_text(text)
-        try:
-            self.serial_device.send(self.protocol.build_keyboard_command(text))
-        except (ValueError, NotImplementedError):
-            for char in text:
-                self.type_key(KeyCode(char))
-        try:
-            self.serial_device.send(
-                self.protocol.build_keytype_command(KeyCode(""), KeyboardOp.ALL_RELEASE)
-            )
-        except NotImplementedError:
-            pass
-
-    def type_key(self, key: KeyCode | SpecialKeyCode) -> None:
-        match key:
-            case KeyCode():
-                press_op = KeyboardOp.PRESS
-                release_op = KeyboardOp.RELEASE
-            case SpecialKeyCode():
-                press_op = KeyboardOp.SPECIAL_PRESS
-                release_op = KeyboardOp.SPECIAL_RELEASE
-            case _:
-                raise ValueError(f"Invalid key type: {type(key)}")
-        self.serial_device.send(self.protocol.build_keytype_command(key, press_op))
-        self.serial_device.send(self.protocol.build_keytype_command(key, release_op))
-
-    def close(self) -> None:
-        pass
-
-
-class _LegacyFrameSourcePort(FrameSourcePort):
-    def __init__(self, capture_device) -> None:
-        self.capture_device = capture_device
-
-    def initialize(self) -> None:
-        initialize = getattr(self.capture_device, "initialize", None)
-        if initialize is not None:
-            initialize()
-
-    def await_ready(self, timeout: float) -> bool:
-        if timeout is None or timeout < 0:
-            raise ValueError("timeout must be greater than or equal to 0")
-        deadline = time.monotonic() + timeout
-        while True:
-            if self.capture_device.get_frame() is not None:
-                return True
-            if time.monotonic() >= deadline:
-                return False
-            time.sleep(0.01)
-
-    def latest_frame(self) -> cv2.typing.MatLike:
-        frame = self.capture_device.get_frame()
-        if frame is None:
-            raise FrameNotReadyError()
-        return frame.copy()
-
-    def close(self) -> None:
-        pass
-
-
-class _LegacyNotificationPort(NotificationPort):
-    def __init__(self, notification_handler) -> None:
-        self.notification_handler = notification_handler
-
-    def publish(self, text: str, img: cv2.typing.MatLike | None = None) -> None:
-        if self.notification_handler is not None:
-            self.notification_handler.publish(text, img)

--- a/tests/unit/framework/io/test_adapters.py
+++ b/tests/unit/framework/io/test_adapters.py
@@ -1,0 +1,135 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from nyxpy.framework.core.constants import Button, KeyboardOp, KeyCode
+from nyxpy.framework.core.io.adapters import (
+    CaptureFrameSourcePort,
+    NotificationHandlerPort,
+    SerialControllerOutputPort,
+)
+from nyxpy.framework.core.io.ports import FrameNotReadyError
+
+
+class SerialDevice:
+    def __init__(self) -> None:
+        self.sent = []
+
+    def send(self, data) -> None:
+        self.sent.append(data)
+
+
+class Protocol:
+    def __init__(self, *, keyboard_supported: bool = True) -> None:
+        self.keyboard_supported = keyboard_supported
+
+    def build_press_command(self, keys):
+        return ("press", keys)
+
+    def build_hold_command(self, keys):
+        return ("hold", keys)
+
+    def build_release_command(self, keys):
+        return ("release", keys)
+
+    def build_keyboard_command(self, text):
+        if not self.keyboard_supported:
+            raise NotImplementedError
+        return ("keyboard", text)
+
+    def build_keytype_command(self, key, op):
+        return ("keytype", key, op)
+
+
+def test_controller_output_port_serializes_send_operations() -> None:
+    serial = SerialDevice()
+    port = SerialControllerOutputPort(serial, Protocol())
+
+    port.press((Button.A,))
+    port.hold((Button.B,))
+    port.release()
+    port.keyboard("AB")
+    port.type_key(KeyCode("C"))
+
+    assert serial.sent == [
+        ("press", (Button.A,)),
+        ("hold", (Button.B,)),
+        ("release", ()),
+        ("keyboard", "AB"),
+        ("keytype", KeyCode(""), KeyboardOp.ALL_RELEASE),
+        ("keytype", KeyCode("C"), KeyboardOp.PRESS),
+        ("keytype", KeyCode("C"), KeyboardOp.RELEASE),
+    ]
+
+
+def test_controller_output_port_keyboard_fallback_types_each_char() -> None:
+    serial = SerialDevice()
+    port = SerialControllerOutputPort(serial, Protocol(keyboard_supported=False))
+
+    port.keyboard("AB")
+
+    assert serial.sent == [
+        ("keytype", KeyCode("A"), KeyboardOp.PRESS),
+        ("keytype", KeyCode("A"), KeyboardOp.RELEASE),
+        ("keytype", KeyCode("B"), KeyboardOp.PRESS),
+        ("keytype", KeyCode("B"), KeyboardOp.RELEASE),
+        ("keytype", KeyCode(""), KeyboardOp.ALL_RELEASE),
+    ]
+
+
+class CaptureDevice:
+    def __init__(self, frames) -> None:
+        self.frames = list(frames)
+        self.initialized = False
+
+    def initialize(self) -> None:
+        self.initialized = True
+
+    def get_frame(self):
+        if not self.frames:
+            raise RuntimeError("not ready")
+        return self.frames.pop(0)
+
+
+def test_frame_source_await_ready_success_after_first_frame() -> None:
+    frame = np.ones((2, 2, 3), dtype=np.uint8)
+    device = CaptureDevice([None, frame])
+    port = CaptureFrameSourcePort(device)
+
+    port.initialize()
+
+    assert device.initialized is True
+    assert port.await_ready(0.1) is True
+
+
+def test_frame_source_await_ready_timeout() -> None:
+    port = CaptureFrameSourcePort(CaptureDevice([]))
+
+    assert port.await_ready(0.01) is False
+
+
+def test_frame_source_latest_frame_returns_copy_and_reports_not_ready() -> None:
+    frame = np.ones((2, 2, 3), dtype=np.uint8)
+    port = CaptureFrameSourcePort(CaptureDevice([frame]))
+
+    latest = port.latest_frame()
+    latest[0, 0, 0] = 0
+
+    assert frame[0, 0, 0] == 1
+
+    with pytest.raises(FrameNotReadyError):
+        port.latest_frame()
+
+
+def test_notification_port_forwards_to_handler() -> None:
+    calls = []
+
+    class Handler:
+        def publish(self, text, img=None) -> None:
+            calls.append((text, img))
+
+    image = np.zeros((1, 1, 3), dtype=np.uint8)
+    NotificationHandlerPort(Handler()).publish("hello", image)
+
+    assert calls == [("hello", image)]


### PR DESCRIPTION
## Summary

Phase 8 として serial / capture / notification の具象 adapter を `runtime.builder` から `io.adapters` へ分離し、Runtime builder を Port composition に集中させました。

## Related

- spec\framework\rearchitecture\IMPLEMENTATION_PLAN.md
- spec\framework\rearchitecture\RUNTIME_AND_IO_PORTS.md

## Changes

- `SerialControllerOutputPort`、`CaptureFrameSourcePort`、`NotificationHandlerPort` を `src\nyxpy\framework\core\io\adapters.py` に追加
- `runtime.builder` から private `_Legacy*Port` 実装を削除し、I/O adapter クラスを組み立てる形へ変更
- `nyxpy.framework.core.io` から adapter を公開
- controller serialization、keyboard fallback、frame readiness / timeout / copy、notification forwarding の adapter 単体テストを追加

## Commit Log

```
85bb531 feat(framework): I/OアダプターをPort層へ分離
```

## Testing

```
uv run pytest tests\unit\ tests\integration\
uv run pytest tests\gui\test_log_pane_user_event.py tests\gui\test_main_window.py -q
uv run pytest tests\perf\test_logging_framework_perf.py -q
uv run ruff check .
```

## Checklist

- [x] lint / format チェック通過
- [x] 既存テスト通過
- [x] コミット prefix (feat/fix 等) が変更の動機と一致している
- [x] 新規・変更コードに対するテスト追加（該当する場合）
- [x] 型チェック通過（Python 型チェッカー設定なし。ruff と pytest で検証）