### PR TITLE
perf(command): ログ呼び出し元取得を軽量化

### DIFF
--- a/src/nyxpy/framework/core/utils/helper.py
+++ b/src/nyxpy/framework/core/utils/helper.py
@@ -18,16 +18,13 @@ class _SettingsDefinition:
 
 def get_caller_class_name():
     """呼び出し元のクラス名を取得する"""
-    stack = inspect.stack()
-    # 0: get_caller_class_name, 1: log, 2: 呼び出し元
-    if len(stack) > 2:
-        frame = stack[2]
-        class_name = None
-        self_obj = frame.frame.f_locals.get("self")
-        if self_obj:
-            class_name = type(self_obj).__name__
-            return class_name
-    return None
+    frame = inspect.currentframe()
+    try:
+        caller = frame.f_back.f_back if frame and frame.f_back else None
+        self_obj = caller.f_locals.get("self") if caller is not None else None
+        return type(self_obj).__name__ if self_obj is not None else None
+    finally:
+        del frame
 
 
 def load_macro_settings(macro_cls) -> dict:


### PR DESCRIPTION
## Summary
- Command.log の呼び出し元クラス名取得を inspect.stack() から direct frame lookup に変更
- フルスイート時に発生していた Command.press overhead の性能テスト失敗を解消

## Commit Log
e607c63 perf(command): 繝ｭ繧ｰ蜻ｼ縺ｳ蜃ｺ縺怜・蜿門ｾ励ｒ霆ｽ驥丞喧

## Testing
- uv run pytest tests\\perf\\test_command_perf.py -q: 5 passed
- uv run ruff check src\\nyxpy\\framework\\core\\utils\\helper.py: passed
- uv run pytest tests\\unit\\ tests\\integration\\ tests\\gui\\ tests\\perf\\ -m "not realdevice": 442 passed
