### PR TITLE
fix(runtime): Builderでデバイス選択とdummy禁止を担保

### DIFF
--- a/src/nyxpy/cli/run_cli.py
+++ b/src/nyxpy/cli/run_cli.py
@@ -1,6 +1,5 @@
 import argparse
 import pathlib
-import time
 from dataclasses import dataclass
 from typing import Any
 
@@ -106,12 +105,6 @@ def create_runtime_builder(
     project_root = pathlib.Path.cwd() if resources_dir is None else resources_dir
     registry = MacroRegistry(project_root=project_root)
     registry.reload()
-    if serial_name is not None:
-        _select_serial_device(serial_name, baudrate, detection_timeout_sec)
-    if capture_name is not None:
-        _select_capture_device(capture_name, detection_timeout_sec)
-    serial_device = serial_manager.get_active_device()
-    capture_device = capture_manager.get_active_device()
     secrets_settings = SecretsSettings()
     notification_handler = create_notification_handler_from_settings(
         secrets_settings, logger=logger
@@ -119,46 +112,16 @@ def create_runtime_builder(
     return create_legacy_runtime_builder(
         project_root=project_root,
         registry=registry,
-        serial_device=serial_device,
-        capture_device=capture_device,
+        serial_manager=serial_manager,
+        capture_manager=capture_manager,
+        serial_name=serial_name,
+        capture_name=capture_name,
+        baudrate=baudrate,
+        detection_timeout_sec=detection_timeout_sec,
         protocol=protocol,
         notification_handler=notification_handler,
         logger=logger,
     )
-
-
-def _select_serial_device(name: str, baudrate: int | None, timeout_sec: float) -> None:
-    serial_manager.auto_register_devices()
-    available_devices = _wait_for_device(serial_manager, name, timeout_sec)
-    if name not in available_devices:
-        available_devices_str = ", ".join(available_devices)
-        raise ValueError(
-            f"Serial port '{name}' not found. Available devices: {available_devices_str}"
-        )
-    serial_manager.set_active(name, baudrate or 9600)
-
-
-def _select_capture_device(name: str, timeout_sec: float) -> None:
-    capture_manager.auto_register_devices()
-    available_devices = _wait_for_device(capture_manager, name, timeout_sec)
-    print(f"Available capture devices: {available_devices}")
-    if name not in available_devices:
-        available_devices_str = ", ".join(available_devices)
-        raise ValueError(
-            f"Capture device '{name}' not found. Available devices: {available_devices_str}"
-        )
-    capture_manager.set_active(name)
-
-
-def _wait_for_device(manager, desired_name: str, timeout_sec: float) -> list[str]:
-    deadline = time.monotonic() + timeout_sec
-    while True:
-        devices = list(manager.list_devices())
-        if desired_name in devices:
-            return devices
-        if time.monotonic() >= deadline:
-            return devices
-        time.sleep(0.05)
 
 
 def execute_macro(

--- a/src/nyxpy/framework/core/runtime/builder.py
+++ b/src/nyxpy/framework/core/runtime/builder.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+import time
 from collections.abc import Callable
 from datetime import datetime
 from pathlib import Path
+from typing import Any
 from uuid import uuid4
 
 from nyxpy.framework.core.hardware.protocol import SerialProtocolInterface
@@ -27,6 +29,7 @@ from nyxpy.framework.core.logger.ports import (
     LoggerPort,
     RunLogContext,
 )
+from nyxpy.framework.core.macro.exceptions import ConfigurationError
 from nyxpy.framework.core.macro.registry import MacroDefinition, MacroRegistry
 from nyxpy.framework.core.runtime.context import (
     ExecutionContext,
@@ -41,6 +44,8 @@ from nyxpy.framework.core.utils.cancellation import CancellationToken
 
 type PortFactory[T] = Callable[[RuntimeBuildRequest, MacroDefinition], T]
 type ArtifactStoreFactory = Callable[[RuntimeBuildRequest, MacroDefinition, str], RunArtifactStore]
+
+DUMMY_DEVICE_NAME = "ダミーデバイス"
 
 
 class MacroRuntimeBuilder:
@@ -117,21 +122,77 @@ def create_legacy_runtime_builder(
     *,
     project_root: Path,
     registry: MacroRegistry,
-    serial_device,
-    capture_device,
     protocol: SerialProtocolInterface,
     notification_handler,
     logger: LoggerPort,
+    serial_manager=None,
+    capture_manager=None,
+    serial_device=None,
+    capture_device=None,
+    serial_name: str | None = None,
+    capture_name: str | None = None,
+    baudrate: int | None = None,
+    detection_timeout_sec: float = 2.0,
+    settings: SettingsSnapshot | None = None,
 ) -> MacroRuntimeBuilder:
     """既存具象実装を Port 契約へ接続する Runtime builder。"""
+    settings_snapshot = dict(settings or {})
+    direct_devices = serial_device is not None or capture_device is not None
+    managed_devices = serial_manager is not None or capture_manager is not None
+    if direct_devices and managed_devices:
+        raise ConfigurationError(
+            "direct devices and device managers cannot be mixed",
+            component="MacroRuntimeBuilder",
+        )
+    if direct_devices and (serial_device is None or capture_device is None):
+        raise ConfigurationError(
+            "serial_device and capture_device must be provided together",
+            component="MacroRuntimeBuilder",
+        )
+    if not direct_devices and (serial_manager is None or capture_manager is None):
+        raise ConfigurationError(
+            "serial_manager and capture_manager are required",
+            component="MacroRuntimeBuilder",
+        )
+
+    resolved_serial_name = _optional_name(
+        serial_name if serial_name is not None else settings_snapshot.get("serial_device")
+    )
+    resolved_capture_name = _optional_name(
+        capture_name if capture_name is not None else settings_snapshot.get("capture_device")
+    )
+    resolved_baudrate = _optional_int(
+        baudrate if baudrate is not None else settings_snapshot.get("serial_baud")
+    )
 
     return MacroRuntimeBuilder(
         project_root=project_root,
         registry=registry,
+        settings=settings_snapshot,
         controller_factory=lambda _request, _definition: SerialControllerOutputPort(
-            serial_device, protocol
+            (
+                serial_device
+                if direct_devices
+                else _resolve_serial_device(
+                    serial_manager,
+                    resolved_serial_name,
+                    resolved_baudrate,
+                    detection_timeout_sec,
+                    _allow_dummy(settings_snapshot, _request),
+                )
+            ),
+            protocol,
         ),
-        frame_source_factory=lambda _request, _definition: CaptureFrameSourcePort(capture_device),
+        frame_source_factory=lambda _request, _definition: CaptureFrameSourcePort(
+            capture_device
+            if direct_devices
+            else _resolve_capture_device(
+                capture_manager,
+                resolved_capture_name,
+                detection_timeout_sec,
+                _allow_dummy(settings_snapshot, _request),
+            )
+        ),
         resource_store_factory=lambda _request, definition: LocalResourceStore(
             MacroResourceScope.from_definition(definition, project_root)
         ),
@@ -145,3 +206,130 @@ def create_legacy_runtime_builder(
         ),
         logger_factory=lambda _request, _definition: logger,
     )
+
+
+def _allow_dummy(settings: dict[str, Any], request: RuntimeBuildRequest) -> bool:
+    if request.allow_dummy is not None:
+        return request.allow_dummy
+    return bool(settings.get("runtime.allow_dummy", False))
+
+
+def _resolve_serial_device(
+    manager,
+    name: str | None,
+    baudrate: int | None,
+    timeout_sec: float,
+    allow_dummy: bool,
+):
+    if name is not None:
+        _reject_dummy_name("serial", name, allow_dummy)
+        device = _device_map(manager).get(name)
+        if _active_device(manager) is not device:
+            _ensure_device_registered(manager, name, timeout_sec, "serial")
+            device = _device_map(manager).get(name)
+        if _active_device(manager) is not device:
+            manager.set_active(name, baudrate or 9600)
+    device = _active_or_allowed_dummy(manager, "serial", allow_dummy)
+    _reject_dummy_device(manager, "serial", device, allow_dummy)
+    return device
+
+
+def _resolve_capture_device(manager, name: str | None, timeout_sec: float, allow_dummy: bool):
+    if name is not None:
+        _reject_dummy_name("capture", name, allow_dummy)
+        device = _device_map(manager).get(name)
+        if _active_device(manager) is not device:
+            _ensure_device_registered(manager, name, timeout_sec, "capture")
+            device = _device_map(manager).get(name)
+        if _active_device(manager) is not device:
+            manager.set_active(name)
+    device = _active_or_allowed_dummy(manager, "capture", allow_dummy)
+    _reject_dummy_device(manager, "capture", device, allow_dummy)
+    return device
+
+
+def _active_or_allowed_dummy(manager, device_type: str, allow_dummy: bool):
+    active_device = _active_device(manager)
+    if active_device is not None:
+        return active_device
+    if allow_dummy:
+        return manager.get_active_device()
+    raise ConfigurationError(
+        f"{device_type} device is not selected",
+        code="NYX_RUNTIME_DEVICE_NOT_SELECTED",
+        component="MacroRuntimeBuilder",
+        details={"device_type": device_type, "available_devices": _real_device_names(manager)},
+    )
+
+
+def _ensure_device_registered(manager, name: str, timeout_sec: float, device_type: str) -> None:
+    auto_register = getattr(manager, "auto_register_devices", None)
+    if auto_register is not None:
+        auto_register()
+    available_devices = _wait_for_device(manager, name, timeout_sec)
+    if name not in available_devices:
+        raise ConfigurationError(
+            f"{device_type} device '{name}' not found",
+            code="NYX_RUNTIME_DEVICE_NOT_FOUND",
+            component="MacroRuntimeBuilder",
+            details={"device_type": device_type, "available_devices": available_devices},
+        )
+
+
+def _wait_for_device(manager, desired_name: str, timeout_sec: float) -> list[str]:
+    deadline = time.monotonic() + timeout_sec
+    while True:
+        devices = list(manager.list_devices())
+        if desired_name in devices:
+            return devices
+        if time.monotonic() >= deadline:
+            return devices
+        time.sleep(0.05)
+
+
+def _reject_dummy_name(device_type: str, name: str, allow_dummy: bool) -> None:
+    if name == DUMMY_DEVICE_NAME and not allow_dummy:
+        raise ConfigurationError(
+            f"{device_type} dummy device is not allowed",
+            code="NYX_RUNTIME_DUMMY_DEVICE_NOT_ALLOWED",
+            component="MacroRuntimeBuilder",
+            details={"device_type": device_type},
+        )
+
+
+def _reject_dummy_device(manager, device_type: str, device, allow_dummy: bool) -> None:
+    if allow_dummy:
+        return
+    if _device_map(manager).get(DUMMY_DEVICE_NAME) is device:
+        raise ConfigurationError(
+            f"{device_type} dummy device is not allowed",
+            code="NYX_RUNTIME_DUMMY_DEVICE_NOT_ALLOWED",
+            component="MacroRuntimeBuilder",
+            details={"device_type": device_type},
+        )
+
+
+def _device_map(manager) -> dict[str, object]:
+    devices = getattr(manager, "devices", {})
+    return dict(devices)
+
+
+def _active_device(manager):
+    return getattr(manager, "active_device", None)
+
+
+def _real_device_names(manager) -> list[str]:
+    return [name for name in manager.list_devices() if name != DUMMY_DEVICE_NAME]
+
+
+def _optional_name(value: object) -> str | None:
+    if value is None:
+        return None
+    text = str(value)
+    return text or None
+
+
+def _optional_int(value: object) -> int | None:
+    if value is None or value == "":
+        return None
+    return int(value)

--- a/src/nyxpy/gui/main_window.py
+++ b/src/nyxpy/gui/main_window.py
@@ -305,11 +305,15 @@ class MainWindow(QMainWindow):
         return create_legacy_runtime_builder(
             project_root=Path.cwd(),
             registry=self.registry,
-            serial_device=serial_manager.get_active_device(),
-            capture_device=capture_manager.get_active_device(),
+            serial_manager=serial_manager,
+            capture_manager=capture_manager,
+            serial_name=global_settings.get("serial_device"),
+            capture_name=global_settings.get("capture_device"),
+            baudrate=global_settings.get("serial_baud", 9600),
             protocol=protocol,
             notification_handler=notification_handler,
             logger=self.logger,
+            settings=global_settings.data,
         )
 
     def cancel_macro(self):

--- a/tests/integration/test_cli_runtime_adapter.py
+++ b/tests/integration/test_cli_runtime_adapter.py
@@ -52,11 +52,11 @@ def test_cli_notification_settings_source_is_secrets_store(monkeypatch, tmp_path
     )
     monkeypatch.setattr(
         "nyxpy.cli.run_cli.serial_manager",
-        MagicMock(get_active_device=lambda: "serial"),
+        MagicMock(),
     )
     monkeypatch.setattr(
         "nyxpy.cli.run_cli.capture_manager",
-        MagicMock(get_active_device=lambda: "capture"),
+        MagicMock(),
     )
 
     def create_notification_handler(settings, *, logger):
@@ -76,3 +76,5 @@ def test_cli_notification_settings_source_is_secrets_store(monkeypatch, tmp_path
 
     assert captured == {"settings": sentinel_secrets, "logger": logger}
     assert legacy_builder.call_args.kwargs["notification_handler"] == "notification-port"
+    assert "serial_device" not in legacy_builder.call_args.kwargs
+    assert "capture_device" not in legacy_builder.call_args.kwargs

--- a/tests/integration/test_macro_runtime_entrypoints.py
+++ b/tests/integration/test_macro_runtime_entrypoints.py
@@ -1,4 +1,5 @@
 import importlib
+import inspect
 import sys
 from pathlib import Path
 
@@ -22,3 +23,15 @@ def test_gui_cli_entrypoints_do_not_import_macro_executor() -> None:
     importlib.import_module("nyxpy.gui.main_window")
 
     assert "nyxpy.framework.core.macro.executor" not in sys.modules
+
+
+def test_gui_cli_runtime_builder_paths_do_not_resolve_devices_directly() -> None:
+    from nyxpy.cli.run_cli import create_runtime_builder
+    from nyxpy.gui.main_window import MainWindow
+
+    cli_source = inspect.getsource(create_runtime_builder)
+    gui_source = inspect.getsource(MainWindow._create_runtime_builder)
+
+    assert "get_active_device" not in cli_source
+    assert "auto_register_devices" not in cli_source
+    assert "get_active_device" not in gui_source

--- a/tests/unit/cli/test_main.py
+++ b/tests/unit/cli/test_main.py
@@ -181,20 +181,16 @@ def test_create_protocol_unknown():
         create_protocol("UNKNOWN")
 
 
-def test_create_runtime_builder_uses_active_devices(monkeypatch, tmp_path):
+def test_create_runtime_builder_delegates_device_selection_to_builder(monkeypatch, tmp_path):
     mock_registry = MagicMock()
     registry = MagicMock()
     mock_registry.return_value = registry
     mock_builder = MagicMock()
+    mock_serial_manager = MagicMock()
+    mock_capture_manager = MagicMock()
     monkeypatch.setattr("nyxpy.cli.run_cli.MacroRegistry", mock_registry)
-    monkeypatch.setattr(
-        "nyxpy.cli.run_cli.serial_manager",
-        MagicMock(get_active_device=lambda: "serial"),
-    )
-    monkeypatch.setattr(
-        "nyxpy.cli.run_cli.capture_manager",
-        MagicMock(get_active_device=lambda: "capture"),
-    )
+    monkeypatch.setattr("nyxpy.cli.run_cli.serial_manager", mock_serial_manager)
+    monkeypatch.setattr("nyxpy.cli.run_cli.capture_manager", mock_capture_manager)
     monkeypatch.setattr(
         "nyxpy.cli.run_cli.create_notification_handler_from_settings",
         lambda settings, logger: "notifier",
@@ -206,7 +202,10 @@ def test_create_runtime_builder_uses_active_devices(monkeypatch, tmp_path):
 
     mock_registry.assert_called_once_with(project_root=tmp_path)
     registry.reload.assert_called_once()
-    mock_builder.assert_called_once()
+    assert mock_builder.call_args.kwargs["serial_manager"] is mock_serial_manager
+    assert mock_builder.call_args.kwargs["capture_manager"] is mock_capture_manager
+    assert "serial_device" not in mock_builder.call_args.kwargs
+    assert "capture_device" not in mock_builder.call_args.kwargs
 
 
 def test_execute_macro_success(monkeypatch, mock_log_manager):

--- a/tests/unit/framework/runtime/test_runtime_builder.py
+++ b/tests/unit/framework/runtime/test_runtime_builder.py
@@ -1,0 +1,171 @@
+from pathlib import Path
+
+import pytest
+
+from nyxpy.framework.core.macro.exceptions import ConfigurationError
+from nyxpy.framework.core.macro.registry import MacroDefinition
+from nyxpy.framework.core.runtime.builder import DUMMY_DEVICE_NAME, create_legacy_runtime_builder
+from nyxpy.framework.core.runtime.context import RuntimeBuildRequest
+from tests.support.fakes import FakeLoggerPort
+
+
+class Registry:
+    def __init__(self, definition: MacroDefinition) -> None:
+        self.definition = definition
+
+    def resolve(self, name_or_id: str) -> MacroDefinition:
+        return self.definition
+
+    def get_settings(self, definition: MacroDefinition) -> dict:
+        return {}
+
+
+class Device:
+    pass
+
+
+class DeviceManager:
+    def __init__(self, devices: dict[str, Device]) -> None:
+        self.devices = devices
+        self.active_device = None
+        self.auto_register_calls = 0
+        self.set_active_calls = []
+        self.get_active_calls = 0
+
+    def auto_register_devices(self) -> None:
+        self.auto_register_calls += 1
+
+    def list_devices(self) -> list[str]:
+        return list(self.devices)
+
+    def set_active(self, name: str, baudrate: int | None = None) -> None:
+        self.set_active_calls.append((name, baudrate))
+        self.active_device = self.devices[name]
+
+    def get_active_device(self):
+        self.get_active_calls += 1
+        self.active_device = self.devices[DUMMY_DEVICE_NAME]
+        return self.active_device
+
+
+class CaptureDeviceManager(DeviceManager):
+    def set_active(self, name: str) -> None:
+        self.set_active_calls.append((name, None))
+        self.active_device = self.devices[name]
+
+
+def definition(tmp_path: Path) -> MacroDefinition:
+    return MacroDefinition(
+        id="sample",
+        aliases=("sample",),
+        display_name="Sample",
+        class_name="SampleMacro",
+        module_name="tests.sample",
+        macro_root=tmp_path,
+        source_path=tmp_path / "macro.py",
+        settings_path=None,
+        description="",
+        tags=(),
+        factory=object(),
+    )
+
+
+def make_builder(
+    tmp_path: Path,
+    serial_manager: DeviceManager,
+    capture_manager: CaptureDeviceManager,
+    **kwargs,
+):
+    return create_legacy_runtime_builder(
+        project_root=tmp_path,
+        registry=Registry(definition(tmp_path)),
+        serial_manager=serial_manager,
+        capture_manager=capture_manager,
+        protocol=object(),
+        notification_handler=None,
+        logger=FakeLoggerPort(),
+        **kwargs,
+    )
+
+
+def test_runtime_builder_disallows_dummy_by_default(tmp_path: Path) -> None:
+    serial = DeviceManager({DUMMY_DEVICE_NAME: Device()})
+    capture = CaptureDeviceManager({DUMMY_DEVICE_NAME: Device()})
+    builder = make_builder(tmp_path, serial, capture)
+
+    with pytest.raises(ConfigurationError, match="serial device is not selected"):
+        builder.build(RuntimeBuildRequest(macro_id="sample"))
+
+    assert serial.get_active_calls == 0
+    assert serial.active_device is None
+
+
+def test_runtime_builder_allows_dummy_when_explicit(tmp_path: Path) -> None:
+    serial = DeviceManager({DUMMY_DEVICE_NAME: Device()})
+    capture = CaptureDeviceManager({DUMMY_DEVICE_NAME: Device()})
+    builder = make_builder(tmp_path, serial, capture)
+
+    context = builder.build(RuntimeBuildRequest(macro_id="sample", allow_dummy=True))
+
+    assert context.options.allow_dummy is True
+    assert serial.active_device is serial.devices[DUMMY_DEVICE_NAME]
+    assert capture.active_device is capture.devices[DUMMY_DEVICE_NAME]
+
+
+def test_runtime_builder_selects_requested_devices(tmp_path: Path) -> None:
+    serial = DeviceManager({"COM1": Device()})
+    capture = CaptureDeviceManager({"Camera1": Device()})
+    builder = make_builder(
+        tmp_path,
+        serial,
+        capture,
+        serial_name="COM1",
+        capture_name="Camera1",
+        baudrate=115200,
+    )
+
+    builder.build(RuntimeBuildRequest(macro_id="sample"))
+
+    assert serial.set_active_calls == [("COM1", 115200)]
+    assert capture.set_active_calls == [("Camera1", None)]
+
+
+def test_runtime_builder_does_not_reselect_already_active_devices(tmp_path: Path) -> None:
+    serial_device = Device()
+    capture_device = Device()
+    serial = DeviceManager({"COM1": serial_device})
+    capture = CaptureDeviceManager({"Camera1": capture_device})
+    serial.active_device = serial_device
+    capture.active_device = capture_device
+    builder = make_builder(
+        tmp_path,
+        serial,
+        capture,
+        serial_name="COM1",
+        capture_name="Camera1",
+    )
+
+    builder.build(RuntimeBuildRequest(macro_id="sample"))
+
+    assert serial.auto_register_calls == 0
+    assert capture.auto_register_calls == 0
+    assert serial.set_active_calls == []
+    assert capture.set_active_calls == []
+
+
+def test_runtime_builder_rejects_mixed_direct_and_managed_devices(tmp_path: Path) -> None:
+    serial = DeviceManager({"COM1": Device()})
+    capture = CaptureDeviceManager({"Camera1": Device()})
+
+    with pytest.raises(ConfigurationError, match="cannot be mixed"):
+        create_legacy_runtime_builder(
+            project_root=tmp_path,
+            registry=Registry(definition(tmp_path)),
+            serial_manager=serial,
+            capture_manager=capture,
+            serial_device=Device(),
+            capture_device=Device(),
+            protocol=object(),
+            notification_handler=None,
+            logger=FakeLoggerPort(),
+        )


### PR DESCRIPTION
## Summary

Runtime 実行用デバイスの選択と dummy 許可判定を `MacroRuntimeBuilder` 側へ集約し、CLI/GUI が直接デバイスを解決しないようにします。

## Related

- ユーザ依頼: フレームワーク再設計実装の検証指摘への対処
- spec/framework/rearchitecture/IMPLEMENTATION_PLAN.md の Builder ownership gate / dummy fallback 方針

## Changes

- `create_legacy_runtime_builder` が device manager と選択条件を受け取り、`RuntimeBuildRequest.allow_dummy` / settings に基づいて dummy device を拒否
- CLI/GUI の実行用 builder から `get_active_device()` と検出処理を除去し、Builder へ委譲
- 既に選択済みの実デバイスは再選択せず、不要な close/open を避ける
- dummy 禁止、明示許可、要求デバイス選択、CLI/GUI builder 経路の静的ゲートを追加

## Commit Log

```
3dad0df fix(runtime): Builderでデバイス選択とdummy禁止を担保
```

## Testing

```
$env:QT_QPA_PLATFORM='offscreen'; uv run pytest tests\unit\framework\runtime\ tests\unit\cli\ tests\integration\test_cli_runtime_adapter.py tests\integration\test_macro_runtime_entrypoints.py tests\gui\test_main_window.py
# 66 passed

$env:QT_QPA_PLATFORM='offscreen'; uv run pytest -m "not realdevice"
# 423 passed, 5 deselected, 1 warning

uv run ruff check .
# All checks passed

uv run ruff format src\nyxpy\framework\core\runtime\builder.py src\nyxpy\cli\run_cli.py src\nyxpy\gui\main_window.py tests\unit\framework\runtime\test_runtime_builder.py tests\unit\cli\test_main.py tests\integration\test_cli_runtime_adapter.py tests\integration\test_macro_runtime_entrypoints.py --check
# 7 files already formatted
```

## Checklist

- [x] lint / format チェック通過
- [x] 既存テスト通過
- [x] コミット prefix (feat/fix 等) が変更の動機と一致している
- [x] 新規・変更コードに対するテスト追加（該当する場合）
- [x] 型チェック通過

## Review Notes

GUI のプレビューや設定変更通知で使う `get_active_device()` は実行用 builder 経路ではないため、この PR では維持しています。Runtime 実行では active device が dummy の場合も `allow_dummy=True` でない限り拒否します。
