### PR TITLE
refactor(app): 初期化ディレクトリを Resource I/O 構成へ更新

### DIFF
--- a/src/nyxpy/__main__.py
+++ b/src/nyxpy/__main__.py
@@ -9,9 +9,9 @@ from nyxpy.gui.run_gui import main as gui_main
 
 def init_app() -> int:
     """
-    Initialize the workspace for GUI/CLI: create macros, snapshots, static folders.
+    Initialize the workspace for GUI/CLI: create macros, snapshots, resources, runs folders.
     """
-    dirs = ["macros", "snapshots", "static"]
+    dirs = ["macros", "snapshots", "resources", "runs"]
     for d in dirs:
         Path(d).mkdir(exist_ok=True)
     # Ensure macros is a package
@@ -82,7 +82,8 @@ def parse_arguments() -> argparse.Namespace:
 
     # GUI/CLI 初期化および GUI 起動コマンド
     subparsers.add_parser(
-        "init", help="Initialize workspace (create macros, snapshots, static folders)"
+        "init",
+        help="Initialize workspace (create macros, snapshots, resources, runs folders)",
     )
 
     # GUI 起動サブコマンド

--- a/src/nyxpy/gui/run_gui.py
+++ b/src/nyxpy/gui/run_gui.py
@@ -1,5 +1,5 @@
-import os
 import sys
+from pathlib import Path
 
 from PySide6.QtWidgets import QApplication
 
@@ -8,8 +8,8 @@ from nyxpy.gui.main_window import MainWindow
 
 def main():
     # Initialize required directories
-    for d in ("macros", "snapshots", "static"):
-        os.makedirs(d, exist_ok=True)
+    for d in ("macros", "snapshots", "resources", "runs"):
+        Path(d).mkdir(exist_ok=True)
     app = QApplication(sys.argv)
     window = MainWindow()
     window.show()

--- a/tests/unit/test_workspace_initialization.py
+++ b/tests/unit/test_workspace_initialization.py
@@ -1,0 +1,40 @@
+import pytest
+
+import nyxpy.__main__ as nyx_main
+from nyxpy.gui import run_gui
+
+
+def test_init_app_creates_resource_io_directories_without_static(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+
+    result = nyx_main.init_app()
+
+    assert result == 0
+    for name in ("macros", "snapshots", "resources", "runs", ".nyxpy"):
+        assert (tmp_path / name).exists()
+    assert not (tmp_path / "static").exists()
+
+
+def test_gui_startup_creates_resource_io_directories_without_static(tmp_path, monkeypatch):
+    class FakeApplication:
+        def __init__(self, _args):
+            pass
+
+        def exec(self):
+            return 0
+
+    class FakeMainWindow:
+        def show(self):
+            pass
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(run_gui, "QApplication", FakeApplication)
+    monkeypatch.setattr(run_gui, "MainWindow", FakeMainWindow)
+
+    with pytest.raises(SystemExit) as exc_info:
+        run_gui.main()
+
+    assert exc_info.value.code == 0
+    for name in ("macros", "snapshots", "resources", "runs"):
+        assert (tmp_path / name).exists()
+    assert not (tmp_path / "static").exists()


### PR DESCRIPTION
## Summary
- init と GUI 起動時に static ではなく resources/runs を作成
- ワークスペース初期化の回帰テストを追加

## Commit Log
cb45360 refactor(app): 蛻晄悄蛹悶ョ繧｣繝ｬ繧ｯ繝医Μ繧・Resource I/O 讒区・縺ｸ譖ｴ譁ｰ

## Testing
- uv run pytest tests\\unit\\test_workspace_initialization.py -q: 2 passed
- uv run pytest tests\\unit\\test_workspace_initialization.py tests\\unit\\cli\\test_main.py tests\\gui\\test_main_window.py -q: 28 passed
- uv run ruff check .: passed
- uv run ruff format . --check: 185 files already formatted
