### PR TITLE
feat(cli): RunResultベースの終了コードへ移行

### DIFF
--- a/src/nyxpy/cli/run_cli.py
+++ b/src/nyxpy/cli/run_cli.py
@@ -1,5 +1,7 @@
 import argparse
 import pathlib
+import time
+from dataclasses import dataclass
 from typing import Any
 
 from nyxpy.framework.core.api.notification_handler import (
@@ -12,9 +14,33 @@ from nyxpy.framework.core.macro.registry import MacroRegistry
 from nyxpy.framework.core.runtime.builder import MacroRuntimeBuilder, create_legacy_runtime_builder
 from nyxpy.framework.core.runtime.context import RuntimeBuildRequest
 from nyxpy.framework.core.runtime.result import RunResult, RunStatus
-from nyxpy.framework.core.settings.global_settings import GlobalSettings
+from nyxpy.framework.core.settings.secrets_settings import SecretsSettings
 from nyxpy.framework.core.singletons import capture_manager, serial_manager
 from nyxpy.framework.core.utils.helper import parse_define_args
+
+
+@dataclass(frozen=True)
+class UserMessage:
+    level: str
+    text: str
+    code: str | None = None
+
+
+class CliPresenter:
+    def render_result(self, result: RunResult) -> UserMessage:
+        if result.status is RunStatus.SUCCESS:
+            return UserMessage("INFO", "Macro execution completed")
+        if result.status is RunStatus.CANCELLED:
+            return UserMessage("WARNING", "Macro execution was interrupted")
+        message = result.error.message if result.error is not None else "Macro execution failed"
+        return UserMessage("ERROR", message)
+
+    def exit_code(self, result: RunResult) -> int:
+        if result.status is RunStatus.SUCCESS:
+            return 0
+        if result.status is RunStatus.CANCELLED:
+            return 130
+        return 2
 
 
 def configure_logging(silence: bool = False, verbose: bool = False) -> LoggingComponents:
@@ -57,6 +83,11 @@ def create_runtime_builder(
     protocol: SerialProtocolInterface,
     logger: LoggerPort,
     resources_dir: pathlib.Path | None = None,
+    *,
+    serial_name: str | None = None,
+    capture_name: str | None = None,
+    baudrate: int | None = None,
+    detection_timeout_sec: float = 2.0,
 ) -> MacroRuntimeBuilder:
     """
     指定されたコンポーネントでCommandインスタンスを作成します。
@@ -65,6 +96,9 @@ def create_runtime_builder(
         protocol: 使用するプロトコル実装
         logger: Runtime に注入する logger
         resources_dir: 旧互換引数。指定時はプロジェクトルートとして扱います。
+        serial_name: 使用するシリアルデバイス名
+        capture_name: 使用するキャプチャデバイス名
+        baudrate: シリアルボーレート
 
     Returns:
         設定済みの Runtime builder
@@ -72,10 +106,16 @@ def create_runtime_builder(
     project_root = pathlib.Path.cwd() if resources_dir is None else resources_dir
     registry = MacroRegistry(project_root=project_root)
     registry.reload()
+    if serial_name is not None:
+        _select_serial_device(serial_name, baudrate, detection_timeout_sec)
+    if capture_name is not None:
+        _select_capture_device(capture_name, detection_timeout_sec)
     serial_device = serial_manager.get_active_device()
     capture_device = capture_manager.get_active_device()
-    global_settings = GlobalSettings()
-    notification_handler = create_notification_handler_from_settings(global_settings, logger=logger)
+    secrets_settings = SecretsSettings()
+    notification_handler = create_notification_handler_from_settings(
+        secrets_settings, logger=logger
+    )
     return create_legacy_runtime_builder(
         project_root=project_root,
         registry=registry,
@@ -85,6 +125,40 @@ def create_runtime_builder(
         notification_handler=notification_handler,
         logger=logger,
     )
+
+
+def _select_serial_device(name: str, baudrate: int | None, timeout_sec: float) -> None:
+    serial_manager.auto_register_devices()
+    available_devices = _wait_for_device(serial_manager, name, timeout_sec)
+    if name not in available_devices:
+        available_devices_str = ", ".join(available_devices)
+        raise ValueError(
+            f"Serial port '{name}' not found. Available devices: {available_devices_str}"
+        )
+    serial_manager.set_active(name, baudrate or 9600)
+
+
+def _select_capture_device(name: str, timeout_sec: float) -> None:
+    capture_manager.auto_register_devices()
+    available_devices = _wait_for_device(capture_manager, name, timeout_sec)
+    print(f"Available capture devices: {available_devices}")
+    if name not in available_devices:
+        available_devices_str = ", ".join(available_devices)
+        raise ValueError(
+            f"Capture device '{name}' not found. Available devices: {available_devices_str}"
+        )
+    capture_manager.set_active(name)
+
+
+def _wait_for_device(manager, desired_name: str, timeout_sec: float) -> list[str]:
+    deadline = time.monotonic() + timeout_sec
+    while True:
+        devices = list(manager.list_devices())
+        if desired_name in devices:
+            return devices
+        if time.monotonic() >= deadline:
+            return devices
+        time.sleep(0.05)
 
 
 def execute_macro(
@@ -118,7 +192,7 @@ def execute_macro(
     if not result.ok:
         message = result.error.message if result.error is not None else "Macro execution failed"
         logger.user("ERROR", message, component="CLI", event="macro.failed")
-        raise RuntimeError(message)
+        return result
     logger.user("INFO", "Macro execution completed", component="CLI", event="macro.finished")
     return result
 
@@ -139,49 +213,34 @@ def cli_main(args: argparse.Namespace) -> int:
         logging = configure_logging(silence=args.silence, verbose=args.verbose)
         logger = logging.logger
 
-        # シングルトンの初期化
         capture_manager.set_logger(logger)
-        serial_manager.auto_register_devices()
-        capture_manager.auto_register_devices()
-
-        available_serial_devices = serial_manager.list_devices()
-        if not available_serial_devices:
-            raise ValueError("No serial devices detected")
-        if args.serial not in available_serial_devices:
-            available_devices_str = ", ".join(available_serial_devices)
-            raise ValueError(
-                f"Serial port '{args.serial}' not found. Available devices: {available_devices_str}"
-            )
         baudrate = ProtocolFactory.resolve_baudrate(args.protocol, getattr(args, "baud", None))
-        serial_manager.set_active(args.serial, baudrate)
-
-        available_capture_devices = capture_manager.list_devices()
-        print(f"Available capture devices: {available_capture_devices}")
-        if not available_capture_devices:
-            raise ValueError("No capture devices detected")
-        if args.capture not in available_capture_devices:
-            available_devices_str = ", ".join(available_capture_devices)
-            raise ValueError(
-                f"Capture device '{args.capture}' not found. "
-                f"Available devices: {available_devices_str}"
-            )
-        capture_manager.set_active(args.capture)
 
         protocol = create_protocol(args.protocol)
-        runtime_builder = create_runtime_builder(protocol=protocol, logger=logger)
+        runtime_builder = create_runtime_builder(
+            protocol=protocol,
+            logger=logger,
+            serial_name=args.serial,
+            capture_name=args.capture,
+            baudrate=baudrate,
+        )
 
         # マクロ実行引数の解析
         exec_args = parse_define_args(args.define)
 
         # マクロの実行
-        execute_macro(
+        result = execute_macro(
             runtime_builder=runtime_builder,
             macro_name=args.macro_name,
             exec_args=exec_args,
             logger=logger,
         )
 
-        return 0  # 成功時の終了コード
+        presenter = CliPresenter()
+        user_message = presenter.render_result(result)
+        if user_message.level != "INFO":
+            print(user_message.text)
+        return presenter.exit_code(result)
 
     except ValueError as ve:
         if "logger" in locals():
@@ -215,13 +274,10 @@ def cli_main(args: argparse.Namespace) -> int:
             pass
 
 
-def main():
+def build_parser() -> argparse.ArgumentParser:
     """
-    CLIのメインエントリーポイント
-    コマンドライン引数を解析してcli_mainを呼び出します
+    CLIの引数パーサーを構築します。
     """
-    import argparse
-
     parser = argparse.ArgumentParser(description="NyX CLI - Nintendo Switch Automation Tool")
     parser.add_argument("macro_name", help="実行するマクロ名")
     parser.add_argument("--serial", required=True, help="シリアルデバイス名")
@@ -235,6 +291,15 @@ def main():
         action="append",
         help="マクロ実行時の変数定義 (key=value形式)",
     )
+    return parser
+
+
+def main():
+    """
+    CLIのメインエントリーポイント
+    コマンドライン引数を解析してcli_mainを呼び出します
+    """
+    parser = build_parser()
 
     args = parser.parse_args()
     exit_code = cli_main(args)

--- a/tests/integration/test_cli_runtime_adapter.py
+++ b/tests/integration/test_cli_runtime_adapter.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+from datetime import datetime
+from unittest.mock import MagicMock
+
+from nyxpy.cli import run_cli
+from nyxpy.framework.core.runtime.result import RunResult, RunStatus
+
+
+class Logger:
+    def bind_context(self, context):
+        return self
+
+    def user(self, level, message, *, component, event, code=None, extra=None):
+        pass
+
+    def technical(self, level, message, *, component, event="log.message", extra=None, exc=None):
+        pass
+
+
+def run_result(status: RunStatus = RunStatus.SUCCESS) -> RunResult:
+    now = datetime.now()
+    return RunResult(
+        run_id="run-1",
+        macro_id="sample",
+        macro_name="Sample",
+        status=status,
+        started_at=now,
+        finished_at=now,
+    )
+
+
+def test_cli_uses_runtime_and_run_result() -> None:
+    builder = MagicMock(run=MagicMock(return_value=run_result(RunStatus.CANCELLED)))
+
+    result = run_cli.execute_macro(builder, "sample", {"count": 1}, Logger())
+
+    assert result.status is RunStatus.CANCELLED
+    request = builder.run.call_args.args[0]
+    assert request.macro_id == "sample"
+    assert request.entrypoint == "cli"
+    assert request.exec_args == {"count": 1}
+
+
+def test_cli_notification_settings_source_is_secrets_store(monkeypatch, tmp_path) -> None:
+    sentinel_secrets = object()
+    captured = {}
+
+    monkeypatch.setattr("nyxpy.cli.run_cli.SecretsSettings", lambda: sentinel_secrets)
+    monkeypatch.setattr(
+        "nyxpy.cli.run_cli.MacroRegistry", lambda project_root: MagicMock(reload=lambda: None)
+    )
+    monkeypatch.setattr(
+        "nyxpy.cli.run_cli.serial_manager",
+        MagicMock(get_active_device=lambda: "serial"),
+    )
+    monkeypatch.setattr(
+        "nyxpy.cli.run_cli.capture_manager",
+        MagicMock(get_active_device=lambda: "capture"),
+    )
+
+    def create_notification_handler(settings, *, logger):
+        captured["settings"] = settings
+        captured["logger"] = logger
+        return "notification-port"
+
+    monkeypatch.setattr(
+        "nyxpy.cli.run_cli.create_notification_handler_from_settings",
+        create_notification_handler,
+    )
+    legacy_builder = MagicMock()
+    monkeypatch.setattr("nyxpy.cli.run_cli.create_legacy_runtime_builder", legacy_builder)
+    logger = Logger()
+
+    run_cli.create_runtime_builder(MagicMock(), logger=logger, resources_dir=tmp_path)
+
+    assert captured == {"settings": sentinel_secrets, "logger": logger}
+    assert legacy_builder.call_args.kwargs["notification_handler"] == "notification-port"

--- a/tests/unit/cli/test_main.py
+++ b/tests/unit/cli/test_main.py
@@ -4,6 +4,8 @@ from unittest.mock import MagicMock
 import pytest
 
 from nyxpy.cli.run_cli import (
+    CliPresenter,
+    build_parser,
     cli_main,
     configure_logging,
     create_protocol,
@@ -230,8 +232,25 @@ def test_execute_macro_cancelled(monkeypatch, mock_log_manager):
 def test_execute_macro_failed(monkeypatch, mock_log_manager):
     builder = MagicMock(run=MagicMock(return_value=result(RunStatus.FAILED, "boom")))
 
-    with pytest.raises(RuntimeError, match="boom"):
-        execute_macro(builder, "Sample", {}, mock_log_manager.logger)
+    run_result = execute_macro(builder, "Sample", {}, mock_log_manager.logger)
+
+    assert run_result.status is RunStatus.FAILED
+    assert any(log[1] == "ERROR" for log in mock_log_manager.logger.logs)
+
+
+def test_cli_presenter_exit_codes() -> None:
+    presenter = CliPresenter()
+
+    assert presenter.exit_code(result(RunStatus.SUCCESS)) == 0
+    assert presenter.exit_code(result(RunStatus.CANCELLED)) == 130
+    assert presenter.exit_code(result(RunStatus.FAILED, "boom")) == 2
+
+
+def test_cli_does_not_accept_notification_secret_args() -> None:
+    options = {action.dest for action in build_parser()._actions}
+
+    assert "discord_webhook_url" not in options
+    assert "bluesky_password" not in options
 
 
 def make_args():
@@ -253,7 +272,8 @@ def test_cli_main_success(monkeypatch, mock_serial_manager, mock_capture_manager
     mock_configure = MagicMock(return_value=mock_logging)
     mock_protocol = MagicMock()
     mock_builder = MagicMock()
-    mock_execute = MagicMock()
+    mock_create_builder = MagicMock(return_value=mock_builder)
+    mock_execute = MagicMock(return_value=result(RunStatus.SUCCESS))
 
     monkeypatch.setattr("nyxpy.cli.run_cli.serial_manager", mock_serial_manager)
     monkeypatch.setattr("nyxpy.cli.run_cli.capture_manager", mock_capture_manager)
@@ -261,14 +281,20 @@ def test_cli_main_success(monkeypatch, mock_serial_manager, mock_capture_manager
     monkeypatch.setattr("nyxpy.cli.run_cli.create_protocol", lambda name: mock_protocol)
     monkeypatch.setattr(
         "nyxpy.cli.run_cli.create_runtime_builder",
-        lambda protocol, logger: mock_builder,
+        mock_create_builder,
     )
     monkeypatch.setattr("nyxpy.cli.run_cli.parse_define_args", lambda args: {})
     monkeypatch.setattr("nyxpy.cli.run_cli.execute_macro", mock_execute)
 
     assert cli_main(args) == 0
     mock_configure.assert_called_once()
-    assert mock_serial_manager.active_baudrate == 9600
+    mock_create_builder.assert_called_once_with(
+        protocol=mock_protocol,
+        logger=mock_logging.logger,
+        serial_name="COM1",
+        capture_name="Camera1",
+        baudrate=9600,
+    )
     mock_execute.assert_called_once_with(
         runtime_builder=mock_builder,
         macro_name="Sample",
@@ -289,14 +315,19 @@ def test_cli_main_uses_3ds_default_baudrate(monkeypatch, mock_serial_manager, mo
     )
     monkeypatch.setattr(
         "nyxpy.cli.run_cli.create_runtime_builder",
-        lambda protocol, logger: MagicMock(),
+        MagicMock(return_value=MagicMock()),
     )
     monkeypatch.setattr("nyxpy.cli.run_cli.parse_define_args", lambda args: {})
-    monkeypatch.setattr("nyxpy.cli.run_cli.execute_macro", MagicMock())
+    monkeypatch.setattr(
+        "nyxpy.cli.run_cli.execute_macro",
+        MagicMock(return_value=result(RunStatus.SUCCESS)),
+    )
 
     assert cli_main(args) == 0
-    assert mock_serial_manager.active_name == "COM1"
-    assert mock_serial_manager.active_baudrate == 115200
+    create_builder = __import__(
+        "nyxpy.cli.run_cli", fromlist=["create_runtime_builder"]
+    ).create_runtime_builder
+    assert create_builder.call_args.kwargs["baudrate"] == 115200
 
 
 def test_cli_main_baud_override(monkeypatch, mock_serial_manager, mock_capture_manager):
@@ -312,13 +343,19 @@ def test_cli_main_baud_override(monkeypatch, mock_serial_manager, mock_capture_m
     )
     monkeypatch.setattr(
         "nyxpy.cli.run_cli.create_runtime_builder",
-        lambda protocol, logger: MagicMock(),
+        MagicMock(return_value=MagicMock()),
     )
     monkeypatch.setattr("nyxpy.cli.run_cli.parse_define_args", lambda args: {})
-    monkeypatch.setattr("nyxpy.cli.run_cli.execute_macro", MagicMock())
+    monkeypatch.setattr(
+        "nyxpy.cli.run_cli.execute_macro",
+        MagicMock(return_value=result(RunStatus.SUCCESS)),
+    )
 
     assert cli_main(args) == 0
-    assert mock_serial_manager.active_baudrate == 9600
+    create_builder = __import__(
+        "nyxpy.cli.run_cli", fromlist=["create_runtime_builder"]
+    ).create_runtime_builder
+    assert create_builder.call_args.kwargs["baudrate"] == 9600
 
 
 def test_cli_main_value_error(


### PR DESCRIPTION
## Summary

Phase 9 として CLI を `RunResult` ベースの表示・終了コードへ移行し、通知設定を `SecretsSettings` 由来へ統一しました。

## Related

- spec\framework\rearchitecture\IMPLEMENTATION_PLAN.md
- spec\framework\rearchitecture\OBSERVABILITY_AND_GUI_CLI.md

## Changes

- `CliPresenter` / `UserMessage` を追加し、成功 0・中断 130・失敗 2 の終了コードを `RunResult` から決定
- `execute_macro()` は Runtime builder の `RunResult` を返し、失敗時も例外化せず presenter に委譲
- CLI の通知設定ソースを `SecretsSettings` に変更し、通知 secret を CLI 引数に追加しないことをテスト
- CLI のデバイス選択・検出待ちを `create_runtime_builder()` 側へ集約
- CLI Runtime adapter の結合テストを追加

## Commit Log

```
0b419c5 feat(cli): RunResultベースの終了コードへ移行
```

## Testing

```
uv run pytest tests\unit\ tests\integration\
uv run pytest tests\gui\test_log_pane_user_event.py tests\gui\test_main_window.py -q
uv run pytest tests\perf\test_logging_framework_perf.py -q
uv run ruff check .
```

## Checklist

- [x] lint / format チェック通過
- [x] 既存テスト通過
- [x] コミット prefix (feat/fix 等) が変更の動機と一致している
- [x] 新規・変更コードに対するテスト追加（該当する場合）
- [x] 型チェック通過（Python 型チェッカー設定なし。ruff と pytest で検証）