### PR TITLE
test(runtime): 実機と発見性能のゲートを追加

### DIFF
--- a/tests/hardware/test_macro_runtime_realdevice.py
+++ b/tests/hardware/test_macro_runtime_realdevice.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from nyxpy.framework.core.api.notification_handler import NotificationHandler
+from nyxpy.framework.core.hardware.capture import AsyncCaptureDevice
+from nyxpy.framework.core.hardware.protocol_factory import ProtocolFactory
+from nyxpy.framework.core.hardware.serial_comm import SerialComm
+from nyxpy.framework.core.logger import NullLoggerPort
+from nyxpy.framework.core.macro.registry import MacroRegistry
+from nyxpy.framework.core.runtime.builder import create_legacy_runtime_builder
+from nyxpy.framework.core.runtime.context import RuntimeBuildRequest
+from nyxpy.framework.core.runtime.result import RunStatus
+
+
+def _required_env(name: str) -> str:
+    value = os.environ.get(name)
+    if not value:
+        pytest.skip(f"{name} is required for realdevice runtime test")
+    return value
+
+
+def _write_runtime_macro(project_root: Path) -> None:
+    macro_dir = project_root / "macros" / "runtime_realdevice"
+    macro_dir.mkdir(parents=True)
+    (macro_dir / "macro.py").write_text(
+        """from nyxpy.framework.core.constants import Button
+from nyxpy.framework.core.macro.base import MacroBase
+from nyxpy.framework.core.macro.command import Command
+
+
+class RuntimeRealDeviceMacro(MacroBase):
+    def initialize(self, cmd: Command, args: dict) -> None:
+        pass
+
+    def run(self, cmd: Command) -> None:
+        frame = cmd.capture()
+        if frame is None:
+            raise RuntimeError("capture returned None")
+        cmd.press(Button.A, dur=0, wait=0)
+
+    def finalize(self, cmd: Command) -> None:
+        pass
+""",
+        encoding="utf-8",
+    )
+
+
+@pytest.mark.realdevice
+def test_macro_runtime_runs_with_real_serial_and_capture(tmp_path: Path) -> None:
+    serial_port = _required_env("NYX_REAL_SERIAL_PORT")
+    capture_index = int(os.environ.get("NYX_REAL_CAPTURE_INDEX", "0"))
+    protocol_name = os.environ.get("NYX_REAL_PROTOCOL", "CH552")
+    baudrate = int(os.environ.get("NYX_REAL_BAUD", "9600"))
+
+    _write_runtime_macro(tmp_path)
+    registry = MacroRegistry(project_root=tmp_path)
+    registry.reload()
+
+    serial = SerialComm(serial_port)
+    capture = AsyncCaptureDevice(device_index=capture_index, fps=30.0)
+    try:
+        serial.open(baudrate)
+    except Exception as exc:
+        pytest.skip(f"serial device is not available: {exc}")
+
+    try:
+        builder = create_legacy_runtime_builder(
+            project_root=tmp_path,
+            registry=registry,
+            serial_device=serial,
+            capture_device=capture,
+            protocol=ProtocolFactory.create_protocol(protocol_name),
+            notification_handler=NotificationHandler([]),
+            logger=NullLoggerPort(),
+        )
+
+        result = builder.run(RuntimeBuildRequest(macro_id="runtime_realdevice"))
+
+        assert result.status is RunStatus.SUCCESS
+    finally:
+        serial.close()
+        capture.release()

--- a/tests/perf/test_macro_discovery_perf.py
+++ b/tests/perf/test_macro_discovery_perf.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import time
+from pathlib import Path
+
+from nyxpy.framework.core.macro.registry import MacroRegistry
+
+MACRO_COUNT = 60
+RELOAD_THRESHOLD_S = 2.0
+
+
+def _write_macro(path: Path, index: int) -> None:
+    package_dir = path / f"perf_macro_{index:03d}"
+    package_dir.mkdir()
+    class_name = f"PerfMacro{index:03d}"
+    (package_dir / "macro.py").write_text(
+        f"""from nyxpy.framework.core.macro.base import MacroBase
+from nyxpy.framework.core.macro.command import Command
+
+
+class {class_name}(MacroBase):
+    description = "perf macro"
+    tags = ["perf"]
+
+    def initialize(self, cmd: Command, args: dict) -> None:
+        pass
+
+    def run(self, cmd: Command) -> None:
+        pass
+
+    def finalize(self, cmd: Command) -> None:
+        pass
+""",
+        encoding="utf-8",
+    )
+
+
+def test_macro_registry_reload_perf(tmp_path: Path) -> None:
+    macros_dir = tmp_path / "macros"
+    macros_dir.mkdir()
+    for index in range(MACRO_COUNT):
+        _write_macro(macros_dir, index)
+
+    registry = MacroRegistry(project_root=tmp_path)
+
+    started = time.perf_counter()
+    registry.reload()
+    elapsed = time.perf_counter() - started
+
+    assert len(registry.definitions) == MACRO_COUNT
+    assert registry.diagnostics == ()
+    assert elapsed < RELOAD_THRESHOLD_S


### PR DESCRIPTION
## Summary

実装計画で対象に含まれていた Runtime 実機ゲートと MacroRegistry discovery 性能ゲートを追加します。

## Related

- ユーザ依頼: フレームワーク再設計実装の検証指摘への対処
- spec/framework/rearchitecture/IMPLEMENTATION_PLAN.md の `tests\hardware\test_macro_runtime_realdevice.py` / `tests\perf\test_macro_discovery_perf.py`

## Changes

- `tests\hardware\test_macro_runtime_realdevice.py` を追加し、実 serial / capture / MacroRuntime の smoke test を `realdevice` マークで分離
- `tests\perf\test_macro_discovery_perf.py` を追加し、60 個の convention macro を `MacroRegistry.reload()` できる性能ゲートを固定

## Commit Log

```
edc3b9f test(runtime): 実機と発見性能のゲートを追加
```

## Testing

```
uv run pytest tests\perf\test_macro_discovery_perf.py tests\hardware\test_macro_runtime_realdevice.py
# 1 passed, 1 skipped

$env:QT_QPA_PLATFORM='offscreen'; uv run pytest -m "not realdevice"
# 415 passed, 6 deselected, 1 warning

uv run ruff check .
# All checks passed

uv run ruff format tests\perf\test_macro_discovery_perf.py tests\hardware\test_macro_runtime_realdevice.py --check
# 2 files already formatted
```

## Checklist

- [x] lint / format チェック通過
- [x] 既存テスト通過
- [x] コミット prefix (feat/fix 等) が変更の動機と一致している
- [x] 新規・変更コードに対するテスト追加（該当する場合）
- [x] 型チェック通過

## Review Notes

実機テストは `NYX_REAL_SERIAL_PORT`、任意で `NYX_REAL_CAPTURE_INDEX` / `NYX_REAL_PROTOCOL` / `NYX_REAL_BAUD` を使います。通常テストでは既存 conftest により `realdevice` として分離されます。
