### PR TITLE
refactor(gui): 仮想コントローラー送信をPort経由へ移行

### DIFF
--- a/spec/framework/rearchitecture/RUNTIME_AND_IO_PORTS.md
+++ b/spec/framework/rearchitecture/RUNTIME_AND_IO_PORTS.md
@@ -778,7 +778,7 @@ Runtime 自体は原則としてシングルトンにしない。GUI と CLI が
 - [x] 本番 Runtime 経路で暗黙 dummy fallback を禁止
 - [x] GUI の `DefaultCommand` 直接構築を Runtime 利用へ移行
 - [x] CLI の `DefaultCommand` 直接構築を Runtime 利用へ移行
-- [ ] `VirtualControllerModel` を `ControllerOutputPort` 利用へ移行
+- [x] `VirtualControllerModel` を `ControllerOutputPort` 利用へ移行
 - [ ] `singletons.py` の `reset_for_testing()` が Runtime/Port 関連状態を初期化
 
 ### 6.3 検証

--- a/src/nyxpy/gui/models/virtual_controller_model.py
+++ b/src/nyxpy/gui/models/virtual_controller_model.py
@@ -4,6 +4,8 @@ from nyxpy.framework.core.constants import Button, Hat, LStick, RStick
 from nyxpy.framework.core.hardware.protocol import SerialProtocolInterface
 from nyxpy.framework.core.hardware.protocol_factory import ProtocolFactory
 from nyxpy.framework.core.hardware.serial_comm import SerialCommInterface
+from nyxpy.framework.core.io.adapters import SerialControllerOutputPort
+from nyxpy.framework.core.io.ports import ControllerOutputPort
 from nyxpy.framework.core.logger import LoggerPort
 from nyxpy.gui.events import EventBus, EventType
 
@@ -17,13 +19,17 @@ class VirtualControllerModel(QObject):
     def __init__(
         self,
         logger: LoggerPort,
+        controller: ControllerOutputPort | None = None,
         serial_device: SerialCommInterface | None = None,
         protocol: SerialProtocolInterface | None = None,
     ) -> None:
         super().__init__()
         self.logger = logger
-        self.serial_device = serial_device
         self.protocol = protocol or ProtocolFactory.create_protocol("CH552")
+        self.serial_device = serial_device
+        self.controller = controller
+        if self.controller is None and self.serial_device is not None:
+            self.controller = SerialControllerOutputPort(self.serial_device, self.protocol)
         self.event_bus = EventBus.get_instance()
         self.event_bus.subscribe(EventType.SERIAL_DEVICE_CHANGED, self.on_serial_device_changed)
         self.event_bus.subscribe(EventType.PROTOCOL_CHANGED, self.on_protocol_changed)
@@ -37,10 +43,17 @@ class VirtualControllerModel(QObject):
     def set_serial_device(self, serial_device: SerialCommInterface) -> None:
         """シリアルデバイスを設定"""
         self.serial_device = serial_device
+        self.controller = SerialControllerOutputPort(serial_device, self.protocol)
+
+    def set_controller(self, controller: ControllerOutputPort | None) -> None:
+        """コントローラー出力 Port を設定"""
+        self.controller = controller
 
     def set_protocol(self, protocol: SerialProtocolInterface) -> None:
         """シリアルプロトコルを設定"""
         self.protocol = protocol
+        if self.serial_device is not None:
+            self.controller = SerialControllerOutputPort(self.serial_device, self.protocol)
 
     def button_press(self, button: Button) -> None:
         """ボタンが押されたときの処理"""
@@ -98,11 +111,10 @@ class VirtualControllerModel(QObject):
             self.current_r_stick = RStick.CENTER
 
     def send_release_command(self, keys: tuple[Button | Hat | LStick | RStick, ...]) -> None:
-        if not self.serial_device:
+        if self.controller is None:
             return
         try:
-            command_data = self.protocol.build_release_command(keys)
-            self.serial_device.send(command_data)
+            self.controller.release(keys)
         except Exception as e:
             self.logger.technical(
                 "ERROR",
@@ -111,14 +123,13 @@ class VirtualControllerModel(QObject):
                 event="controller.release_failed",
                 exc=e,
             )
-            raise e
+            raise
 
     def send_press_command(self, keys: tuple[Button | Hat | LStick | RStick, ...]) -> None:
-        if not self.serial_device:
+        if self.controller is None:
             return
         try:
-            command_data = self.protocol.build_press_command(keys)
-            self.serial_device.send(command_data)
+            self.controller.press(keys)
         except Exception as e:
             self.logger.technical(
                 "ERROR",
@@ -127,7 +138,7 @@ class VirtualControllerModel(QObject):
                 event="controller.press_failed",
                 exc=e,
             )
-            raise e
+            raise
 
     def on_serial_device_changed(self, data):
         self.set_serial_device(data["device"])

--- a/tests/gui/test_virtual_controller_model.py
+++ b/tests/gui/test_virtual_controller_model.py
@@ -1,0 +1,72 @@
+import pytest
+
+from nyxpy.framework.core.constants import Button, Hat
+from nyxpy.gui.events import EventBus, EventType
+from nyxpy.gui.models.virtual_controller_model import VirtualControllerModel
+from tests.support.fakes import FakeControllerOutputPort, FakeLoggerPort
+
+
+@pytest.fixture(autouse=True)
+def reset_event_bus():
+    EventBus._instance = None
+    yield
+    EventBus._instance = None
+
+
+def test_button_operations_use_controller_output_port() -> None:
+    controller = FakeControllerOutputPort()
+    model = VirtualControllerModel(logger=FakeLoggerPort(), controller=controller)
+
+    model.button_press(Button.A)
+    model.button_release(Button.A)
+
+    assert controller.events == [
+        ("press", (Button.A,)),
+        ("release", (Button.A,)),
+    ]
+
+
+def test_hat_center_releases_previous_direction() -> None:
+    controller = FakeControllerOutputPort()
+    model = VirtualControllerModel(logger=FakeLoggerPort(), controller=controller)
+
+    model.set_hat_direction(Hat.UP)
+    model.set_hat_direction(Hat.CENTER)
+
+    assert controller.events == [
+        ("press", (Hat.UP,)),
+        ("release", (Hat.UP,)),
+    ]
+
+
+def test_missing_controller_is_noop() -> None:
+    model = VirtualControllerModel(logger=FakeLoggerPort(), controller=None)
+
+    model.button_press(Button.B)
+    model.button_release(Button.B)
+
+    assert model.pressed_buttons == set()
+
+
+def test_serial_device_event_replaces_controller_port() -> None:
+    class SerialDevice:
+        def __init__(self) -> None:
+            self.sent: list[bytes] = []
+
+        def send(self, data: bytes) -> None:
+            self.sent.append(data)
+
+    class Protocol:
+        def build_press_command(self, keys):
+            return b"press:" + b",".join(key.name.encode() for key in keys)
+
+        def build_release_command(self, keys=()):
+            return b"release:" + b",".join(key.name.encode() for key in keys)
+
+    serial = SerialDevice()
+    model = VirtualControllerModel(logger=FakeLoggerPort(), protocol=Protocol())
+
+    EventBus.get_instance().publish(EventType.SERIAL_DEVICE_CHANGED, {"device": serial})
+    model.button_press(Button.X)
+
+    assert serial.sent == [b"press:X"]

--- a/tests/integration/test_macro_runtime_entrypoints.py
+++ b/tests/integration/test_macro_runtime_entrypoints.py
@@ -35,3 +35,12 @@ def test_gui_cli_runtime_builder_paths_do_not_resolve_devices_directly() -> None
     assert "get_active_device" not in cli_source
     assert "auto_register_devices" not in cli_source
     assert "get_active_device" not in gui_source
+
+
+def test_virtual_controller_model_uses_controller_output_port() -> None:
+    from nyxpy.gui.models.virtual_controller_model import VirtualControllerModel
+
+    source = inspect.getsource(VirtualControllerModel)
+
+    assert "ControllerOutputPort" in source
+    assert ".send(" not in source


### PR DESCRIPTION
## Summary

VirtualControllerModel の直接シリアル送信をやめ、ControllerOutputPort 経由の送信へ移行します。

## Related

- User request: 再設計実装の検証で見つかった残課題を重要度順に修正し、PR 経由で取り込む
- spec\framework\rearchitecture\RUNTIME_AND_IO_PORTS.md

## Changes

- VirtualControllerModel が ControllerOutputPort を保持し、press/release を Port 経由で送信するよう変更
- 既存の serial/protocol イベント経路は SerialControllerOutputPort を組み立てて互換維持
- GUI モデルの単体テストと Runtime entrypoint の静的ゲートを追加
- 該当チェックリストを実装済みに更新

## Commit Log

```
687ac36 refactor(gui): 仮想コントローラー送信をPort経由へ移行
```

## Testing

```
$env:QT_QPA_PLATFORM='offscreen'; uv run pytest tests\gui\test_virtual_controller_model.py tests\integration\test_macro_runtime_entrypoints.py
$env:QT_QPA_PLATFORM='offscreen'; uv run pytest -m "not realdevice"
uv run ruff check .
uv run ruff format src\nyxpy\gui\models\virtual_controller_model.py tests\gui\test_virtual_controller_model.py tests\integration\test_macro_runtime_entrypoints.py --check
```

## Checklist

- [x] lint / format チェック通過
- [x] 既存テスト通過
- [x] コミット prefix (feat/fix 等) が変更の動機と一致している
- [x] 新規・変更コードに対するテスト追加（該当する場合）
- [ ] 型チェック通過