### PR TITLE
feat(runtime): macro args schema検証を追加

### DIFF
--- a/spec/framework/rearchitecture/ERROR_CANCELLATION_LOGGING.md
+++ b/spec/framework/rearchitecture/ERROR_CANCELLATION_LOGGING.md
@@ -553,7 +553,7 @@ class MacroArgsSchema:
 - [x] GUI/CLI cancel が例外を送出しない中断要求 API へ移行
 - [x] `MacroExecutor` を削除対象とし、Runtime / Runner での `RunResult` 生成・例外正規化・`finalize` outcome 伝達を固定
 - [x] 既存 `finalize(cmd)` マクロの互換テスト作成
-- [ ] `macro args schema` と検証処理の実装
+- [x] `macro args schema` と検証処理の実装
 - [x] `SettingsStore` / `SecretsStore` schema 検証と secret マスク実装
 - [x] `parse_define_args()` の `str` / `Iterable[str]` 対応と `ConfigurationError` 正規化
 - [x] 異常・中断イベントを `LOGGING_FRAMEWORK.md` の `LoggerPort` へ接続

--- a/src/nyxpy/framework/core/macro/base.py
+++ b/src/nyxpy/framework/core/macro/base.py
@@ -1,12 +1,17 @@
 from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING
 
 from .command import Command
+
+if TYPE_CHECKING:
+    from nyxpy.framework.core.settings.schema import SettingsSchema
 
 
 class MacroBase(ABC):
     # GUI 用メタデータ: マクロの説明文とタグ
     description: str = ""
     tags: list[str] = []
+    args_schema: "SettingsSchema | None" = None
 
     @abstractmethod
     def initialize(self, cmd: Command, args: dict) -> None:

--- a/src/nyxpy/framework/core/runtime/runner.py
+++ b/src/nyxpy/framework/core/runtime/runner.py
@@ -9,6 +9,7 @@ from typing import Protocol, runtime_checkable
 from nyxpy.framework.core.macro.base import MacroBase
 from nyxpy.framework.core.macro.command import Command
 from nyxpy.framework.core.macro.exceptions import (
+    ConfigurationError,
     ErrorInfo,
     ErrorKind,
     FrameworkError,
@@ -16,6 +17,7 @@ from nyxpy.framework.core.macro.exceptions import (
 )
 from nyxpy.framework.core.runtime.context import RunContext
 from nyxpy.framework.core.runtime.result import RunResult, RunStatus
+from nyxpy.framework.core.settings.schema import SettingsSchema
 
 type RuntimeValue = str | int | float | bool | list[RuntimeValue] | dict[str, RuntimeValue] | None
 
@@ -36,7 +38,8 @@ class MacroRunner:
         started_at = run_context.started_at
         result: RunResult
         try:
-            macro.initialize(cmd, dict(exec_args))
+            macro_args = self._validate_exec_args(macro, exec_args)
+            macro.initialize(cmd, macro_args)
             macro.run(cmd)
         except MacroStopException as exc:
             result = self._result(
@@ -102,6 +105,36 @@ class MacroRunner:
                 error=replace(result.error, details=details),
             )
         return replace(result, finished_at=datetime.now())
+
+    def _validate_exec_args(
+        self,
+        macro: MacroBase,
+        exec_args: Mapping[str, RuntimeValue],
+    ) -> dict[str, RuntimeValue]:
+        schema = getattr(macro, "args_schema", None)
+        if schema is None:
+            return dict(exec_args)
+        if not isinstance(schema, SettingsSchema):
+            raise ConfigurationError(
+                "macro args_schema must be a SettingsSchema",
+                code="NYX_MACRO_ARGS_INVALID",
+                component="MacroRunner",
+                details={"macro": type(macro).__name__},
+            )
+        try:
+            return schema.validate(exec_args)
+        except ConfigurationError as exc:
+            raise ConfigurationError(
+                "macro arguments do not match schema",
+                code="NYX_MACRO_ARGS_INVALID",
+                component="MacroRunner",
+                details={
+                    "macro": type(macro).__name__,
+                    "schema_error_code": exc.code,
+                    "schema_error": exc.message,
+                },
+                cause=exc,
+            ) from exc
 
     def _result(
         self,

--- a/tests/unit/framework/runtime/test_macro_runner.py
+++ b/tests/unit/framework/runtime/test_macro_runner.py
@@ -15,6 +15,7 @@ from nyxpy.framework.core.macro.exceptions import (
     MacroStopException,
 )
 from nyxpy.framework.core.runtime import MacroRunner, RunContext, RunResult, RunStatus
+from nyxpy.framework.core.settings.schema import SettingField, SettingsSchema
 from nyxpy.framework.core.utils.cancellation import CancellationToken, cancellation_aware_wait
 
 
@@ -86,6 +87,20 @@ class OrderedMacro(MacroBase):
         self.events.append("finalize")
 
 
+class ArgsSchemaMacro(OrderedMacro):
+    args_schema = SettingsSchema(
+        fields={
+            "count": SettingField("count", int, 1),
+            "label": SettingField("label", str, "default"),
+        },
+        preserve_unknown=False,
+    )
+
+    def initialize(self, cmd: Command, args: dict) -> None:
+        self.events.append("initialize")
+        self.args = args
+
+
 def test_runner_calls_lifecycle_in_order() -> None:
     events: list[str] = []
     result = MacroRunner().run(
@@ -99,6 +114,29 @@ def test_runner_calls_lifecycle_in_order() -> None:
     assert result.status is RunStatus.SUCCESS
     assert result.error is None
     assert result.ok
+
+
+def test_runner_validates_macro_args_schema_and_applies_defaults() -> None:
+    events: list[str] = []
+    macro = ArgsSchemaMacro(events)
+
+    result = MacroRunner().run(macro, RecordingCommand(), {"count": 3}, _run_context())
+
+    assert result.status is RunStatus.SUCCESS
+    assert macro.args == {"count": 3, "label": "default"}
+
+
+def test_runner_returns_configuration_error_for_invalid_macro_args() -> None:
+    events: list[str] = []
+    macro = ArgsSchemaMacro(events)
+
+    result = MacroRunner().run(macro, RecordingCommand(), {"count": "many"}, _run_context())
+
+    assert result.status is RunStatus.FAILED
+    assert result.error is not None
+    assert result.error.code == "NYX_MACRO_ARGS_INVALID"
+    assert result.error.kind is ErrorKind.CONFIGURATION
+    assert events == ["finalize"]
 
 
 class ErrorMacro(MacroBase):


### PR DESCRIPTION
## Summary

MacroBase.args_schema を MacroRunner で検証し、マクロ実行引数の schema 不一致を RunResult に正規化します。

## Related

- User request: 再設計実装の検証で見つかった残課題を重要度順に修正し、PR 経由で取り込む
- spec\framework\rearchitecture\ERROR_CANCELLATION_LOGGING.md

## Changes

- MacroBase に `args_schema` 公開属性を追加
- MacroRunner が initialize 前に SettingsSchema で exec args を検証し、既定値を適用
- schema 不一致や不正 schema を `NYX_MACRO_ARGS_INVALID` の `ConfigurationError` として RunResult に正規化
- 成功/失敗の単体テストを追加
- 該当チェックリストを実装済みに更新

## Commit Log

```
6eed28d feat(runtime): macro args schema検証を追加
```

## Testing

```
uv run pytest tests\unit\framework\runtime\test_macro_runner.py tests\unit\framework\runtime\test_macro_runtime.py
$env:QT_QPA_PLATFORM='offscreen'; uv run pytest -m "not realdevice"
uv run ruff check .
uv run ruff format src\nyxpy\framework\core\macro\base.py src\nyxpy\framework\core\runtime\runner.py tests\unit\framework\runtime\test_macro_runner.py --check
```

## Checklist

- [x] lint / format チェック通過
- [x] 既存テスト通過
- [x] コミット prefix (feat/fix 等) が変更の動機と一致している
- [x] 新規・変更コードに対するテスト追加（該当する場合）
- [ ] 型チェック通過