### PR TITLE
fix(runtime): 失敗と中断を技術ログへ記録

### DIFF
--- a/spec/framework/rearchitecture/ERROR_CANCELLATION_LOGGING.md
+++ b/spec/framework/rearchitecture/ERROR_CANCELLATION_LOGGING.md
@@ -556,7 +556,7 @@ class MacroArgsSchema:
 - [ ] `macro args schema` と検証処理の実装
 - [ ] `SettingsStore` / `SecretsStore` schema 検証と secret マスク実装
 - [x] `parse_define_args()` の `str` / `Iterable[str]` 対応と `ConfigurationError` 正規化
-- [ ] 異常・中断イベントを `LOGGING_FRAMEWORK.md` の `LoggerPort` へ接続
+- [x] 異常・中断イベントを `LOGGING_FRAMEWORK.md` の `LoggerPort` へ接続
 - [x] `LogPane` への表示経路は `LOGGING_FRAMEWORK.md` の `UserEvent` 購読へ委譲
 - [x] `NotificationHandler` の通知失敗ログを構造化
 - [x] CLI 通知設定ソースを secrets snapshot に統一

--- a/spec/framework/rearchitecture/LOGGING_FRAMEWORK.md
+++ b/spec/framework/rearchitecture/LOGGING_FRAMEWORK.md
@@ -468,7 +468,7 @@ sink 例外はマクロ実行結果を失敗にしない。ただし技術ログ
 - [x] `TestLogSink` を実装
 - [x] ログファイル配置、rotation、保持期間、cleanup を実装
 - [x] `LogPane` を `UserEvent` 購読へ移行
-- [ ] 通知失敗と Runtime 失敗を技術ログへ記録
+- [x] 通知失敗と Runtime 失敗を技術ログへ記録
 
 ### 6.3 検証
 

--- a/src/nyxpy/framework/core/runtime/runtime.py
+++ b/src/nyxpy/framework/core/runtime/runtime.py
@@ -65,10 +65,11 @@ class MacroRuntime:
             cleanup_warnings = self._close_ports(context)
 
         if cleanup_warnings:
-            return replace(
+            result = replace(
                 result,
                 cleanup_warnings=(*result.cleanup_warnings, *cleanup_warnings),
             )
+        self._emit_result_log(context, result)
         return result
 
     def start(self, context: ExecutionContext) -> RunHandle:
@@ -135,6 +136,48 @@ class MacroRuntime:
             recoverable=False,
             details={},
             traceback=traceback.format_exc(),
+        )
+
+    def _emit_result_log(self, context: ExecutionContext, result: RunResult) -> None:
+        if result.status is RunStatus.SUCCESS:
+            return
+
+        error = result.error
+        extra = {
+            "status": result.status.value,
+            "run_id": result.run_id,
+            "macro_id": result.macro_id,
+            "macro_name": result.macro_name,
+            "cleanup_warning_count": len(result.cleanup_warnings),
+        }
+        if error is not None:
+            extra.update(
+                {
+                    "error_kind": error.kind.value,
+                    "error_code": error.code,
+                    "error_component": error.component,
+                    "exception_type": error.exception_type,
+                    "recoverable": error.recoverable,
+                    "details": error.details,
+                }
+            )
+
+        if result.status is RunStatus.CANCELLED:
+            context.logger.technical(
+                "WARNING",
+                "macro cancelled",
+                component="MacroRuntime",
+                event="runtime.cancelled",
+                extra=extra,
+            )
+            return
+
+        context.logger.technical(
+            "ERROR",
+            "macro failed",
+            component="MacroRuntime",
+            event="runtime.failed",
+            extra=extra,
         )
 
     def _close_ports(self, context: ExecutionContext) -> tuple[CleanupWarning, ...]:

--- a/tests/unit/framework/runtime/test_macro_runtime.py
+++ b/tests/unit/framework/runtime/test_macro_runtime.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 from nyxpy.framework.core.macro.base import MacroBase
 from nyxpy.framework.core.macro.command import Command
+from nyxpy.framework.core.macro.exceptions import MacroStopException
 from nyxpy.framework.core.macro.registry import MacroDefinition
 from nyxpy.framework.core.runtime.result import RunStatus
 from nyxpy.framework.core.runtime.runtime import MacroRuntime
@@ -48,6 +49,18 @@ class RecordingMacro(MacroBase):
 
     def finalize(self, cmd: Command) -> None:
         self.calls.append("finalize")
+
+
+class ErrorMacro(RecordingMacro):
+    def run(self, cmd: Command) -> None:
+        self.calls.append("run")
+        raise RuntimeError("boom")
+
+
+class StopMacro(RecordingMacro):
+    def run(self, cmd: Command) -> None:
+        self.calls.append("run")
+        raise MacroStopException("stop")
 
 
 class NotReadyFrameSource(FakeFrameSourcePort):
@@ -101,6 +114,38 @@ def test_macro_runtime_pre_run_frame_not_ready_returns_failed_result(tmp_path) -
     assert result.error is not None
     assert result.error.code == "NYX_FRAME_NOT_READY"
     assert macro.calls == []
+    log = context.logger.technical_logs[-1].event
+    assert log.event == "runtime.failed"
+    assert log.extra["error_code"] == "NYX_FRAME_NOT_READY"
+
+
+def test_macro_runtime_logs_macro_failure_result(tmp_path) -> None:
+    macro = ErrorMacro()
+    context = make_fake_execution_context(tmp_path)
+    runtime = MacroRuntime(Registry(definition_for(macro)))
+
+    result = runtime.run(context)
+
+    assert result.status is RunStatus.FAILED
+    log = context.logger.technical_logs[-1].event
+    assert log.event == "runtime.failed"
+    assert log.level == "ERROR"
+    assert log.extra["error_code"] == "NYX_MACRO_FAILED"
+    assert log.extra["exception_type"] == "RuntimeError"
+
+
+def test_macro_runtime_logs_cancelled_result(tmp_path) -> None:
+    macro = StopMacro()
+    context = make_fake_execution_context(tmp_path)
+    runtime = MacroRuntime(Registry(definition_for(macro)))
+
+    result = runtime.run(context)
+
+    assert result.status is RunStatus.CANCELLED
+    log = context.logger.technical_logs[-1].event
+    assert log.event == "runtime.cancelled"
+    assert log.level == "WARNING"
+    assert log.extra["error_code"] == "NYX_MACRO_CANCELLED"
 
 
 def test_macro_runtime_adds_cleanup_warnings_without_overwriting_status(tmp_path) -> None:


### PR DESCRIPTION
## Summary

MacroRuntime の失敗・中断結果を LoggerPort の技術ログへ記録します。

## Related

- User request: 再設計実装の検証で見つかった残課題を重要度順に修正し、PR 経由で取り込む
- spec\framework\rearchitecture\LOGGING_FRAMEWORK.md
- spec\framework\rearchitecture\ERROR_CANCELLATION_LOGGING.md

## Changes

- MacroRuntime が FAILED / CANCELLED の RunResult を返す前に `runtime.failed` / `runtime.cancelled` 技術ログを出力
- error code、kind、component、exception_type、cleanup warning count を構造化 extra に含める
- pre-run failure、macro failure、cancelled のログテストを追加
- 該当チェックリストを実装済みに更新

## Commit Log

```
0a7c5d1 fix(runtime): 失敗と中断を技術ログへ記録
```

## Testing

```
uv run pytest tests\unit\framework\runtime\test_macro_runtime.py tests\unit\framework\logger\test_logging_framework.py
$env:QT_QPA_PLATFORM='offscreen'; uv run pytest -m "not realdevice"
uv run ruff check .
uv run ruff format src\nyxpy\framework\core\runtime\runtime.py tests\unit\framework\runtime\test_macro_runtime.py --check
```

## Checklist

- [x] lint / format チェック通過
- [x] 既存テスト通過
- [x] コミット prefix (feat/fix 等) が変更の動機と一致している
- [x] 新規・変更コードに対するテスト追加（該当する場合）
- [ ] 型チェック通過