### PR TITLE
feat(runtime): 通知Port adapterを明示実装

### DIFF
--- a/spec/framework/rearchitecture/RUNTIME_AND_IO_PORTS.md
+++ b/spec/framework/rearchitecture/RUNTIME_AND_IO_PORTS.md
@@ -772,7 +772,7 @@ Runtime 自体は原則としてシングルトンにしない。GUI と CLI が
 - [x] `CaptureFrameSourcePort` と frame readiness 実装
 - [x] Resource File I/O の path traversal 防止を `RESOURCE_FILE_IO.md` に従って実装
 - [x] Resource File I/O の atomic write と overwrite policy を `RESOURCE_FILE_IO.md` に従って実装
-- [ ] `NotificationHandlerAdapter` と `NoopNotificationAdapter` 実装
+- [x] `NotificationHandlerAdapter` と `NoopNotificationAdapter` 実装
 - [x] `LoggerPort` adapter 実装
 - [x] serial/capture detection race を避ける検出完了待ち API 実装
 - [x] 本番 Runtime 経路で暗黙 dummy fallback を禁止

--- a/src/nyxpy/framework/core/io/__init__.py
+++ b/src/nyxpy/framework/core/io/__init__.py
@@ -1,5 +1,7 @@
 from nyxpy.framework.core.io.adapters import (
     CaptureFrameSourcePort,
+    NoopNotificationAdapter,
+    NotificationHandlerAdapter,
     NotificationHandlerPort,
     SerialControllerOutputPort,
 )
@@ -40,6 +42,8 @@ __all__ = [
     "LocalRunArtifactStore",
     "FrameSourcePort",
     "MacroResourceScope",
+    "NoopNotificationAdapter",
+    "NotificationHandlerAdapter",
     "NotificationPort",
     "NotificationHandlerPort",
     "OverwritePolicy",

--- a/src/nyxpy/framework/core/io/adapters.py
+++ b/src/nyxpy/framework/core/io/adapters.py
@@ -96,10 +96,18 @@ class CaptureFrameSourcePort(FrameSourcePort):
         pass
 
 
-class NotificationHandlerPort(NotificationPort):
+class NotificationHandlerAdapter(NotificationPort):
     def __init__(self, notification_handler) -> None:
         self.notification_handler = notification_handler
 
     def publish(self, text: str, img: cv2.typing.MatLike | None = None) -> None:
-        if self.notification_handler is not None:
-            self.notification_handler.publish(text, img)
+        self.notification_handler.publish(text, img)
+
+
+class NoopNotificationAdapter(NotificationPort):
+    def publish(self, text: str, img: cv2.typing.MatLike | None = None) -> None:
+        pass
+
+
+class NotificationHandlerPort(NotificationHandlerAdapter):
+    """Backward-compatible alias for the notification port adapter."""

--- a/src/nyxpy/framework/core/runtime/builder.py
+++ b/src/nyxpy/framework/core/runtime/builder.py
@@ -10,7 +10,8 @@ from uuid import uuid4
 from nyxpy.framework.core.hardware.protocol import SerialProtocolInterface
 from nyxpy.framework.core.io.adapters import (
     CaptureFrameSourcePort,
-    NotificationHandlerPort,
+    NoopNotificationAdapter,
+    NotificationHandlerAdapter,
     SerialControllerOutputPort,
 )
 from nyxpy.framework.core.io.ports import (
@@ -201,8 +202,10 @@ def create_legacy_runtime_builder(
             macro_id=definition.id,
             run_id=run_id,
         ),
-        notification_factory=lambda _request, _definition: NotificationHandlerPort(
-            notification_handler
+        notification_factory=lambda _request, _definition: (
+            NoopNotificationAdapter()
+            if notification_handler is None
+            else NotificationHandlerAdapter(notification_handler)
         ),
         logger_factory=lambda _request, _definition: logger,
     )

--- a/tests/unit/framework/io/test_adapters.py
+++ b/tests/unit/framework/io/test_adapters.py
@@ -6,6 +6,8 @@ import pytest
 from nyxpy.framework.core.constants import Button, KeyboardOp, KeyCode
 from nyxpy.framework.core.io.adapters import (
     CaptureFrameSourcePort,
+    NoopNotificationAdapter,
+    NotificationHandlerAdapter,
     NotificationHandlerPort,
     SerialControllerOutputPort,
 )
@@ -130,6 +132,22 @@ def test_notification_port_forwards_to_handler() -> None:
             calls.append((text, img))
 
     image = np.zeros((1, 1, 3), dtype=np.uint8)
-    NotificationHandlerPort(Handler()).publish("hello", image)
+    NotificationHandlerAdapter(Handler()).publish("hello", image)
 
     assert calls == [("hello", image)]
+
+
+def test_notification_handler_port_remains_backward_compatible() -> None:
+    calls = []
+
+    class Handler:
+        def publish(self, text, img=None) -> None:
+            calls.append((text, img))
+
+    NotificationHandlerPort(Handler()).publish("hello")
+
+    assert calls == [("hello", None)]
+
+
+def test_noop_notification_adapter_ignores_publish() -> None:
+    NoopNotificationAdapter().publish("hello")

--- a/tests/unit/framework/runtime/test_runtime_builder.py
+++ b/tests/unit/framework/runtime/test_runtime_builder.py
@@ -2,6 +2,7 @@ from pathlib import Path
 
 import pytest
 
+from nyxpy.framework.core.io.adapters import NoopNotificationAdapter, NotificationHandlerAdapter
 from nyxpy.framework.core.macro.exceptions import ConfigurationError
 from nyxpy.framework.core.macro.registry import MacroDefinition
 from nyxpy.framework.core.runtime.builder import DUMMY_DEVICE_NAME, create_legacy_runtime_builder
@@ -76,13 +77,14 @@ def make_builder(
     capture_manager: CaptureDeviceManager,
     **kwargs,
 ):
+    notification_handler = kwargs.pop("notification_handler", None)
     return create_legacy_runtime_builder(
         project_root=tmp_path,
         registry=Registry(definition(tmp_path)),
         serial_manager=serial_manager,
         capture_manager=capture_manager,
         protocol=object(),
-        notification_handler=None,
+        notification_handler=notification_handler,
         logger=FakeLoggerPort(),
         **kwargs,
     )
@@ -110,6 +112,19 @@ def test_runtime_builder_allows_dummy_when_explicit(tmp_path: Path) -> None:
     assert context.options.allow_dummy is True
     assert serial.active_device is serial.devices[DUMMY_DEVICE_NAME]
     assert capture.active_device is capture.devices[DUMMY_DEVICE_NAME]
+    assert isinstance(context.notifications, NoopNotificationAdapter)
+
+
+def test_runtime_builder_wraps_notification_handler(tmp_path: Path) -> None:
+    serial = DeviceManager({DUMMY_DEVICE_NAME: Device()})
+    capture = CaptureDeviceManager({DUMMY_DEVICE_NAME: Device()})
+    handler = object()
+    builder = make_builder(tmp_path, serial, capture, notification_handler=handler)
+
+    context = builder.build(RuntimeBuildRequest(macro_id="sample", allow_dummy=True))
+
+    assert isinstance(context.notifications, NotificationHandlerAdapter)
+    assert context.notifications.notification_handler is handler
 
 
 def test_runtime_builder_selects_requested_devices(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

通知 Port の adapter 実装を明示し、handler あり/なしを Runtime builder で型として分けます。

## Related

- User request: 再設計実装の検証で見つかった残課題を重要度順に修正し、PR 経由で取り込む
- spec\framework\rearchitecture\RUNTIME_AND_IO_PORTS.md

## Changes

- NotificationHandlerAdapter と NoopNotificationAdapter を追加
- 既存 NotificationHandlerPort は後方互換 alias として維持
- Runtime builder が notification_handler=None のとき NoopNotificationAdapter を注入するよう変更
- adapter と builder wiring の単体テストを追加
- 該当チェックリストを実装済みに更新

## Commit Log

```
32e6a5b feat(runtime): 通知Port adapterを明示実装
```

## Testing

```
uv run pytest tests\unit\framework\io\test_adapters.py tests\unit\framework\runtime\test_runtime_builder.py
$env:QT_QPA_PLATFORM='offscreen'; uv run pytest -m "not realdevice"
uv run ruff check .
uv run ruff format src\nyxpy\framework\core\io\adapters.py src\nyxpy\framework\core\io\__init__.py src\nyxpy\framework\core\runtime\builder.py tests\unit\framework\io\test_adapters.py tests\unit\framework\runtime\test_runtime_builder.py --check
```

## Checklist

- [x] lint / format チェック通過
- [x] 既存テスト通過
- [x] コミット prefix (feat/fix 等) が変更の動機と一致している
- [x] 新規・変更コードに対するテスト追加（該当する場合）
- [ ] 型チェック通過