### PR TITLE
feat(settings): Store schema検証とsecretマスクを追加

### DIFF
--- a/spec/framework/rearchitecture/CONFIGURATION_AND_RESOURCES.md
+++ b/spec/framework/rearchitecture/CONFIGURATION_AND_RESOURCES.md
@@ -313,7 +313,7 @@ Resource File I/O の path guard、画像読み書き、atomic write、`cmd.save
 
 ## 6. 実装チェックリスト
 
-- [ ] `SettingsStore` / `SecretsStore` schema の公開 API を確定
+- [x] `SettingsStore` / `SecretsStore` schema の公開 API を確定
 - [x] 通常設定と秘密設定の境界を Runtime builder に反映
 - [x] `MacroSettingsResolver` を Resource File I/O から分離
 - [x] `static\<macro_name>\settings.toml` と `Path.cwd()` fallback を削除

--- a/spec/framework/rearchitecture/ERROR_CANCELLATION_LOGGING.md
+++ b/spec/framework/rearchitecture/ERROR_CANCELLATION_LOGGING.md
@@ -554,7 +554,7 @@ class MacroArgsSchema:
 - [x] `MacroExecutor` を削除対象とし、Runtime / Runner での `RunResult` 生成・例外正規化・`finalize` outcome 伝達を固定
 - [x] 既存 `finalize(cmd)` マクロの互換テスト作成
 - [ ] `macro args schema` と検証処理の実装
-- [ ] `SettingsStore` / `SecretsStore` schema 検証と secret マスク実装
+- [x] `SettingsStore` / `SecretsStore` schema 検証と secret マスク実装
 - [x] `parse_define_args()` の `str` / `Iterable[str]` 対応と `ConfigurationError` 正規化
 - [x] 異常・中断イベントを `LOGGING_FRAMEWORK.md` の `LoggerPort` へ接続
 - [x] `LogPane` への表示経路は `LOGGING_FRAMEWORK.md` の `UserEvent` 購読へ委譲

--- a/src/nyxpy/framework/core/settings/global_settings.py
+++ b/src/nyxpy/framework/core/settings/global_settings.py
@@ -1,59 +1,128 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
 from pathlib import Path
+from threading import RLock
+from typing import Any
 
 import tomlkit
+from tomlkit.exceptions import TOMLKitError
+
+from nyxpy.framework.core.macro.exceptions import ConfigurationError
+from nyxpy.framework.core.settings.schema import (
+    SecretBoundaryError,
+    SettingField,
+    SettingsSchema,
+    SettingValue,
+    dotted_get,
+    dotted_set,
+    freeze_mapping,
+)
+
+GLOBAL_SETTINGS_SCHEMA = SettingsSchema(
+    fields={
+        "capture_device": SettingField("capture_device", str, ""),
+        "serial_device": SettingField("serial_device", str, ""),
+        "serial_baud": SettingField("serial_baud", int, 9600),
+        "serial_protocol": SettingField("serial_protocol", str, "CH552"),
+        "runtime.allow_dummy": SettingField("runtime.allow_dummy", bool, False),
+        "runtime.frame_ready_timeout_sec": SettingField(
+            "runtime.frame_ready_timeout_sec", float, 3.0
+        ),
+        "logging.file_level": SettingField(
+            "logging.file_level",
+            str,
+            "DEBUG",
+            choices=("DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"),
+        ),
+        "logging.gui_level": SettingField(
+            "logging.gui_level",
+            str,
+            "INFO",
+            choices=("DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"),
+        ),
+    }
+)
 
 
-class GlobalSettings:
+class SettingsStore:
+    schema: SettingsSchema
+
+    def __init__(
+        self,
+        config_dir: Path | None = None,
+        *,
+        schema: SettingsSchema = GLOBAL_SETTINGS_SCHEMA,
+        filename: str = "global.toml",
+        strict_load: bool = True,
+    ) -> None:
+        if any(field.secret for field in schema.fields.values()):
+            raise SecretBoundaryError("SettingsStore schema must not contain secret fields")
+        self.config_dir = config_dir or Path.cwd() / ".nyxpy"
+        self.config_dir.mkdir(exist_ok=True)
+        self.config_path = self.config_dir / filename
+        self.schema = schema
+        self.strict_load = strict_load
+        self._lock = RLock()
+        self.data: dict[str, SettingValue] = {}
+        self.load()
+
+    def load(self) -> None:
+        with self._lock:
+            try:
+                if self.config_path.exists():
+                    loaded = tomlkit.loads(self.config_path.read_text(encoding="utf-8"))
+                    self.data = self.schema.validate(loaded)
+                else:
+                    self.data = self.schema.defaults()
+                    self.save()
+            except TOMLKitError as exc:
+                if self.strict_load:
+                    raise ConfigurationError(
+                        "failed to parse settings file",
+                        code="NYX_SETTINGS_PARSE_FAILED",
+                        component=type(self).__name__,
+                        details={
+                            "path": self.config_path.name,
+                            "exception_type": type(exc).__name__,
+                        },
+                        cause=exc,
+                    ) from exc
+                self.data = self.schema.defaults()
+            except ConfigurationError:
+                if self.strict_load:
+                    raise
+                self.data = self.schema.defaults()
+
+    def save(self) -> None:
+        with self._lock:
+            self.data = self.schema.validate(self.data)
+            tmp_path = self.config_path.with_suffix(f"{self.config_path.suffix}.tmp")
+            tmp_path.write_text(tomlkit.dumps(self.data), encoding="utf-8")
+            tmp_path.replace(self.config_path)
+
+    def snapshot(self) -> Mapping[str, SettingValue]:
+        with self._lock:
+            return freeze_mapping(self.data)
+
+    def validate(self) -> None:
+        with self._lock:
+            self.data = self.schema.validate(self.data)
+
+    def get(self, key: str, default: Any = None) -> Any:
+        with self._lock:
+            return dotted_get(self.data, key, default)
+
+    def set(self, key: str, value: SettingValue) -> None:
+        with self._lock:
+            dotted_set(self.data, key, value)
+            self.save()
+
+
+class GlobalSettings(SettingsStore):
     """
     Manage global settings stored in .nyxpy/global.toml under the working directory.
     """
 
-    def __init__(self):
-        self.config_dir = Path.cwd() / ".nyxpy"
-        self.config_dir.mkdir(exist_ok=True)
-        self.config_path = self.config_dir / "global.toml"
-        self.data = {}
-        self.load()
-
-    def load(self):
-        if self.config_path.exists():
-            text = self.config_path.read_text(encoding="utf-8")
-            self.data = tomlkit.loads(text)
-        else:
-            # default global settings and persist initial config during init
-            self.data = {
-                "capture_device": "",
-                "serial_device": "",
-                "serial_baud": 9600,
-                "serial_protocol": "CH552",  # デフォルトで CH552 プロトコルを使用
-            }
-            # create initial config file
-            self.save()
-
-    def save(self):
-        toml_str = tomlkit.dumps(self.data)
-        self.config_path.write_text(toml_str, encoding="utf-8")
-
-    def get(self, key, default=None):
-        # ドット区切りキーでネストdictにも対応
-        if "." in key:
-            parts = key.split(".")
-            d = self.data
-            for p in parts[:-1]:
-                d = d.get(p, {})
-            return d.get(parts[-1], default)
-        return self.data.get(key, default)
-
-    def set(self, key, value):
-        # ドット区切りキーでネストdictにも対応
-        if "." in key:
-            parts = key.split(".")
-            d = self.data
-            for p in parts[:-1]:
-                if p not in d or not isinstance(d[p], dict):
-                    d[p] = {}
-                d = d[p]
-            d[parts[-1]] = value
-        else:
-            self.data[key] = value
-        self.save()
+    def __init__(self, config_dir: Path | None = None) -> None:
+        super().__init__(config_dir=config_dir, strict_load=False)

--- a/src/nyxpy/framework/core/settings/schema.py
+++ b/src/nyxpy/framework/core/settings/schema.py
@@ -1,0 +1,204 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from types import MappingProxyType
+from typing import Any
+
+from nyxpy.framework.core.macro.exceptions import ConfigurationError
+
+type SettingValue = str | int | float | bool | list[SettingValue] | dict[str, SettingValue] | None
+
+_MISSING = object()
+
+
+class SecretBoundaryError(ConfigurationError):
+    def __init__(self, message: str = "secret boundary violation", **kwargs: object) -> None:
+        super().__init__(
+            message,
+            code=str(kwargs.pop("code", "NYX_SECRET_BOUNDARY_INVALID")),
+            component=str(kwargs.pop("component", "SecretBoundary")),
+            details=kwargs.pop("details", None),
+            cause=kwargs.pop("cause", None),
+        )
+
+
+@dataclass(frozen=True)
+class SettingField:
+    name: str
+    type_: type | tuple[type, ...]
+    default: SettingValue
+    secret: bool = False
+    required: bool = False
+    choices: tuple[SettingValue, ...] | None = None
+
+
+@dataclass(frozen=True)
+class SettingsSchema:
+    fields: Mapping[str, SettingField]
+    preserve_unknown: bool = True
+
+    def validate(self, data: Mapping[str, Any]) -> dict[str, SettingValue]:
+        result = _plain_mapping(data if self.preserve_unknown else {})
+        source = _plain_mapping(data)
+        for key, field in self.fields.items():
+            value = _get_dotted(source, key, _MISSING)
+            if value is _MISSING:
+                if field.required and field.default is None:
+                    raise _schema_error(
+                        f"required setting is missing: {key}",
+                        key=key,
+                    )
+                value = field.default
+            validated = _validate_field(field, value)
+            _set_dotted(result, key, validated)
+        return result
+
+    def defaults(self) -> dict[str, SettingValue]:
+        result: dict[str, SettingValue] = {}
+        for key, field in self.fields.items():
+            _set_dotted(result, key, _copy_value(field.default))
+        return result
+
+    def mask(self, data: Mapping[str, Any]) -> dict[str, SettingValue]:
+        result = _plain_mapping(data)
+        for key, field in self.fields.items():
+            if not field.secret or _get_dotted(result, key, _MISSING) is _MISSING:
+                continue
+            value = _get_dotted(result, key, "")
+            _set_dotted(result, key, "***" if value not in ("", None) else "")
+        return result
+
+
+@dataclass(frozen=True)
+class SecretsSnapshot:
+    _data: Mapping[str, SettingValue]
+    _schema: SettingsSchema
+
+    def get(self, key: str, default: SettingValue = None) -> SettingValue:
+        value = _get_dotted(self._data, key, _MISSING)
+        return default if value is _MISSING else value
+
+    def get_secret(self, key: str) -> str:
+        field = self._schema.fields.get(key)
+        if field is None or not field.secret:
+            raise SecretBoundaryError(
+                "requested key is not a secret",
+                details={"key": key},
+            )
+        value = _get_dotted(self._data, key, "")
+        return "" if value is None else str(value)
+
+    def masked(self) -> Mapping[str, SettingValue]:
+        return freeze_mapping(self._schema.mask(self._data))
+
+
+def freeze_mapping(data: Mapping[str, Any]) -> Mapping[str, SettingValue]:
+    return _freeze(_plain_mapping(data))
+
+
+def dotted_get(data: Mapping[str, Any], key: str, default: Any = None) -> Any:
+    value = _get_dotted(data, key, _MISSING)
+    return default if value is _MISSING else value
+
+
+def dotted_set(data: dict[str, Any], key: str, value: Any) -> None:
+    _set_dotted(data, key, value)
+
+
+def _validate_field(field: SettingField, value: Any) -> SettingValue:
+    value = _plain_value(value)
+    if not _matches_type(value, field.type_):
+        raise _schema_error(
+            f"invalid type for setting: {field.name}",
+            key=field.name,
+            expected=_type_name(field.type_),
+            actual=type(value).__name__,
+        )
+    if field.choices is not None and value not in field.choices:
+        raise _schema_error(
+            f"invalid choice for setting: {field.name}",
+            key=field.name,
+        )
+    if field.type_ is float and isinstance(value, int) and not isinstance(value, bool):
+        return float(value)
+    return value
+
+
+def _matches_type(value: Any, expected: type | tuple[type, ...]) -> bool:
+    expected_types = expected if isinstance(expected, tuple) else (expected,)
+    if bool in expected_types:
+        return isinstance(value, bool)
+    if isinstance(value, bool) and (int in expected_types or float in expected_types):
+        return False
+    if float in expected_types and isinstance(value, int):
+        return True
+    return isinstance(value, expected_types)
+
+
+def _schema_error(message: str, **details: SettingValue) -> ConfigurationError:
+    return ConfigurationError(
+        message,
+        code="NYX_SETTINGS_SCHEMA_INVALID",
+        component="SettingsSchema",
+        details=dict(details),
+    )
+
+
+def _type_name(expected: type | tuple[type, ...]) -> str:
+    if isinstance(expected, tuple):
+        return " | ".join(t.__name__ for t in expected)
+    return expected.__name__
+
+
+def _plain_mapping(data: Mapping[str, Any]) -> dict[str, SettingValue]:
+    plain = _plain_value(data)
+    if not isinstance(plain, dict):
+        raise _schema_error("settings root must be a mapping")
+    return plain
+
+
+def _plain_value(value: Any) -> SettingValue:
+    unwrap = getattr(value, "unwrap", None)
+    if callable(unwrap):
+        value = unwrap()
+    if isinstance(value, Mapping):
+        return {str(k): _plain_value(v) for k, v in value.items()}
+    if isinstance(value, list | tuple):
+        return [_plain_value(v) for v in value]
+    return value
+
+
+def _copy_value(value: SettingValue) -> SettingValue:
+    return _plain_value(value)
+
+
+def _get_dotted(data: Mapping[str, Any], key: str, default: Any = None) -> Any:
+    if key in data:
+        return data[key]
+    current: Any = data
+    for part in key.split("."):
+        if not isinstance(current, Mapping) or part not in current:
+            return default
+        current = current[part]
+    return current
+
+
+def _set_dotted(data: dict[str, Any], key: str, value: Any) -> None:
+    parts = key.split(".")
+    current = data
+    for part in parts[:-1]:
+        nested = current.get(part)
+        if not isinstance(nested, dict):
+            nested = {}
+            current[part] = nested
+        current = nested
+    current[parts[-1]] = _copy_value(value)
+
+
+def _freeze(value: Any) -> Any:
+    if isinstance(value, Mapping):
+        return MappingProxyType({str(k): _freeze(v) for k, v in value.items()})
+    if isinstance(value, list | tuple):
+        return tuple(_freeze(v) for v in value)
+    return value

--- a/src/nyxpy/framework/core/settings/secrets_settings.py
+++ b/src/nyxpy/framework/core/settings/secrets_settings.py
@@ -1,53 +1,124 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
 from pathlib import Path
+from threading import RLock
+from typing import Any
 
 import tomlkit
+from tomlkit.exceptions import TOMLKitError
+
+from nyxpy.framework.core.macro.exceptions import ConfigurationError
+from nyxpy.framework.core.settings.schema import (
+    SecretsSnapshot,
+    SettingField,
+    SettingsSchema,
+    SettingValue,
+    dotted_get,
+    dotted_set,
+    freeze_mapping,
+)
+
+SECRETS_SETTINGS_SCHEMA = SettingsSchema(
+    fields={
+        "notification.discord.enabled": SettingField("notification.discord.enabled", bool, False),
+        "notification.discord.webhook_url": SettingField(
+            "notification.discord.webhook_url", str, "", secret=True
+        ),
+        "notification.bluesky.enabled": SettingField("notification.bluesky.enabled", bool, False),
+        "notification.bluesky.identifier": SettingField(
+            "notification.bluesky.identifier", str, "", secret=True
+        ),
+        "notification.bluesky.password": SettingField(
+            "notification.bluesky.password", str, "", secret=True
+        ),
+    }
+)
 
 
-class SecretsSettings:
+class SecretsStore:
+    schema: SettingsSchema
+
+    def __init__(
+        self,
+        config_dir: Path | None = None,
+        *,
+        schema: SettingsSchema = SECRETS_SETTINGS_SCHEMA,
+        filename: str = "secrets.toml",
+        strict_load: bool = True,
+    ) -> None:
+        self.config_dir = config_dir or Path.cwd() / ".nyxpy"
+        self.config_dir.mkdir(exist_ok=True)
+        self.config_path = self.config_dir / filename
+        self.schema = schema
+        self.strict_load = strict_load
+        self._lock = RLock()
+        self.data: dict[str, SettingValue] = {}
+        self.load()
+
+    def load(self) -> None:
+        with self._lock:
+            try:
+                if self.config_path.exists():
+                    loaded = tomlkit.loads(self.config_path.read_text(encoding="utf-8"))
+                    self.data = self.schema.validate(loaded)
+                else:
+                    self.data = self.schema.defaults()
+                    self.save()
+            except TOMLKitError as exc:
+                if self.strict_load:
+                    raise ConfigurationError(
+                        "failed to parse secrets file",
+                        code="NYX_SETTINGS_PARSE_FAILED",
+                        component=type(self).__name__,
+                        details={
+                            "path": self.config_path.name,
+                            "exception_type": type(exc).__name__,
+                        },
+                        cause=exc,
+                    ) from exc
+                self.data = self.schema.defaults()
+            except ConfigurationError:
+                if self.strict_load:
+                    raise
+                self.data = self.schema.defaults()
+
+    def save(self) -> None:
+        with self._lock:
+            self.data = self.schema.validate(self.data)
+            tmp_path = self.config_path.with_suffix(f"{self.config_path.suffix}.tmp")
+            tmp_path.write_text(tomlkit.dumps(self.data), encoding="utf-8")
+            tmp_path.replace(self.config_path)
+
+    def snapshot(self) -> SecretsSnapshot:
+        with self._lock:
+            return SecretsSnapshot(freeze_mapping(self.data), self.schema)
+
+    def snapshot_masked(self) -> Mapping[str, SettingValue]:
+        with self._lock:
+            return freeze_mapping(self.schema.mask(self.data))
+
+    def get_secret(self, key: str) -> str:
+        return self.snapshot().get_secret(key)
+
+    def validate(self) -> None:
+        with self._lock:
+            self.data = self.schema.validate(self.data)
+
+    def get(self, key: str, default: Any = None) -> Any:
+        with self._lock:
+            return dotted_get(self.data, key, default)
+
+    def set(self, key: str, value: SettingValue) -> None:
+        with self._lock:
+            dotted_set(self.data, key, value)
+            self.save()
+
+
+class SecretsSettings(SecretsStore):
     """
     Manage secrets stored in .nyxpy/secrets.toml under the working directory.
     """
 
-    def __init__(self):
-        self.config_dir = Path.cwd() / ".nyxpy"
-        self.config_dir.mkdir(exist_ok=True)
-        self.config_path = self.config_dir / "secrets.toml"
-        self.data = {}
-        self.load()
-
-    def load(self):
-        if self.config_path.exists():
-            text = self.config_path.read_text(encoding="utf-8")
-            self.data = tomlkit.loads(text)
-        else:
-            # デフォルト値は空dict。初回は空ファイルを作成
-            self.data = {}
-            self.save()
-
-    def save(self):
-        toml_str = tomlkit.dumps(self.data)
-        self.config_path.write_text(toml_str, encoding="utf-8")
-
-    def get(self, key, default=None):
-        # ドット区切りキーでネストdictにも対応
-        if "." in key:
-            parts = key.split(".")
-            d = self.data
-            for p in parts[:-1]:
-                d = d.get(p, {})
-            return d.get(parts[-1], default)
-        return self.data.get(key, default)
-
-    def set(self, key, value):
-        # ドット区切りキーでネストdictにも対応
-        if "." in key:
-            parts = key.split(".")
-            d = self.data
-            for p in parts[:-1]:
-                if p not in d or not isinstance(d[p], dict):
-                    d[p] = {}
-                d = d[p]
-            d[parts[-1]] = value
-        else:
-            self.data[key] = value
-        self.save()
+    def __init__(self, config_dir: Path | None = None) -> None:
+        super().__init__(config_dir=config_dir, strict_load=False)

--- a/tests/unit/framework/settings/test_settings_schema.py
+++ b/tests/unit/framework/settings/test_settings_schema.py
@@ -1,0 +1,89 @@
+from types import MappingProxyType
+
+import pytest
+
+from nyxpy.framework.core.macro.exceptions import ConfigurationError
+from nyxpy.framework.core.settings.global_settings import SettingsStore
+from nyxpy.framework.core.settings.schema import (
+    SecretBoundaryError,
+    SettingField,
+    SettingsSchema,
+)
+from nyxpy.framework.core.settings.secrets_settings import SecretsStore
+
+
+def test_settings_store_applies_defaults_and_returns_immutable_snapshot(tmp_path) -> None:
+    store = SettingsStore(config_dir=tmp_path)
+
+    snapshot = store.snapshot()
+
+    assert snapshot["serial_baud"] == 9600
+    assert snapshot["runtime"]["allow_dummy"] is False
+    assert isinstance(snapshot, MappingProxyType)
+    with pytest.raises(TypeError):
+        snapshot["serial_baud"] = 115200
+    with pytest.raises(TypeError):
+        snapshot["runtime"]["allow_dummy"] = True
+
+
+def test_settings_store_get_set_supports_dotted_keys(tmp_path) -> None:
+    store = SettingsStore(config_dir=tmp_path)
+
+    store.set("runtime.allow_dummy", True)
+    store.set("serial_baud", 115200)
+
+    assert store.get("runtime.allow_dummy") is True
+    assert store.get("serial_baud") == 115200
+
+
+def test_settings_store_rejects_invalid_schema_type(tmp_path) -> None:
+    (tmp_path / "global.toml").write_text('serial_baud = "fast"\n', encoding="utf-8")
+
+    with pytest.raises(ConfigurationError) as exc_info:
+        SettingsStore(config_dir=tmp_path)
+
+    assert exc_info.value.code == "NYX_SETTINGS_SCHEMA_INVALID"
+
+
+def test_settings_store_rejects_broken_toml_without_overwriting(tmp_path) -> None:
+    config_path = tmp_path / "global.toml"
+    config_path.write_text('serial_device = "unterminated\n', encoding="utf-8")
+
+    with pytest.raises(ConfigurationError) as exc_info:
+        SettingsStore(config_dir=tmp_path)
+
+    assert exc_info.value.code == "NYX_SETTINGS_PARSE_FAILED"
+    assert config_path.read_text(encoding="utf-8") == 'serial_device = "unterminated\n'
+
+
+def test_settings_store_schema_rejects_secret_fields(tmp_path) -> None:
+    schema = SettingsSchema(
+        fields={
+            "token": SettingField("token", str, "", secret=True),
+        }
+    )
+
+    with pytest.raises(SecretBoundaryError):
+        SettingsStore(config_dir=tmp_path, schema=schema)
+
+
+def test_secrets_store_snapshot_masks_secret_values(tmp_path) -> None:
+    store = SecretsStore(config_dir=tmp_path)
+    store.set("notification.discord.enabled", True)
+    store.set("notification.discord.webhook_url", "https://discord/webhook")
+
+    snapshot = store.snapshot()
+    masked = snapshot.masked()
+
+    assert snapshot.get("notification.discord.enabled") is True
+    assert snapshot.get_secret("notification.discord.webhook_url") == "https://discord/webhook"
+    assert masked["notification"]["discord"]["webhook_url"] == "***"
+    with pytest.raises(TypeError):
+        masked["notification"]["discord"]["webhook_url"] = "leak"
+
+
+def test_secrets_snapshot_rejects_non_secret_plaintext_access(tmp_path) -> None:
+    store = SecretsStore(config_dir=tmp_path)
+
+    with pytest.raises(SecretBoundaryError):
+        store.snapshot().get_secret("notification.discord.enabled")


### PR DESCRIPTION
## Summary

SettingsStore / SecretsStore の schema 公開 API と secret mask 境界を実装します。

## Related

- User request: 再設計実装の検証で見つかった残課題を重要度順に修正し、PR 経由で取り込む
- spec\framework\rearchitecture\CONFIGURATION_AND_RESOURCES.md
- spec\framework\rearchitecture\ERROR_CANCELLATION_LOGGING.md

## Changes

- SettingField / SettingsSchema / SecretsSnapshot / SecretBoundaryError を追加
- SettingsStore / SecretsStore に dotted key schema、既定値適用、型検証、immutable snapshot、TOML parse/schema error 正規化を追加
- SecretsStore に secret 平文取得 API と mask 済み snapshot を追加
- 既存 GlobalSettings / SecretsSettings shim は no-arg 利用を維持し、既存 import-time 経路を壊さないよう strict_load=false に設定
- schema と secret boundary の単体テストを追加
- 該当チェックリストを実装済みに更新

## Commit Log

```
26292bb feat(settings): Store schema検証とsecretマスクを追加
```

## Testing

```
uv run pytest tests\unit\framework\settings\test_settings_schema.py tests\unit\api\test_notification_factory.py tests\integration\test_cli_runtime_adapter.py
uv run ruff check .
uv run ruff format src\nyxpy\framework\core\settings\schema.py src\nyxpy\framework\core\settings\global_settings.py src\nyxpy\framework\core\settings\secrets_settings.py tests\unit\framework\settings\test_settings_schema.py --check
$env:QT_QPA_PLATFORM='offscreen'; uv run pytest -m "not realdevice"
```

## Checklist

- [x] lint / format チェック通過
- [x] 既存テスト通過
- [x] コミット prefix (feat/fix 等) が変更の動機と一致している
- [x] 新規・変更コードに対するテスト追加（該当する場合）
- [ ] 型チェック通過

## Review Notes

既存 `GlobalSettings` / `SecretsSettings` は起動時 import 互換を優先して strict load を無効化しています。厳格な parse/schema error は新しい `SettingsStore` / `SecretsStore` API で固定しています。