### PR TITLE
fix(cli): define引数の検証をConfigurationErrorへ統一

### DIFF
--- a/spec/framework/rearchitecture/ERROR_CANCELLATION_LOGGING.md
+++ b/spec/framework/rearchitecture/ERROR_CANCELLATION_LOGGING.md
@@ -555,7 +555,7 @@ class MacroArgsSchema:
 - [x] 既存 `finalize(cmd)` マクロの互換テスト作成
 - [ ] `macro args schema` と検証処理の実装
 - [ ] `SettingsStore` / `SecretsStore` schema 検証と secret マスク実装
-- [ ] `parse_define_args()` の `str` / `Iterable[str]` 対応と `ConfigurationError` 正規化
+- [x] `parse_define_args()` の `str` / `Iterable[str]` 対応と `ConfigurationError` 正規化
 - [ ] 異常・中断イベントを `LOGGING_FRAMEWORK.md` の `LoggerPort` へ接続
 - [x] `LogPane` への表示経路は `LOGGING_FRAMEWORK.md` の `UserEvent` 購読へ委譲
 - [x] `NotificationHandler` の通知失敗ログを構造化

--- a/src/nyxpy/framework/core/utils/helper.py
+++ b/src/nyxpy/framework/core/utils/helper.py
@@ -1,8 +1,13 @@
 import inspect
+from collections.abc import Iterable
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Any
 
 import tomlkit
+from tomlkit.exceptions import TOMLKitError
+
+from nyxpy.framework.core.macro.exceptions import ConfigurationError
 
 
 @dataclass(frozen=True)
@@ -42,7 +47,7 @@ def load_macro_settings(macro_cls) -> dict:
     return MacroSettingsResolver(Path.cwd()).load(definition)
 
 
-def parse_define_args(defines: list[str]) -> dict:
+def parse_define_args(defines: str | Iterable[str]) -> dict[str, Any]:
     """
     コマンドライン引数で渡された定義を解析して辞書に変換する関数
     key=value 形式の文字列を受け取り、tomlパーサに従う形で辞書に変換する。
@@ -63,9 +68,39 @@ def parse_define_args(defines: list[str]) -> dict:
 
     """
 
-    toml_str = "\n".join(defines)  # 引数を改行で結合
-    toml_str = toml_str.replace("=", " = ")  # 等号の前後にスペースを追加
-    exec_args = tomlkit.loads(toml_str)  # toml形式で解析
+    if isinstance(defines, str):
+        define_items = [defines]
+    else:
+        define_items = list(defines)
+
+    for index, define in enumerate(define_items):
+        if not isinstance(define, str):
+            raise ConfigurationError(
+                "define argument must be a string",
+                code="NYX_DEFINE_INVALID",
+                component="parse_define_args",
+                details={"index": index},
+            )
+        key, separator, _value = define.partition("=")
+        if not separator or not key.strip():
+            raise ConfigurationError(
+                "define argument must be key=value",
+                code="NYX_DEFINE_INVALID",
+                component="parse_define_args",
+                details={"index": index},
+            )
+
+    toml_str = "\n".join(define_items)
+    try:
+        exec_args = tomlkit.loads(toml_str)
+    except TOMLKitError as exc:
+        raise ConfigurationError(
+            "failed to parse define arguments",
+            code="NYX_DEFINE_PARSE_FAILED",
+            component="parse_define_args",
+            details={"exception_type": type(exc).__name__},
+            cause=exc,
+        ) from exc
 
     # 変換された辞書を返す
     return exec_args

--- a/tests/unit/executor/test_helper.py
+++ b/tests/unit/executor/test_helper.py
@@ -13,6 +13,7 @@ from types import SimpleNamespace
 
 import pytest
 
+from nyxpy.framework.core.macro.exceptions import ConfigurationError
 from nyxpy.framework.core.utils.helper import (
     calc_aspect_size,
     extract_macro_tags,
@@ -153,6 +154,36 @@ class TestParseDefineArgs:
         """bool 値のパース"""
         result = parse_define_args(["flag=true"])
         assert result["flag"] is True
+
+    def test_accepts_single_define_string(self):
+        """単一文字列入力を 1 つの define として扱う"""
+        result = parse_define_args("count=42")
+        assert result["count"] == 42
+
+    def test_accepts_iterable_defines(self):
+        """list 以外の Iterable[str] 入力を受け付ける"""
+        result = parse_define_args(iter(['name="test"', "value=100"]))
+        assert result["name"] == "test"
+        assert result["value"] == 100
+
+    def test_equal_sign_inside_string_value(self):
+        """値の中の = を壊さず TOML として解釈する"""
+        result = parse_define_args(['token="a=b"'])
+        assert result["token"] == "a=b"
+
+    def test_invalid_missing_separator_raises_configuration_error(self):
+        with pytest.raises(ConfigurationError) as exc_info:
+            parse_define_args(["flag"])
+
+        assert exc_info.value.code == "NYX_DEFINE_INVALID"
+        assert exc_info.value.component == "parse_define_args"
+
+    def test_invalid_toml_raises_configuration_error(self):
+        with pytest.raises(ConfigurationError) as exc_info:
+            parse_define_args(['name="unterminated'])
+
+        assert exc_info.value.code == "NYX_DEFINE_PARSE_FAILED"
+        assert exc_info.value.component == "parse_define_args"
 
 
 # ============================================================


### PR DESCRIPTION
## Summary

CLI/GUI の define 入力を `ConfigurationError` へ正規化し、`str` と `Iterable[str]` の入力を明示的にサポートします。

## Related

- User request: 再設計実装の検証で見つかった残課題を重要度順に修正し、PR 経由で取り込む
- spec\framework\rearchitecture\ERROR_CANCELLATION_LOGGING.md

## Changes

- `parse_define_args()` で単一文字列を 1 件の define として扱い、list 以外の Iterable も受け付けるように変更
- `key=value` でない入力や TOML 解析失敗を `NYX_DEFINE_INVALID` / `NYX_DEFINE_PARSE_FAILED` の `ConfigurationError` に統一
- 値に含まれる `=` を壊さないよう、define 全体への置換処理を廃止
- 該当チェックリストを実装済みに更新

## Commit Log

```
6cdfdb8 fix(cli): define引数の検証をConfigurationErrorへ統一
```

## Testing

```
uv run pytest tests\unit\executor\test_helper.py tests\unit\cli\test_main.py tests\integration\test_cli_runtime_adapter.py
$env:QT_QPA_PLATFORM='offscreen'; uv run pytest -m "not realdevice"
uv run ruff check .
uv run ruff format src\nyxpy\framework\core\utils\helper.py tests\unit\executor\test_helper.py --check
```

## Checklist

- [x] lint / format チェック通過
- [x] 既存テスト通過
- [x] コミット prefix (feat/fix 等) が変更の動機と一致している
- [x] 新規・変更コードに対するテスト追加（該当する場合）
- [ ] 型チェック通過