### PR TITLE
fix(logger): LogBackendをDefaultLoggerへ接続

### DIFF
--- a/spec/framework/rearchitecture/LOGGING_FRAMEWORK.md
+++ b/spec/framework/rearchitecture/LOGGING_FRAMEWORK.md
@@ -453,27 +453,27 @@ sink 例外はマクロ実行結果を失敗にしない。ただし技術ログ
 
 ### 6.1 仕様確定
 
-- [ ] `LogEvent`、`TechnicalLog`、`UserEvent`、`RunLogContext` のシグネチャ確定
-- [ ] `LoggerPort`、`LogSink`、`LogBackend` の抽象定義
+- [x] `LogEvent`、`TechnicalLog`、`UserEvent`、`RunLogContext` のシグネチャ確定
+- [x] `LoggerPort`、`LogSink`、`LogBackend` の抽象定義
 
 ### 6.2 実装
 
-- [ ] `LogManager` singleton と module-level `log_manager` を削除
-- [ ] `DefaultLogger`、`LogSinkDispatcher`、`LogBackend`、`LogSanitizer` を実装
-- [ ] 旧 `LogManager.log()` と handler API の呼び出し元を新 API へ置換
-- [ ] `UserEvent` と `TechnicalLog` の分離配信を実装
-- [ ] `RunLogContext` を `ExecutionContext` と `Command.log()` へ接続
-- [ ] secret mask と JSON 化不能値の縮退処理を実装
-- [ ] sink 登録解除の `RLock`、snapshot 配信、handler 例外隔離を実装
-- [ ] `TestLogSink` を実装
-- [ ] ログファイル配置、rotation、保持期間、cleanup を実装
-- [ ] `LogPane` を `UserEvent` 購読へ移行
+- [x] `LogManager` singleton と module-level `log_manager` を削除
+- [x] `DefaultLogger`、`LogSinkDispatcher`、`LogBackend`、`LogSanitizer` を実装
+- [x] 旧 `LogManager.log()` と handler API の呼び出し元を新 API へ置換
+- [x] `UserEvent` と `TechnicalLog` の分離配信を実装
+- [x] `RunLogContext` を `ExecutionContext` と `Command.log()` へ接続
+- [x] secret mask と JSON 化不能値の縮退処理を実装
+- [x] sink 登録解除の `RLock`、snapshot 配信、handler 例外隔離を実装
+- [x] `TestLogSink` を実装
+- [x] ログファイル配置、rotation、保持期間、cleanup を実装
+- [x] `LogPane` を `UserEvent` 購読へ移行
 - [ ] 通知失敗と Runtime 失敗を技術ログへ記録
 
 ### 6.3 検証
 
-- [ ] ユニットテスト作成・パス
-- [ ] GUI テスト作成・パス
-- [ ] パフォーマンステスト作成・パス
-- [ ] `uv run ruff check .` がパス
-- [ ] `uv run pytest tests\unit\` がパス
+- [x] ユニットテスト作成・パス
+- [x] GUI テスト作成・パス
+- [x] パフォーマンステスト作成・パス
+- [x] `uv run ruff check .` がパス
+- [x] `uv run pytest tests\unit\` がパス

--- a/src/nyxpy/framework/core/logger/__init__.py
+++ b/src/nyxpy/framework/core/logger/__init__.py
@@ -1,3 +1,4 @@
+from nyxpy.framework.core.logger.backend import JsonlLogBackend, NullLogBackend
 from nyxpy.framework.core.logger.default_logger import DefaultLogger, NullLoggerPort
 from nyxpy.framework.core.logger.dispatcher import LogSinkDispatcher
 from nyxpy.framework.core.logger.events import (
@@ -23,7 +24,9 @@ __all__ = [
     "LogSanitizer",
     "LogSink",
     "LogSinkDispatcher",
+    "JsonlLogBackend",
     "NullLoggerPort",
+    "NullLogBackend",
     "RunLogContext",
     "TestLogSink",
     "TechnicalLog",

--- a/src/nyxpy/framework/core/logger/backend.py
+++ b/src/nyxpy/framework/core/logger/backend.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import json
+from dataclasses import asdict
+from datetime import datetime, timedelta
+from pathlib import Path
+from threading import RLock
+
+from nyxpy.framework.core.logger.events import (
+    LogEvent,
+    TechnicalLog,
+    level_enabled,
+    normalize_level,
+)
+
+
+class NullLogBackend:
+    def emit_technical(self, event: TechnicalLog) -> None:
+        pass
+
+    def flush(self) -> None:
+        pass
+
+    def close(self) -> None:
+        pass
+
+
+class JsonlLogBackend:
+    def __init__(
+        self,
+        path: Path,
+        *,
+        level: str = "DEBUG",
+        max_bytes: int = 10 * 1024 * 1024,
+        retention_days: int = 30,
+    ) -> None:
+        self.path = Path(path)
+        self.minimum_level = normalize_level(level)
+        self.max_bytes = max_bytes
+        self.retention_days = retention_days
+        self._lock = RLock()
+        self._closed = False
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        self._cleanup_retention()
+
+    def set_level(self, level: str) -> None:
+        self.minimum_level = normalize_level(level)
+
+    def emit_technical(self, event: TechnicalLog) -> None:
+        if not level_enabled(event.event.level, self.minimum_level):
+            return
+        with self._lock:
+            if self._closed:
+                return
+            self._rotate_if_needed()
+            with self.path.open("a", encoding="utf-8") as file:
+                file.write(json.dumps(_event_to_json(event.event), ensure_ascii=False) + "\n")
+
+    def flush(self) -> None:
+        pass
+
+    def close(self) -> None:
+        with self._lock:
+            self._closed = True
+
+    def _rotate_if_needed(self) -> None:
+        if self.path.exists() and self.path.stat().st_size >= self.max_bytes:
+            rotated = self.path.with_suffix(self.path.suffix + ".1")
+            if rotated.exists():
+                rotated.unlink()
+            self.path.replace(rotated)
+
+    def _cleanup_retention(self) -> None:
+        cutoff = datetime.now() - timedelta(days=self.retention_days)
+        for candidate in self.path.parent.glob(self.path.name + "*"):
+            if datetime.fromtimestamp(candidate.stat().st_mtime) < cutoff:
+                candidate.unlink()
+
+
+def _event_to_json(event: LogEvent) -> dict:
+    payload = asdict(event)
+    payload["timestamp"] = event.timestamp.isoformat()
+    payload["level"] = event.level.value
+    return json.loads(json.dumps(payload, ensure_ascii=False, default=repr))

--- a/src/nyxpy/framework/core/logger/default_logger.py
+++ b/src/nyxpy/framework/core/logger/default_logger.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import traceback
 from datetime import datetime
 
+from nyxpy.framework.core.logger.backend import NullLogBackend
 from nyxpy.framework.core.logger.dispatcher import LogSinkDispatcher
 from nyxpy.framework.core.logger.events import (
     LogEvent,
@@ -12,6 +13,7 @@ from nyxpy.framework.core.logger.events import (
     UserEvent,
     normalize_level,
 )
+from nyxpy.framework.core.logger.ports import LogBackend
 from nyxpy.framework.core.logger.sanitizer import LogSanitizer
 
 
@@ -20,14 +22,16 @@ class DefaultLogger:
         self,
         dispatcher: LogSinkDispatcher,
         sanitizer: LogSanitizer,
+        backend: LogBackend | None = None,
         context: RunLogContext | None = None,
     ) -> None:
         self.dispatcher = dispatcher
         self.sanitizer = sanitizer
+        self.backend = backend or NullLogBackend()
         self.context = context
 
     def bind_context(self, context: RunLogContext) -> DefaultLogger:
-        return DefaultLogger(self.dispatcher, self.sanitizer, context)
+        return DefaultLogger(self.dispatcher, self.sanitizer, self.backend, context)
 
     def technical(
         self,
@@ -52,7 +56,9 @@ class DefaultLogger:
             exception_type=type(exc).__name__ if exc is not None else None,
             traceback="".join(traceback.format_exception(exc)) if exc is not None else None,
         )
-        self.dispatcher.emit_technical(TechnicalLog(log_event, include_traceback=exc is not None))
+        technical_log = TechnicalLog(log_event, include_traceback=exc is not None)
+        self._emit_backend(technical_log)
+        self.dispatcher.emit_technical(technical_log)
 
     def user(
         self,
@@ -78,21 +84,47 @@ class DefaultLogger:
             extra=self.sanitizer.sanitize_extra_for_user(extra),
         )
         self.dispatcher.emit_user(user_event)
-        self.dispatcher.emit_technical(
-            TechnicalLog(
+        technical_log = TechnicalLog(
+            LogEvent(
+                timestamp=timestamp,
+                level=log_level,
+                component=component,
+                event=event,
+                message=self.sanitizer.mask_text(message),
+                run_id=user_event.run_id,
+                macro_id=user_event.macro_id,
+                extra=self.sanitizer.sanitize_extra_for_technical(extra),
+            ),
+            include_traceback=False,
+        )
+        self._emit_backend(technical_log)
+        self.dispatcher.emit_technical(technical_log)
+
+    def _emit_backend(self, log: TechnicalLog) -> None:
+        try:
+            self.backend.emit_technical(log)
+        except Exception as exc:
+            failure = TechnicalLog(
                 LogEvent(
-                    timestamp=timestamp,
-                    level=log_level,
-                    component=component,
-                    event=event,
-                    message=self.sanitizer.mask_text(message),
-                    run_id=user_event.run_id,
-                    macro_id=user_event.macro_id,
-                    extra=self.sanitizer.sanitize_extra_for_technical(extra),
+                    timestamp=datetime.now(),
+                    level=normalize_level("ERROR"),
+                    component="DefaultLogger",
+                    event="backend.emit_failed",
+                    message="Log backend emit failed",
+                    run_id=log.event.run_id,
+                    macro_id=log.event.macro_id,
+                    extra=self.sanitizer.sanitize_extra_for_technical(
+                        {
+                            "emitted_event": log.event.event,
+                            "exception_type": type(exc).__name__,
+                            "message": str(exc),
+                        }
+                    ),
+                    exception_type=type(exc).__name__,
                 ),
                 include_traceback=False,
             )
-        )
+            self.dispatcher.emit_technical(failure)
 
 
 class NullLoggerPort:

--- a/src/nyxpy/framework/core/logger/factory.py
+++ b/src/nyxpy/framework/core/logger/factory.py
@@ -3,13 +3,13 @@ from __future__ import annotations
 from dataclasses import dataclass
 from pathlib import Path
 
+from nyxpy.framework.core.logger.backend import JsonlLogBackend
 from nyxpy.framework.core.logger.default_logger import DefaultLogger
 from nyxpy.framework.core.logger.dispatcher import LogSinkDispatcher
-from nyxpy.framework.core.logger.ports import LogSink
+from nyxpy.framework.core.logger.ports import LogBackend, LogSink
 from nyxpy.framework.core.logger.sanitizer import LogSanitizer
 from nyxpy.framework.core.logger.sinks import (
     ConsoleLogSink,
-    JsonlFileSink,
     RunJsonlFileSink,
     TextFileLogSink,
 )
@@ -20,9 +20,11 @@ class LoggingComponents:
     logger: DefaultLogger
     dispatcher: LogSinkDispatcher
     sanitizer: LogSanitizer
+    backend: LogBackend
     sink_ids: dict[str, str]
 
     def set_all_levels(self, level: str) -> None:
+        _set_backend_level(self.backend, level)
         for sink_id in self.sink_ids.values():
             self.dispatcher.set_level(sink_id, level)
 
@@ -32,7 +34,8 @@ class LoggingComponents:
             self.dispatcher.set_level(sink_id, level)
 
     def set_file_level(self, level: str) -> None:
-        for name in ("human_file", "framework_jsonl", "run_jsonl"):
+        _set_backend_level(self.backend, level)
+        for name in ("human_file", "run_jsonl"):
             sink_id = self.sink_ids.get(name)
             if sink_id is not None:
                 self.dispatcher.set_level(sink_id, level)
@@ -43,6 +46,8 @@ class LoggingComponents:
         return sink_id
 
     def close(self) -> None:
+        self.backend.flush()
+        self.backend.close()
         self.dispatcher.flush()
         self.dispatcher.close()
 
@@ -57,7 +62,8 @@ def create_default_logging(
 ) -> LoggingComponents:
     sanitizer = LogSanitizer(mask_secret_keys)
     dispatcher = LogSinkDispatcher(sanitizer)
-    logger = DefaultLogger(dispatcher, sanitizer)
+    backend = JsonlLogBackend(Path(base_dir) / "framework.jsonl", level=file_level)
+    logger = DefaultLogger(dispatcher, sanitizer, backend)
     sink_ids: dict[str, str] = {}
 
     if console_enabled:
@@ -66,12 +72,14 @@ def create_default_logging(
         TextFileLogSink(Path(base_dir) / "nyxpy.log"),
         level=file_level,
     )
-    sink_ids["framework_jsonl"] = dispatcher.add_sink(
-        JsonlFileSink(Path(base_dir) / "framework.jsonl"),
-        level=file_level,
-    )
     sink_ids["run_jsonl"] = dispatcher.add_sink(
         RunJsonlFileSink(Path(base_dir) / "runs"),
         level=file_level,
     )
-    return LoggingComponents(logger, dispatcher, sanitizer, sink_ids)
+    return LoggingComponents(logger, dispatcher, sanitizer, backend, sink_ids)
+
+
+def _set_backend_level(backend: LogBackend, level: str) -> None:
+    set_level = getattr(backend, "set_level", None)
+    if set_level is not None:
+        set_level(level)

--- a/tests/unit/framework/logger/test_logging_framework.py
+++ b/tests/unit/framework/logger/test_logging_framework.py
@@ -2,15 +2,23 @@ from __future__ import annotations
 
 import importlib
 import importlib.util
+import json
+from datetime import datetime
 from pathlib import Path
 
 from nyxpy.framework.core.logger import (
     DefaultLogger,
+    JsonlLogBackend,
+    LogEvent,
+    LogLevel,
     LogSanitizer,
     LogSinkDispatcher,
     RunLogContext,
+    TechnicalLog,
     TestLogSink,
+    create_default_logging,
 )
+from nyxpy.framework.core.logger.backend import NullLogBackend
 from nyxpy.framework.core.logger.ports import LogSink
 
 
@@ -23,6 +31,16 @@ class FailingSink(LogSink):
 
     def emit_user(self, event):
         raise RuntimeError(self.message)
+
+
+class FailingBackend(NullLogBackend):
+    def emit_technical(self, event):
+        raise RuntimeError("backend failed")
+
+
+class NonJsonValue:
+    def __repr__(self) -> str:
+        return "<non-json-value>"
 
 
 def test_logger_import_has_no_backend_side_effect(tmp_path: Path, monkeypatch) -> None:
@@ -61,6 +79,62 @@ def test_logger_port_binds_run_context() -> None:
 
     assert sink.technical_logs[0].event.run_id == "run-1"
     assert sink.technical_logs[0].event.macro_id == "sample"
+
+
+def test_jsonl_log_backend_writes_technical_log(tmp_path: Path) -> None:
+    backend = JsonlLogBackend(tmp_path / "framework.jsonl")
+    value = NonJsonValue()
+    event = LogEvent(
+        timestamp=datetime.now(),
+        level=LogLevel.INFO,
+        component="test",
+        event="macro.started",
+        message="started",
+        run_id="run-1",
+        macro_id="sample",
+        extra={"value": value},
+    )
+
+    backend.emit_technical(TechnicalLog(event))
+    payload = json.loads((tmp_path / "framework.jsonl").read_text(encoding="utf-8"))
+
+    assert payload["level"] == "INFO"
+    assert payload["component"] == "test"
+    assert payload["event"] == "macro.started"
+    assert payload["run_id"] == "run-1"
+    assert payload["macro_id"] == "sample"
+    assert payload["extra"]["value"] == repr(value)
+
+
+def test_default_logging_uses_framework_jsonl_backend(tmp_path: Path) -> None:
+    logging = create_default_logging(base_dir=tmp_path, console_enabled=False)
+
+    assert isinstance(logging.backend, JsonlLogBackend)
+    assert "framework_jsonl" not in logging.sink_ids
+
+    logger = logging.logger.bind_context(RunLogContext(run_id="run-1", macro_id="sample"))
+    logger.technical("INFO", "message", component="test", event="macro.started")
+    logging.close()
+    payload = json.loads((tmp_path / "framework.jsonl").read_text(encoding="utf-8"))
+
+    assert payload["event"] == "macro.started"
+    assert payload["run_id"] == "run-1"
+    assert payload["macro_id"] == "sample"
+
+
+def test_backend_exception_is_logged_and_dispatch_continues() -> None:
+    sink = TestLogSink()
+    sanitizer = LogSanitizer()
+    dispatcher = LogSinkDispatcher(sanitizer)
+    dispatcher.add_sink(sink, level="DEBUG")
+    logger = DefaultLogger(dispatcher, sanitizer, FailingBackend())
+
+    logger.technical("INFO", "message", component="test", event="macro.started")
+
+    assert [log.event.event for log in sink.technical_logs] == [
+        "backend.emit_failed",
+        "macro.started",
+    ]
 
 
 def test_user_event_does_not_include_traceback_or_secret() -> None:


### PR DESCRIPTION
## Summary

`LOGGING_FRAMEWORK.md` の `LogBackend` 設計に合わせ、`DefaultLogger` が backend を直接保持して framework JSONL 出力を担当する構成へ揃えます。

## Related

- ユーザ依頼: フレームワーク再設計実装の検証指摘への対処
- spec/framework/rearchitecture/LOGGING_FRAMEWORK.md の `LogBackend` / `backend.py` 設計

## Changes

- `src\nyxpy\framework\core\logger\backend.py` を追加し、`JsonlLogBackend` / `NullLogBackend` を実装
- `DefaultLogger` が `LogBackend` へ technical log を出力し、backend 失敗時も dispatcher 配信を継続
- `create_default_logging()` の framework JSONL 出力を sink ではなく backend 経由へ移行
- backend JSONL 出力、JSON 化不能値の縮退、backend 失敗隔離、factory wiring を単体テストで固定
- `LOGGING_FRAMEWORK.md` の完了済みチェックリストを更新

## Commit Log

```
6f8d8f4 fix(logger): LogBackendをDefaultLoggerへ接続
```

## Testing

```
$env:QT_QPA_PLATFORM='offscreen'; uv run pytest tests\unit\framework\logger\test_logging_framework.py tests\gui\test_log_pane_user_event.py tests\perf\test_logging_framework_perf.py tests\unit\cli\test_main.py
# 35 passed

$env:QT_QPA_PLATFORM='offscreen'; uv run pytest -m "not realdevice"
# 418 passed, 6 deselected, 1 warning

uv run ruff check .
# All checks passed

uv run ruff format src\nyxpy\framework\core\logger\backend.py src\nyxpy\framework\core\logger\default_logger.py src\nyxpy\framework\core\logger\factory.py src\nyxpy\framework\core\logger\__init__.py tests\unit\framework\logger\test_logging_framework.py --check
# 5 files already formatted
```

## Checklist

- [x] lint / format チェック通過
- [x] 既存テスト通過
- [x] コミット prefix (feat/fix 等) が変更の動機と一致している
- [x] 新規・変更コードに対するテスト追加（該当する場合）
- [x] 型チェック通過

## Review Notes

`LogPane` 向けの `UserEvent` 配信と run 単位 JSONL sink は既存 dispatcher 経路を維持しています。framework 全体 JSONL は `LogBackend` 側へ移しました。
