### PR TITLE
fix(macro): portable settings path検証をPOSIX基準へ統一

### DIFF
--- a/src/nyxpy/framework/core/macro/settings_resolver.py
+++ b/src/nyxpy/framework/core/macro/settings_resolver.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import Any
 
 import tomlkit
@@ -61,8 +61,8 @@ class MacroSettingsResolver:
                 f"invalid portable settings path: {path_text!r}",
                 code="NYX_SETTINGS_PATH_INVALID",
             )
-        path = Path(path_text)
-        if path.is_absolute() or ".." in path.parts:
+        path = PurePosixPath(path_text)
+        if path.is_absolute() or any(part == ".." or part.strip() == ".." for part in path.parts):
             raise ConfigurationError(
                 f"invalid portable settings path: {path_text!r}",
                 code="NYX_SETTINGS_PATH_INVALID",


### PR DESCRIPTION
## Summary

Linux CI で失敗していた macro settings の portable path 検証を修正します。

## Related

- CI failure: Python CI on master
- `tests/unit/framework/macro/test_registry.py::test_settings_resolver_rejects_invalid_portable_path[.. /bad.toml]`

## Changes

- portable settings path の検証を OS 依存の `Path` ではなく `PurePosixPath` 基準へ変更
- `.. /bad.toml` のような空白付き parent segment も `NYX_SETTINGS_PATH_INVALID` として拒否
- Linux CI で `FileNotFoundError` へ進む前に設計通り `ConfigurationError` へ正規化

## Commit Log

```
763002c fix(macro): portable settings path検証をPOSIX基準へ統一
```

## Testing

```
uv run pytest tests\unit\framework\macro\test_registry.py::test_settings_resolver_rejects_invalid_portable_path -v
uv run pytest tests\unit tests\integration -v
uv run ruff check .
uv run ruff format src\nyxpy\framework\core\macro\settings_resolver.py tests\unit\framework\macro\test_registry.py --check
```

## Checklist

- [x] lint / format チェック通過
- [x] 既存テスト通過
- [x] コミット prefix (feat/fix 等) が変更の動機と一致している
- [ ] 新規・変更コードに対するテスト追加（該当する場合）
- [ ] 型チェック通過

## Review Notes

既存テスト `.. /bad.toml` が Linux CI の失敗再現ケースです。Windows と Linux で path segment 解釈がずれないよう、manifest/class metadata の portable path は POSIX path として検証します。