### PR TITLE
refactor(macro): 初期Seedマクロの出力を run artifacts へ移行

### DIFF
--- a/macros/frlg_initial_seed/config.py
+++ b/macros/frlg_initial_seed/config.py
@@ -40,7 +40,7 @@ class FrlgInitialSeedConfig:
     edition: str = "Switch"
     hardware: Hardware = Hardware.SWITCH
     fps: float = 60.0
-    output_dir: str = "static/frlg_initial_seed"
+    output_dir: str = ""
 
     # === ゲーム内設定 ===
     sound_mode: str = "モノラル"

--- a/macros/frlg_initial_seed/csv_helper.py
+++ b/macros/frlg_initial_seed/csv_helper.py
@@ -12,7 +12,10 @@
 from __future__ import annotations
 
 import csv
+from io import TextIOWrapper
 from pathlib import Path
+
+from nyxpy.framework.core.io.resources import OverwritePolicy, RunArtifactStore
 
 from .config import FrlgInitialSeedConfig
 
@@ -64,13 +67,23 @@ CSV_DETAIL_FILENAME = "initial_seeds_details.csv"
 
 
 def build_csv_path(cfg: FrlgInitialSeedConfig) -> Path:
-    """共有用 CSV パスを返す。"""
-    return Path(cfg.output_dir) / CSV_FILENAME
+    """共有用 CSV の run outputs 相対パスを返す。"""
+    return _build_output_path(cfg, CSV_FILENAME)
 
 
 def build_detail_csv_path(cfg: FrlgInitialSeedConfig) -> Path:
-    """詳細ログ CSV パスを返す。"""
-    return Path(cfg.output_dir) / CSV_DETAIL_FILENAME
+    """詳細ログ CSV の run outputs 相対パスを返す。"""
+    return _build_output_path(cfg, CSV_DETAIL_FILENAME)
+
+
+def build_debug_image_dir(cfg: FrlgInitialSeedConfig) -> Path:
+    """デバッグ画像の run outputs 相対ディレクトリを返す。"""
+    return _build_output_path(cfg, "img")
+
+
+def _build_output_path(cfg: FrlgInitialSeedConfig, name: str) -> Path:
+    output_dir = cfg.output_dir.strip()
+    return Path(output_dir) / name if output_dir else Path(name)
 
 
 def _append_row(csv_path: Path, fieldnames: list[str], row: dict[str, str]) -> None:
@@ -93,3 +106,43 @@ def append_csv_row(csv_path: Path, row: dict[str, str]) -> None:
 def append_detail_csv_row(csv_path: Path, row: dict[str, str]) -> None:
     """詳細ログ CSV に 1 行追加する。"""
     _append_row(csv_path, CSV_DETAIL_FIELDNAMES, row)
+
+
+def append_csv_artifact(
+    artifacts: RunArtifactStore, output_path: Path, row: dict[str, str]
+) -> None:
+    """共有用 CSV を run outputs に追記する。"""
+    _append_artifact_row(artifacts, output_path, CSV_FIELDNAMES, row)
+
+
+def append_detail_csv_artifact(
+    artifacts: RunArtifactStore, output_path: Path, row: dict[str, str]
+) -> None:
+    """詳細 CSV を run outputs に追記する。"""
+    _append_artifact_row(artifacts, output_path, CSV_DETAIL_FIELDNAMES, row)
+
+
+def _append_artifact_row(
+    artifacts: RunArtifactStore,
+    output_path: Path,
+    fieldnames: list[str],
+    row: dict[str, str],
+) -> None:
+    ref = artifacts.resolve_output_path(output_path)
+    write_header = not ref.path.exists() or ref.path.stat().st_size == 0
+
+    with artifacts.open_output(
+        output_path,
+        mode="ab",
+        overwrite=OverwritePolicy.REPLACE,
+        atomic=False,
+    ) as raw:
+        text = TextIOWrapper(raw, encoding="utf-8", newline="")
+        try:
+            writer = csv.DictWriter(text, fieldnames=fieldnames)
+            if write_header:
+                writer.writeheader()
+            writer.writerow(row)
+            text.flush()
+        finally:
+            text.detach()

--- a/macros/frlg_initial_seed/macro.py
+++ b/macros/frlg_initial_seed/macro.py
@@ -9,7 +9,6 @@ Switch (720p) 専用。
 from __future__ import annotations
 
 from datetime import datetime, timedelta
-from pathlib import Path
 
 from macros.shared.frlg_opening import skip_opening_and_continue
 from macros.shared.game_restart import restart_game
@@ -21,16 +20,17 @@ from nyxpy.framework.core.macro.command import Command
 
 from .config import FrlgInitialSeedConfig
 from .csv_helper import (
-    append_csv_row,
-    append_detail_csv_row,
+    append_csv_artifact,
+    append_detail_csv_artifact,
     build_csv_path,
+    build_debug_image_dir,
     build_detail_csv_path,
 )
 from .recognizer import (
     ROI_STATS,
+    crop_and_pad,
     get_stat_digits,
     recognize_stats,
-    save_roi_image,
 )
 from .seed_solver import solve_initial_seed
 
@@ -96,19 +96,16 @@ class FrlgInitialSeedMacro(MacroBase):
             level="INFO",
         )
 
-        # デバッグ画像保存先を確保
-        self._img_dir = Path(cfg.output_dir) / "img"
-        self._img_dir.mkdir(parents=True, exist_ok=True)
-        cmd.log(f"デバッグ画像保存先: {self._img_dir}", level="DEBUG")
+        self._img_dir = build_debug_image_dir(cfg)
+        cmd.log(f"デバッグ画像保存先(run outputs相対): {self._img_dir}", level="DEBUG")
 
-        # CSV 追記パス
         self._csv_path = build_csv_path(cfg)
         self._detail_csv_path = build_detail_csv_path(cfg)
         cmd.log(
-            f"CSV 出力先: {self._csv_path} — Frame {cfg.min_frame + cfg.frame1_offset} から開始",
+            f"CSV 出力先(run outputs相対): {self._csv_path} — Frame {cfg.min_frame + cfg.frame1_offset} から開始",
             level="INFO",
         )
-        cmd.log(f"詳細CSV 出力先: {self._detail_csv_path}", level="INFO")
+        cmd.log(f"詳細CSV 出力先(run outputs相対): {self._detail_csv_path}", level="INFO")
 
         # OCR ウォームアップ (ステータス認識は en を使用)
         warmup_ocr(cmd, language="en")
@@ -177,11 +174,11 @@ class FrlgInitialSeedMacro(MacroBase):
                 else:
                     for k in ("hp", "atk", "def", "spa", "spd", "spe"):
                         detail_row[k] = ""
-                append_detail_csv_row(self._detail_csv_path, detail_row)
+                append_detail_csv_artifact(cmd.artifacts, self._detail_csv_path, detail_row)
 
                 # 共有用 (Seed 特定成功行のみ)
                 if seed_result not in ("MULT", "False"):
-                    append_csv_row(self._csv_path, {**meta, "note": ""})
+                    append_csv_artifact(cmd.artifacts, self._csv_path, {**meta, "note": ""})
 
                 adv_str = str(advance) if advance is not None else "-"
                 cmd.log(
@@ -331,7 +328,7 @@ class FrlgInitialSeedMacro(MacroBase):
             return None
 
         for roi, name in zip(ROI_STATS, _STAT_FILE_NAMES):
-            save_roi_image(stat_image, roi, self._img_dir / f"stat_{name}.png")
+            cmd.save_img(self._img_dir / f"stat_{name}.png", crop_and_pad(stat_image, roi))
 
         stat_raw = get_stat_digits(stat_image)
         cmd.log(

--- a/src/nyxpy/framework/core/macro/command.py
+++ b/src/nyxpy/framework/core/macro/command.py
@@ -153,6 +153,10 @@ class Command(ABC):
         """
         pass
 
+    @property
+    def artifacts(self) -> RunArtifactStore:
+        raise NotImplementedError("Current command does not expose run artifacts.")
+
     def touch(self, x: int, y: int, dur: float = 0.1, wait: float = 0.1) -> None:
         raise NotImplementedError("Current serial protocol does not support touch input.")
 

--- a/tests/unit/macro/test_frlg_initial_seed.py
+++ b/tests/unit/macro/test_frlg_initial_seed.py
@@ -528,11 +528,15 @@ from frlg_initial_seed.csv_helper import (
     CSV_DETAIL_FILENAME,
     CSV_FIELDNAMES,
     CSV_FILENAME,
+    append_csv_artifact,
     append_csv_row,
     append_detail_csv_row,
     build_csv_path,
+    build_debug_image_dir,
     build_detail_csv_path,
 )
+
+from nyxpy.framework.core.io.resources import LocalRunArtifactStore
 
 
 class TestCSVHelper:
@@ -542,15 +546,21 @@ class TestCSVHelper:
         """固定ファイル名 initial_seeds.csv が返る"""
         cfg = FrlgInitialSeedConfig()
         path = build_csv_path(cfg)
-        expected = Path("static/frlg_initial_seed") / CSV_FILENAME
-        assert path == expected
+        assert path == Path(CSV_FILENAME)
 
     def test_build_detail_csv_path_fixed(self):
         """固定ファイル名 initial_seeds_details.csv が返る"""
         cfg = FrlgInitialSeedConfig()
         path = build_detail_csv_path(cfg)
-        expected = Path("static/frlg_initial_seed") / CSV_DETAIL_FILENAME
-        assert path == expected
+        assert path == Path(CSV_DETAIL_FILENAME)
+
+    def test_build_output_paths_respect_relative_output_dir(self):
+        """output_dir は run outputs 配下の相対ディレクトリとして扱う"""
+        cfg = FrlgInitialSeedConfig(output_dir="reports")
+
+        assert build_csv_path(cfg) == Path("reports") / CSV_FILENAME
+        assert build_detail_csv_path(cfg) == Path("reports") / CSV_DETAIL_FILENAME
+        assert build_debug_image_dir(cfg) == Path("reports") / "img"
 
     def test_append_creates_with_header(self, tmp_path):
         """ファイルが存在しない場合、ヘッダー付きで作成される"""
@@ -645,6 +655,39 @@ class TestCSVHelper:
             lines = f.readlines()
         # ヘッダー 1 行 + データ 2 行
         assert len(lines) == 3
+
+    def test_append_csv_artifact_writes_under_run_outputs(self, tmp_path):
+        """artifact store 経由で run outputs に CSV を追記する"""
+        store = LocalRunArtifactStore(
+            tmp_path / "runs" / "run-1" / "outputs",
+            macro_id="frlg_initial_seed",
+            run_id="run-1",
+        )
+        output_path = build_csv_path(FrlgInitialSeedConfig())
+
+        for seed in ("AAAA", "BBBB"):
+            append_csv_artifact(
+                store,
+                output_path,
+                {
+                    "frame": "2120",
+                    "seed": seed,
+                    "region": "JPN",
+                    "version": "FR",
+                    "edition": "Switch",
+                    "sound_mode": "モノラル",
+                    "button_mode": "ヘルプ",
+                    "keyinput": "none",
+                    "hardware": "Switch",
+                    "fps": "60.0",
+                    "note": "",
+                },
+            )
+
+        csv_path = tmp_path / "runs" / "run-1" / "outputs" / CSV_FILENAME
+        with open(csv_path, encoding="utf-8") as f:
+            rows = list(csv.DictReader(f))
+        assert [row["seed"] for row in rows] == ["AAAA", "BBBB"]
 
     def test_csv_contains_metadata_columns(self, tmp_path):
         """CSV に hardware/fps/note を含む全カラムが存在する"""


### PR DESCRIPTION
## Summary
- FRLG 初期Seedマクロの CSV とデバッグ画像を static 直書きから run outputs 相対パスへ移行
- CSV 追記を RunArtifactStore 経由に変更
- Command API に artifacts プロパティを明示

## Commit Log
a47bca9 refactor(macro): 蛻晄悄Seed繝槭け繝ｭ縺ｮ蜃ｺ蜉帙ｒ run artifacts 縺ｸ遘ｻ陦・

## Testing
- uv run pytest tests\\unit\\macro\\test_frlg_initial_seed.py tests\\unit\\framework\\runtime\\test_default_command_ports.py tests\\integration\\test_resource_file_io_migration.py -q: 53 passed
- uv run pytest tests\\unit\\ tests\\integration\\ tests\\gui\\ tests\\perf\\ -m "not realdevice": 444 passed
- uv run ruff check .: passed
- uv run ruff format . --check: 184 files already formatted
