### PR TITLE
refactor(cli): Runtime adapter契約を固定

### DIFF
--- a/src/nyxpy/cli/run_cli.py
+++ b/src/nyxpy/cli/run_cli.py
@@ -89,7 +89,7 @@ def create_runtime_builder(
     detection_timeout_sec: float = 2.0,
 ) -> MacroRuntimeBuilder:
     """
-    指定されたコンポーネントでCommandインスタンスを作成します。
+    CLI で利用する Runtime builder を作成します。
 
     Args:
         protocol: 使用するプロトコル実装
@@ -131,15 +131,15 @@ def execute_macro(
     logger: LoggerPort,
 ) -> RunResult:
     """
-    適切なエラー処理でマクロを実行します。
+    CLI entrypoint の RuntimeBuildRequest を作成し、Runtime builder で実行します。
 
     Args:
         runtime_builder: 実行用 Runtime builder
         macro_name: 実行するマクロの名前
         exec_args: マクロに渡す引数
 
-    Raises:
-        RuntimeError: マクロ実行が失敗した場合
+    Returns:
+        Runtime が返した RunResult
     """
     result = runtime_builder.run(
         RuntimeBuildRequest(macro_id=macro_name, entrypoint="cli", exec_args=exec_args)
@@ -163,7 +163,7 @@ def execute_macro(
 def cli_main(args: argparse.Namespace) -> int:
     """
     CLIアプリケーションのメインエントリーポイント。
-    この関数はコマンドライン引数を解析し、適切なコマンドを実行します。
+    この関数は解析済み引数から Runtime 実行要求を組み立てます。
 
     Args:
         args: コマンドライン引数

--- a/src/nyxpy/cli/run_cli.py
+++ b/src/nyxpy/cli/run_cli.py
@@ -189,7 +189,7 @@ def cli_main(args: argparse.Namespace) -> int:
         )
 
         # マクロ実行引数の解析
-        exec_args = parse_define_args(args.define)
+        exec_args = parse_define_args(args.define or [])
 
         # マクロの実行
         result = execute_macro(

--- a/src/nyxpy/cli/run_cli.py
+++ b/src/nyxpy/cli/run_cli.py
@@ -1,5 +1,6 @@
 import argparse
 import pathlib
+import sys
 from dataclasses import dataclass
 from typing import Any
 
@@ -9,6 +10,7 @@ from nyxpy.framework.core.api.notification_handler import (
 from nyxpy.framework.core.hardware.protocol import SerialProtocolInterface
 from nyxpy.framework.core.hardware.protocol_factory import ProtocolFactory
 from nyxpy.framework.core.logger import LoggerPort, LoggingComponents, create_default_logging
+from nyxpy.framework.core.macro.exceptions import ConfigurationError
 from nyxpy.framework.core.macro.registry import MacroRegistry
 from nyxpy.framework.core.runtime.builder import MacroRuntimeBuilder, create_legacy_runtime_builder
 from nyxpy.framework.core.runtime.context import RuntimeBuildRequest
@@ -160,6 +162,41 @@ def execute_macro(
     return result
 
 
+def _record_cleanup_failure(
+    logger: LoggerPort | None,
+    action: str,
+    exc: BaseException,
+) -> None:
+    message = f"Cleanup failed while trying to {action}"
+    if logger is None:
+        print(message, file=sys.stderr)
+        return
+
+    try:
+        logger.technical(
+            "WARNING",
+            message,
+            component="CLI",
+            event="resource.cleanup_failed",
+            extra={"action": action, "exception_type": type(exc).__name__},
+            exc=exc,
+        )
+    except Exception as log_exc:
+        print(message, file=sys.stderr)
+        print(f"Cleanup failure logging failed: {type(log_exc).__name__}", file=sys.stderr)
+
+
+def _run_cleanup(
+    action: str,
+    cleanup,
+    logger: LoggerPort | None,
+) -> None:
+    try:
+        cleanup()
+    except Exception as exc:
+        _record_cleanup_failure(logger, action, exc)
+
+
 def cli_main(args: argparse.Namespace) -> int:
     """
     CLIアプリケーションのメインエントリーポイント。
@@ -205,9 +242,16 @@ def cli_main(args: argparse.Namespace) -> int:
             print(user_message.text)
         return presenter.exit_code(result)
 
-    except ValueError as ve:
+    except (ConfigurationError, ValueError) as ve:
         if "logger" in locals():
             logger.user("ERROR", str(ve), component="CLI", event="configuration.invalid")
+            logger.technical(
+                "ERROR",
+                "Invalid CLI configuration",
+                component="CLI",
+                event="configuration.invalid",
+                exc=ve,
+            )
         print(f"エラー: {ve}")
         return 1  # エラー時の終了コード
 
@@ -217,24 +261,18 @@ def cli_main(args: argparse.Namespace) -> int:
                 "ERROR",
                 "Unhandled exception",
                 component="CLI",
-                event="macro.failed",
+                event="cli.unhandled",
                 exc=e,
             )
-        print(f"Unexpected error: {e}")
+        print("Unexpected error. See logs for details.")
         return 2  # 重大なエラー時の終了コード
 
     finally:
+        cleanup_logger = logger if "logger" in locals() else None
+        _run_cleanup("release capture device", capture_manager.release_active, cleanup_logger)
+        _run_cleanup("close serial device", serial_manager.close_active, cleanup_logger)
         if "logging" in locals():
-            logging.close()
-        # デバイスリソースを確実に解放（ゾンビプロセス防止）
-        try:
-            capture_manager.release_active()
-        except Exception:
-            pass
-        try:
-            serial_manager.close_active()
-        except Exception:
-            pass
+            _run_cleanup("close logging", logging.close, cleanup_logger)
 
 
 def build_parser() -> argparse.ArgumentParser:

--- a/tests/integration/test_cli_runtime_adapter.py
+++ b/tests/integration/test_cli_runtime_adapter.py
@@ -8,11 +8,14 @@ from nyxpy.framework.core.runtime.result import RunResult, RunStatus
 
 
 class Logger:
+    def __init__(self) -> None:
+        self.user_events = []
+
     def bind_context(self, context):
         return self
 
     def user(self, level, message, *, component, event, code=None, extra=None):
-        pass
+        self.user_events.append((level, message, component, event))
 
     def technical(self, level, message, *, component, event="log.message", extra=None, exc=None):
         pass
@@ -31,15 +34,24 @@ def run_result(status: RunStatus = RunStatus.SUCCESS) -> RunResult:
 
 
 def test_cli_uses_runtime_and_run_result() -> None:
+    logger = Logger()
     builder = MagicMock(run=MagicMock(return_value=run_result(RunStatus.CANCELLED)))
 
-    result = run_cli.execute_macro(builder, "sample", {"count": 1}, Logger())
+    result = run_cli.execute_macro(builder, "sample", {"count": 1}, logger)
 
     assert result.status is RunStatus.CANCELLED
     request = builder.run.call_args.args[0]
     assert request.macro_id == "sample"
     assert request.entrypoint == "cli"
     assert request.exec_args == {"count": 1}
+    assert logger.user_events == [
+        ("WARNING", "Macro execution was interrupted", "CLI", "macro.cancelled")
+    ]
+
+
+def test_create_runtime_builder_docstring_describes_runtime_builder() -> None:
+    assert "Runtime builder" in (run_cli.create_runtime_builder.__doc__ or "")
+    assert "Command" not in (run_cli.create_runtime_builder.__doc__ or "")
 
 
 def test_cli_notification_settings_source_is_secrets_store(monkeypatch, tmp_path) -> None:

--- a/tests/integration/test_cli_runtime_adapter.py
+++ b/tests/integration/test_cli_runtime_adapter.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import ast
 from datetime import datetime
+from pathlib import Path
 from unittest.mock import MagicMock
 
 from nyxpy.cli import run_cli
@@ -90,3 +92,28 @@ def test_cli_notification_settings_source_is_secrets_store(monkeypatch, tmp_path
     assert legacy_builder.call_args.kwargs["notification_handler"] == "notification-port"
     assert "serial_device" not in legacy_builder.call_args.kwargs
     assert "capture_device" not in legacy_builder.call_args.kwargs
+
+
+def test_cli_does_not_import_removed_runtime_apis() -> None:
+    cli_dir = Path(__file__).resolve().parents[2] / "src" / "nyxpy" / "cli"
+    forbidden_names = {"MacroExecutor", "DefaultCommand", "LogManager", "log_manager"}
+
+    for source_path in cli_dir.glob("*.py"):
+        source = source_path.read_text(encoding="utf-8")
+        tree = ast.parse(source, filename=str(source_path))
+        imported_names: set[str] = set()
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                for alias in node.names:
+                    imported_names.update(alias.name.split("."))
+                    if alias.asname:
+                        imported_names.add(alias.asname)
+            elif isinstance(node, ast.ImportFrom):
+                if node.module:
+                    imported_names.update(node.module.split("."))
+                for alias in node.names:
+                    imported_names.add(alias.name)
+                    if alias.asname:
+                        imported_names.add(alias.asname)
+
+        assert imported_names.isdisjoint(forbidden_names), source_path

--- a/tests/unit/cli/test_cli_presenter.py
+++ b/tests/unit/cli/test_cli_presenter.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+import pytest
+
+from nyxpy.cli.run_cli import CliPresenter
+from nyxpy.framework.core.macro.exceptions import ErrorInfo, ErrorKind
+from nyxpy.framework.core.runtime.result import RunResult, RunStatus
+
+
+def run_result(status: RunStatus, error: ErrorInfo | None = None) -> RunResult:
+    now = datetime.now()
+    return RunResult(
+        run_id="run-1",
+        macro_id="sample",
+        macro_name="Sample",
+        status=status,
+        started_at=now,
+        finished_at=now,
+        error=error,
+    )
+
+
+def error_info(message: str = "safe failure message") -> ErrorInfo:
+    return ErrorInfo(
+        kind=ErrorKind.MACRO,
+        code="NYX_MACRO_FAILED",
+        message=message,
+        component="TestMacro",
+        exception_type="RuntimeError",
+        recoverable=False,
+        details={
+            "path": "E:\\secret\\payload.txt",
+            "token": "super-secret-token",
+        },
+        traceback="Traceback (most recent call last): super-secret-token",
+    )
+
+
+@pytest.mark.parametrize(
+    ("status", "expected_code"),
+    [
+        (RunStatus.SUCCESS, 0),
+        (RunStatus.FAILED, 2),
+        (RunStatus.CANCELLED, 130),
+    ],
+)
+def test_cli_presenter_exit_codes(status: RunStatus, expected_code: int) -> None:
+    presenter = CliPresenter()
+
+    assert presenter.exit_code(run_result(status)) == expected_code
+
+
+def test_cli_presenter_excludes_traceback() -> None:
+    presenter = CliPresenter()
+
+    message = presenter.render_result(run_result(RunStatus.FAILED, error_info()))
+
+    assert message.text == "safe failure message"
+    assert "Traceback" not in message.text
+    assert "E:\\secret\\payload.txt" not in message.text
+    assert "super-secret-token" not in message.text
+
+
+def test_cli_presenter_renders_cancelled_message() -> None:
+    presenter = CliPresenter()
+
+    message = presenter.render_result(run_result(RunStatus.CANCELLED))
+
+    assert message.level == "WARNING"
+    assert message.text == "Macro execution was interrupted"

--- a/tests/unit/cli/test_main.py
+++ b/tests/unit/cli/test_main.py
@@ -465,6 +465,8 @@ def test_cli_cleanup_failures_are_logged(monkeypatch, mock_serial_manager):
 
     assert cli_main(args) == 0
     cleanup_events = [
-        log for log in logging.logger.logs if log[0] == "technical" and log[4] == "resource.cleanup_failed"
+        log
+        for log in logging.logger.logs
+        if log[0] == "technical" and log[4] == "resource.cleanup_failed"
     ]
     assert len(cleanup_events) == 3

--- a/tests/unit/cli/test_main.py
+++ b/tests/unit/cli/test_main.py
@@ -13,7 +13,7 @@ from nyxpy.cli.run_cli import (
     execute_macro,
 )
 from nyxpy.framework.core.hardware.protocol import CH552SerialProtocol, ThreeDSSerialProtocol
-from nyxpy.framework.core.macro.exceptions import ErrorInfo, ErrorKind
+from nyxpy.framework.core.macro.exceptions import ConfigurationError, ErrorInfo, ErrorKind
 from nyxpy.framework.core.runtime.result import RunResult, RunStatus
 
 
@@ -45,6 +45,11 @@ class MockLoggingComponents:
 
     def close(self):
         self.closed = True
+
+
+class FailingLoggingComponents(MockLoggingComponents):
+    def close(self):
+        raise RuntimeError("close failed")
 
 
 class MockSerialManager:
@@ -392,3 +397,74 @@ def test_cli_main_exception(
         log[1] == "ERROR" and "Unhandled exception" in log[2]
         for log in mock_log_manager.logger.logs
     )
+
+
+def test_cli_unhandled_exception_uses_fixed_user_message(
+    monkeypatch, mock_log_manager, mock_serial_manager, mock_capture_manager, capsys
+):
+    args = make_args()
+    monkeypatch.setattr(
+        "nyxpy.cli.run_cli.configure_logging", MagicMock(return_value=mock_log_manager)
+    )
+    monkeypatch.setattr("nyxpy.cli.run_cli.serial_manager", mock_serial_manager)
+    monkeypatch.setattr("nyxpy.cli.run_cli.capture_manager", mock_capture_manager)
+    monkeypatch.setattr(
+        "nyxpy.cli.run_cli.create_protocol",
+        lambda name: (_ for _ in ()).throw(
+            RuntimeError("secret value leaked from E:\\secret\\payload.txt")
+        ),
+    )
+
+    assert cli_main(args) == 2
+
+    captured = capsys.readouterr()
+    assert captured.out.strip() == "Unexpected error. See logs for details."
+    assert "secret value" not in captured.out
+    assert "E:\\secret\\payload.txt" not in captured.out
+    assert any(log[4] == "cli.unhandled" for log in mock_log_manager.logger.logs)
+
+
+def test_cli_configuration_error_returns_1(
+    monkeypatch, mock_log_manager, mock_serial_manager, mock_capture_manager
+):
+    args = make_args()
+    monkeypatch.setattr(
+        "nyxpy.cli.run_cli.configure_logging", MagicMock(return_value=mock_log_manager)
+    )
+    monkeypatch.setattr("nyxpy.cli.run_cli.serial_manager", mock_serial_manager)
+    monkeypatch.setattr("nyxpy.cli.run_cli.capture_manager", mock_capture_manager)
+    monkeypatch.setattr(
+        "nyxpy.cli.run_cli.create_protocol",
+        lambda name: (_ for _ in ()).throw(ConfigurationError("invalid protocol settings")),
+    )
+
+    assert cli_main(args) == 1
+    assert any(log[4] == "configuration.invalid" for log in mock_log_manager.logger.logs)
+
+
+def test_cli_cleanup_failures_are_logged(monkeypatch, mock_serial_manager):
+    args = make_args()
+    logging = FailingLoggingComponents()
+    capture_manager = MockCaptureManager({"Camera1": MagicMock()})
+    capture_manager.release_active = MagicMock(side_effect=RuntimeError("release failed"))
+    mock_serial_manager.close_active = MagicMock(side_effect=RuntimeError("close failed"))
+
+    monkeypatch.setattr("nyxpy.cli.run_cli.configure_logging", MagicMock(return_value=logging))
+    monkeypatch.setattr("nyxpy.cli.run_cli.serial_manager", mock_serial_manager)
+    monkeypatch.setattr("nyxpy.cli.run_cli.capture_manager", capture_manager)
+    monkeypatch.setattr("nyxpy.cli.run_cli.create_protocol", lambda name: MagicMock())
+    monkeypatch.setattr(
+        "nyxpy.cli.run_cli.create_runtime_builder",
+        MagicMock(return_value=MagicMock()),
+    )
+    monkeypatch.setattr("nyxpy.cli.run_cli.parse_define_args", lambda args: {})
+    monkeypatch.setattr(
+        "nyxpy.cli.run_cli.execute_macro",
+        MagicMock(return_value=result(RunStatus.SUCCESS)),
+    )
+
+    assert cli_main(args) == 0
+    cleanup_events = [
+        log for log in logging.logger.logs if log[0] == "technical" and log[4] == "resource.cleanup_failed"
+    ]
+    assert len(cleanup_events) == 3

--- a/tests/unit/cli/test_run_cli_parser.py
+++ b/tests/unit/cli/test_run_cli_parser.py
@@ -1,0 +1,160 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any
+
+from nyxpy.cli import run_cli
+from nyxpy.framework.core.runtime.context import RuntimeBuildRequest
+from nyxpy.framework.core.runtime.result import RunResult, RunStatus
+
+
+class Logger:
+    def bind_context(self, context):
+        return self
+
+    def user(self, level, message, *, component, event, code=None, extra=None):
+        pass
+
+    def technical(self, level, message, *, component, event="log.message", extra=None, exc=None):
+        pass
+
+
+@dataclass
+class Logging:
+    logger: Logger
+
+    def close(self) -> None:
+        pass
+
+
+class RecordingBuilder:
+    def __init__(self) -> None:
+        self.request: RuntimeBuildRequest | None = None
+
+    def run(self, request: RuntimeBuildRequest) -> RunResult:
+        self.request = request
+        now = datetime.now()
+        return RunResult(
+            run_id="run-1",
+            macro_id=request.macro_id,
+            macro_name=request.macro_id,
+            status=RunStatus.SUCCESS,
+            started_at=now,
+            finished_at=now,
+        )
+
+
+def test_cli_parser_keeps_existing_options() -> None:
+    parser = run_cli.build_parser()
+
+    args = parser.parse_args(
+        [
+            "sample",
+            "--serial",
+            "serial-1",
+            "--capture",
+            "capture-1",
+            "--protocol",
+            "ch552",
+            "--baud",
+            "115200",
+            "--silence",
+            "--verbose",
+            "--define",
+            "count=3",
+            "--define",
+            'name="nyx"',
+        ]
+    )
+
+    assert args.macro_name == "sample"
+    assert args.serial == "serial-1"
+    assert args.capture == "capture-1"
+    assert args.protocol == "ch552"
+    assert args.baud == 115200
+    assert args.silence is True
+    assert args.verbose is True
+    assert args.define == ["count=3", 'name="nyx"']
+
+
+def test_cli_does_not_accept_notification_secret_args() -> None:
+    parser = run_cli.build_parser()
+
+    option_strings = {
+        option
+        for action in parser._actions
+        for option in action.option_strings
+    }
+
+    assert "--discord-webhook-url" not in option_strings
+    assert "--bluesky-password" not in option_strings
+
+
+def test_cli_define_args_are_passed_to_request(monkeypatch) -> None:
+    builder = RecordingBuilder()
+
+    monkeypatch.setattr(run_cli, "configure_logging", lambda *, silence, verbose: Logging(Logger()))
+    monkeypatch.setattr(run_cli, "create_protocol", lambda protocol_name: object())
+    monkeypatch.setattr(run_cli.ProtocolFactory, "resolve_baudrate", lambda protocol, baud: baud)
+    monkeypatch.setattr(
+        run_cli,
+        "create_runtime_builder",
+        lambda **kwargs: builder,
+    )
+    monkeypatch.setattr(run_cli, "capture_manager", _Manager())
+    monkeypatch.setattr(run_cli, "serial_manager", _Manager())
+
+    args = run_cli.build_parser().parse_args(
+        [
+            "sample",
+            "--serial",
+            "serial-1",
+            "--capture",
+            "capture-1",
+            "--define",
+            "count=3",
+            "--define",
+            'name="nyx"',
+        ]
+    )
+
+    exit_code = run_cli.cli_main(args)
+
+    assert exit_code == 0
+    assert builder.request is not None
+    assert builder.request.macro_id == "sample"
+    assert builder.request.entrypoint == "cli"
+    assert builder.request.exec_args == {"count": 3, "name": "nyx"}
+
+
+def test_cli_define_defaults_to_empty_request_args(monkeypatch) -> None:
+    builder = RecordingBuilder()
+
+    monkeypatch.setattr(run_cli, "configure_logging", lambda *, silence, verbose: Logging(Logger()))
+    monkeypatch.setattr(run_cli, "create_protocol", lambda protocol_name: object())
+    monkeypatch.setattr(run_cli.ProtocolFactory, "resolve_baudrate", lambda protocol, baud: baud)
+    monkeypatch.setattr(run_cli, "create_runtime_builder", lambda **kwargs: builder)
+    monkeypatch.setattr(run_cli, "capture_manager", _Manager())
+    monkeypatch.setattr(run_cli, "serial_manager", _Manager())
+
+    args = run_cli.build_parser().parse_args(
+        ["sample", "--serial", "serial-1", "--capture", "capture-1"]
+    )
+
+    exit_code = run_cli.cli_main(args)
+
+    assert exit_code == 0
+    assert builder.request is not None
+    assert builder.request.exec_args == {}
+
+
+class _Manager:
+    def set_logger(self, logger: Any) -> None:
+        pass
+
+    def release_active(self) -> None:
+        pass
+
+    def close_active(self) -> None:
+        pass

--- a/tests/unit/cli/test_run_cli_parser.py
+++ b/tests/unit/cli/test_run_cli_parser.py
@@ -81,11 +81,7 @@ def test_cli_parser_keeps_existing_options() -> None:
 def test_cli_does_not_accept_notification_secret_args() -> None:
     parser = run_cli.build_parser()
 
-    option_strings = {
-        option
-        for action in parser._actions
-        for option in action.option_strings
-    }
+    option_strings = {option for action in parser._actions for option in action.option_strings}
 
     assert "--discord-webhook-url" not in option_strings
     assert "--bluesky-password" not in option_strings


### PR DESCRIPTION
## Summary
- CLI の Presenter / parser 契約を unit test に分離し、既存オプションと通知 secret 引数なしを固定
- RuntimeBuildRequest(entrypoint="cli") / RunResult ベースの adapter 責務を明確化
- ConfigurationError の終了コード 1 化、未捕捉例外の固定表示、cleanup 失敗の technical log 記録を追加
- 削除済み Runtime API の再導入を防ぐ静的テストを追加

## Commit Log
- ac2de80 test(cli): 削除済みRuntime APIの再導入を防止
- f01367a fix(cli): cleanup失敗と構成不正を記録
- 86edaac refactor(cli): Runtime実行入口の責務を明確化
- 4e03e97 test(cli): CLI入出力契約を固定

## Testing
- uv run ruff check .: passed
- uv run pytest: 460 passed, 6 skipped