### PR TITLE
feat(framework): preview向けFrameSourcePortを追加

### DIFF
--- a/spec/framework/rearchitecture/FOLLOWUP_FIXES.md
+++ b/spec/framework/rearchitecture/FOLLOWUP_FIXES.md
@@ -117,7 +117,7 @@ def try_latest_frame(self) -> cv2.typing.MatLike | None:
 
 ### 4.3 removal gate
 
-framework 新 Runtime 経路では次を禁止する。
+framework 新 Runtime 経路では次を禁止する。静的テストの探索対象は `src\nyxpy\framework\core\runtime\`, `src\nyxpy\framework\core\io\`, `src\nyxpy\framework\core\macro\` に限定し、後続の CLI 追加修正が完了するまで GUI / CLI の composition root は対象外にする。
 
 | 禁止対象 | 代替 |
 |----------|------|
@@ -142,10 +142,10 @@ framework 新 Runtime 経路では次を禁止する。
 
 ## 6. 実装チェックリスト
 
-- [ ] `FrameSourcePort.try_latest_frame()` のシグネチャを確定する。
-- [ ] `CaptureFrameSourcePort` / `DummyFrameSourcePort` に非ブロッキング取得を実装する。
-- [ ] GUI preview が UI thread から `latest_frame()` を呼ばないことを固定する。
-- [ ] `MacroRuntimeBuilder.shutdown()` が GUI lifetime Port を閉じる。
-- [ ] preview / Runtime 同時利用の性能テストを追加する。
-- [ ] 標準 CPython で性能ゲートを測定し、未達時だけ free-threaded CPython 評価仕様を作る。
-- [ ] removal gate の静的テストで旧 API への逆戻りを防ぐ。
+- [x] `FrameSourcePort.try_latest_frame()` のシグネチャを確定する。
+- [x] `CaptureFrameSourcePort` / `DummyFrameSourcePort` に非ブロッキング取得を実装する。
+- [x] GUI preview が UI thread から `latest_frame()` を呼ばないことを固定する。
+- [x] `MacroRuntimeBuilder.shutdown()` が GUI lifetime Port を閉じる。
+- [x] preview / Runtime 同時利用の性能テストを追加する。
+- [x] 標準 CPython で性能ゲートを測定し、未達時だけ free-threaded CPython 評価仕様を作る。
+- [x] removal gate の静的テストで旧 API への逆戻りを防ぐ。

--- a/src/nyxpy/framework/core/io/__init__.py
+++ b/src/nyxpy/framework/core/io/__init__.py
@@ -1,5 +1,6 @@
 from nyxpy.framework.core.io.adapters import (
     CaptureFrameSourcePort,
+    DummyFrameSourcePort,
     NoopNotificationAdapter,
     NotificationHandlerAdapter,
     NotificationHandlerPort,
@@ -8,6 +9,7 @@ from nyxpy.framework.core.io.adapters import (
 from nyxpy.framework.core.io.ports import (
     ControllerOutputPort,
     FrameNotReadyError,
+    FrameReadError,
     FrameSourcePort,
     NotificationPort,
     SleepControlCapability,
@@ -37,7 +39,9 @@ __all__ = [
     "ControllerOutputPort",
     "CaptureFrameSourcePort",
     "DefaultResourcePathGuard",
+    "DummyFrameSourcePort",
     "FrameNotReadyError",
+    "FrameReadError",
     "LocalResourceStore",
     "LocalRunArtifactStore",
     "FrameSourcePort",

--- a/src/nyxpy/framework/core/io/adapters.py
+++ b/src/nyxpy/framework/core/io/adapters.py
@@ -1,14 +1,17 @@
 from __future__ import annotations
 
 import time
+from threading import Lock
 
 import cv2
+import numpy as np
 
 from nyxpy.framework.core.constants import KeyboardOp, KeyCode, KeyType, SpecialKeyCode
 from nyxpy.framework.core.hardware.protocol import SerialProtocolInterface
 from nyxpy.framework.core.io.ports import (
     ControllerOutputPort,
     FrameNotReadyError,
+    FrameReadError,
     FrameSourcePort,
     NotificationPort,
 )
@@ -63,6 +66,7 @@ class SerialControllerOutputPort(ControllerOutputPort):
 class CaptureFrameSourcePort(FrameSourcePort):
     def __init__(self, capture_device) -> None:
         self.capture_device = capture_device
+        self._frame_lock = Lock()
 
     def initialize(self) -> None:
         initialize = getattr(self.capture_device, "initialize", None)
@@ -74,26 +78,79 @@ class CaptureFrameSourcePort(FrameSourcePort):
             raise ValueError("timeout must be greater than or equal to 0")
         deadline = time.monotonic() + timeout
         while True:
-            try:
-                if self.capture_device.get_frame() is not None:
-                    return True
-            except RuntimeError:
-                pass
+            if self._frame_lock.acquire(blocking=False):
+                try:
+                    try:
+                        if self.capture_device.get_frame() is not None:
+                            return True
+                    except RuntimeError:
+                        pass
+                finally:
+                    self._frame_lock.release()
             if time.monotonic() >= deadline:
                 return False
             time.sleep(0.01)
 
     def latest_frame(self) -> cv2.typing.MatLike:
+        if not self._frame_lock.acquire(timeout=0.1):
+            raise FrameReadError("Frame source lock acquisition timed out.")
         try:
             frame = self.capture_device.get_frame()
         except RuntimeError as exc:
             raise FrameNotReadyError() from exc
+        finally:
+            self._frame_lock.release()
+        return self._copy_ready_frame(frame)
+
+    def try_latest_frame(self) -> cv2.typing.MatLike | None:
+        if not self._frame_lock.acquire(blocking=False):
+            return None
+        try:
+            try:
+                frame = self.capture_device.get_frame()
+            except RuntimeError:
+                return None
+        finally:
+            self._frame_lock.release()
+        if frame is None:
+            return None
+        return frame.copy()
+
+    def _copy_ready_frame(self, frame) -> cv2.typing.MatLike:
         if frame is None:
             raise FrameNotReadyError()
         return frame.copy()
 
     def close(self) -> None:
         pass
+
+
+class DummyFrameSourcePort(FrameSourcePort):
+    def __init__(self, frame: cv2.typing.MatLike | None = None) -> None:
+        self._frame = frame if frame is not None else np.zeros((720, 1280, 3), dtype=np.uint8)
+        self.initialized = False
+        self.closed = False
+
+    def initialize(self) -> None:
+        self.initialized = True
+
+    def await_ready(self, timeout: float) -> bool:
+        if timeout is None or timeout < 0:
+            raise ValueError("timeout must be greater than or equal to 0")
+        return self.initialized
+
+    def latest_frame(self) -> cv2.typing.MatLike:
+        if not self.initialized:
+            raise FrameNotReadyError()
+        return self._frame.copy()
+
+    def try_latest_frame(self) -> cv2.typing.MatLike | None:
+        if not self.initialized:
+            return None
+        return self._frame.copy()
+
+    def close(self) -> None:
+        self.closed = True
 
 
 class NotificationHandlerAdapter(NotificationPort):

--- a/src/nyxpy/framework/core/io/ports.py
+++ b/src/nyxpy/framework/core/io/ports.py
@@ -18,6 +18,15 @@ class FrameNotReadyError(DeviceError):
         )
 
 
+class FrameReadError(DeviceError):
+    def __init__(self, message: str = "Frame source read failed.") -> None:
+        super().__init__(
+            message,
+            code="NYX_FRAME_READ_FAILED",
+            component="FrameSourcePort",
+        )
+
+
 class ControllerOutputPort(ABC):
     @abstractmethod
     def press(self, keys: tuple[KeyType, ...]) -> None: ...
@@ -59,6 +68,9 @@ class FrameSourcePort(ABC):
 
     @abstractmethod
     def latest_frame(self) -> cv2.typing.MatLike: ...
+
+    @abstractmethod
+    def try_latest_frame(self) -> cv2.typing.MatLike | None: ...
 
     @abstractmethod
     def close(self) -> None: ...

--- a/src/nyxpy/framework/core/runtime/builder.py
+++ b/src/nyxpy/framework/core/runtime/builder.py
@@ -44,6 +44,7 @@ from nyxpy.framework.core.runtime.runtime import MacroRuntime
 from nyxpy.framework.core.utils.cancellation import CancellationToken
 
 type PortFactory[T] = Callable[[RuntimeBuildRequest, MacroDefinition], T]
+type LifetimePortFactory[T] = Callable[[], T]
 type ArtifactStoreFactory = Callable[[RuntimeBuildRequest, MacroDefinition, str], RunArtifactStore]
 
 DUMMY_DEVICE_NAME = "ダミーデバイス"
@@ -63,6 +64,8 @@ class MacroRuntimeBuilder:
         artifact_store_factory: ArtifactStoreFactory,
         notification_factory: PortFactory[NotificationPort],
         logger_factory: PortFactory[LoggerPort],
+        preview_frame_source_factory: LifetimePortFactory[FrameSourcePort] | None = None,
+        manual_controller_factory: LifetimePortFactory[ControllerOutputPort] | None = None,
     ) -> None:
         self.project_root = Path(project_root).resolve()
         self.registry = registry
@@ -74,6 +77,10 @@ class MacroRuntimeBuilder:
         self._artifact_store_factory = artifact_store_factory
         self._notification_factory = notification_factory
         self._logger_factory = logger_factory
+        self._preview_frame_source_factory = preview_frame_source_factory
+        self._manual_controller_factory = manual_controller_factory
+        self._preview_frame_source: FrameSourcePort | None = None
+        self._manual_controller: ControllerOutputPort | None = None
 
     def build(self, request: RuntimeBuildRequest) -> ExecutionContext:
         definition = self.registry.resolve(request.macro_id)
@@ -112,6 +119,30 @@ class MacroRuntimeBuilder:
 
     def start(self, request: RuntimeBuildRequest) -> RunHandle:
         return self.runtime.start(self.build(request))
+
+    def frame_source_for_preview(self) -> FrameSourcePort | None:
+        if self._preview_frame_source is None and self._preview_frame_source_factory is not None:
+            self._preview_frame_source = self._preview_frame_source_factory()
+        return self._preview_frame_source
+
+    def controller_output_for_manual_input(self) -> ControllerOutputPort | None:
+        if self._manual_controller is None and self._manual_controller_factory is not None:
+            self._manual_controller = self._manual_controller_factory()
+        return self._manual_controller
+
+    def shutdown(self) -> None:
+        errors: list[Exception] = []
+        for port in (self._manual_controller, self._preview_frame_source):
+            if port is None:
+                continue
+            try:
+                port.close()
+            except Exception as exc:
+                errors.append(exc)
+        self._manual_controller = None
+        self._preview_frame_source = None
+        if errors:
+            raise ExceptionGroup("Runtime builder shutdown failed", errors)
 
     def _allow_dummy(self, request: RuntimeBuildRequest) -> bool:
         if request.allow_dummy is not None:
@@ -165,6 +196,7 @@ def create_legacy_runtime_builder(
     resolved_baudrate = _optional_int(
         baudrate if baudrate is not None else settings_snapshot.get("serial_baud")
     )
+    lifetime_request = RuntimeBuildRequest(macro_id="__gui_lifetime__")
 
     return MacroRuntimeBuilder(
         project_root=project_root,
@@ -208,6 +240,30 @@ def create_legacy_runtime_builder(
             else NotificationHandlerAdapter(notification_handler)
         ),
         logger_factory=lambda _request, _definition: logger,
+        preview_frame_source_factory=lambda: CaptureFrameSourcePort(
+            capture_device
+            if direct_devices
+            else _resolve_capture_device(
+                capture_manager,
+                resolved_capture_name,
+                detection_timeout_sec,
+                _allow_dummy(settings_snapshot, lifetime_request),
+            )
+        ),
+        manual_controller_factory=lambda: SerialControllerOutputPort(
+            (
+                serial_device
+                if direct_devices
+                else _resolve_serial_device(
+                    serial_manager,
+                    resolved_serial_name,
+                    resolved_baudrate,
+                    detection_timeout_sec,
+                    _allow_dummy(settings_snapshot, lifetime_request),
+                )
+            ),
+            protocol,
+        ),
     )
 
 

--- a/src/nyxpy/gui/panes/preview_pane.py
+++ b/src/nyxpy/gui/panes/preview_pane.py
@@ -8,6 +8,8 @@ from PySide6.QtGui import QImage, QPixmap
 from PySide6.QtWidgets import QVBoxLayout, QWidget
 
 from nyxpy.framework.core.hardware.capture import CaptureDeviceInterface
+from nyxpy.framework.core.io.adapters import CaptureFrameSourcePort
+from nyxpy.framework.core.io.ports import FrameSourcePort
 from nyxpy.framework.core.utils.helper import calc_aspect_size
 from nyxpy.gui.events import EventBus, EventType
 from nyxpy.gui.widgets import AspectRatioLabel
@@ -22,7 +24,11 @@ class PreviewPane(QWidget):
     """
 
     def __init__(
-        self, capture_device: CaptureDeviceInterface | None = None, parent=None, preview_fps=30
+        self,
+        capture_device: CaptureDeviceInterface | None = None,
+        parent=None,
+        preview_fps=30,
+        frame_source: FrameSourcePort | None = None,
     ):
         super().__init__(parent)
         layout = QVBoxLayout(self)
@@ -31,7 +37,10 @@ class PreviewPane(QWidget):
         self.label.setMinimumHeight(100)
         layout.addWidget(self.label)
 
-        self.capture_device: CaptureDeviceInterface = capture_device
+        self.capture_device: CaptureDeviceInterface | None = capture_device
+        self.frame_source: FrameSourcePort | None = frame_source
+        if self.frame_source is None and capture_device is not None:
+            self.frame_source = CaptureFrameSourcePort(capture_device)
         self.preview_fps = preview_fps  # プレビュー用のみ
         self.event_bus = EventBus.get_instance()
         self.event_bus.subscribe(EventType.CAPTURE_DEVICE_CHANGED, self.on_capture_device_changed)
@@ -46,16 +55,26 @@ class PreviewPane(QWidget):
 
     def set_capture_device(self, device: CaptureDeviceInterface):
         self.capture_device = device
+        self.frame_source = CaptureFrameSourcePort(device) if device is not None else None
         self.update_preview()
 
+    def set_frame_source(self, frame_source: FrameSourcePort | None) -> None:
+        self.capture_device = None
+        self.frame_source = frame_source
+        self.update_preview()
+
+    def pause(self) -> None:
+        self.timer.stop()
+
+    def resume(self) -> None:
+        if self.isVisible() and self.frame_source is not None:
+            self.apply_fps()
+
     def update_preview(self):
-        if not self.isVisible() or self.capture_device is None:
+        if not self.isVisible() or self.frame_source is None:
             return
-        try:
-            frame = self.capture_device.get_frame()
-            if frame is None:
-                return
-        except RuntimeError:
+        frame = self.frame_source.try_latest_frame()
+        if frame is None:
             return
         size = self.label.size()
         target_w, target_h = calc_aspect_size(size, self.label.aspect_w, self.label.aspect_h)
@@ -76,10 +95,10 @@ class PreviewPane(QWidget):
         snaps_dir.mkdir(exist_ok=True)
         timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
         filepath = snaps_dir / f"{timestamp}.png"
-        if self.capture_device is None:
+        if self.frame_source is None:
             msg = "プレビューがありません。スナップショットに失敗しました。"
         else:
-            pix = self.capture_device.get_frame()
+            pix = self.frame_source.try_latest_frame()
             if pix is not None:
                 target_w, target_h = 1280, 720
                 pix = cv2.resize(pix, (target_w, target_h), interpolation=cv2.INTER_AREA)

--- a/tests/gui/test_preview_pane.py
+++ b/tests/gui/test_preview_pane.py
@@ -49,9 +49,10 @@ class TestPreviewPane:
         result = preview_pane.take_snapshot()
         expected_path = Path.cwd() / SNAPSHOT_DIR / f"{mock_timestamp}.png"
         assert os.path.exists(Path.cwd() / SNAPSHOT_DIR)
-        mock_cv2.resize.assert_called_once_with(
-            test_frame, (1280, 720), interpolation=mock_cv2.INTER_AREA
-        )
+        resized_frame, target_size = mock_cv2.resize.call_args.args
+        assert np.array_equal(resized_frame, test_frame)
+        assert target_size == (1280, 720)
+        assert mock_cv2.resize.call_args.kwargs == {"interpolation": mock_cv2.INTER_AREA}
         mock_cv2.imwrite.assert_called_once_with(str(expected_path), test_frame)
         signal_mock.emit.assert_called_once_with(f"スナップショット保存: {mock_timestamp}.png")
         assert result == f"スナップショット保存: {mock_timestamp}.png"
@@ -99,3 +100,20 @@ class TestPreviewPane:
         expected_msg = f"スナップショット保存: {mock_timestamp}.png"
         signal_mock.emit.assert_called_once_with(expected_msg)
         assert result == expected_msg
+
+    def test_update_preview_skips_when_frame_source_busy(self, preview_pane, qtbot):
+        """Busy FrameSourcePort should keep the current pixmap and not block the UI."""
+        frame_source = Mock()
+        frame_source.try_latest_frame.return_value = None
+        preview_pane.set_frame_source(frame_source)
+        preview_pane.show()
+        qtbot.wait(10)
+        before_pixmap = preview_pane.label.pixmap()
+        before_key = before_pixmap.cacheKey() if before_pixmap is not None else None
+
+        preview_pane.update_preview()
+
+        after_pixmap = preview_pane.label.pixmap()
+        after_key = after_pixmap.cacheKey() if after_pixmap is not None else None
+        assert after_key == before_key
+        frame_source.try_latest_frame.assert_called()

--- a/tests/perf/test_preview_runtime_frame_source_contention.py
+++ b/tests/perf/test_preview_runtime_frame_source_contention.py
@@ -1,0 +1,56 @@
+import statistics
+import time
+
+import numpy as np
+
+from nyxpy.framework.core.io.adapters import CaptureFrameSourcePort
+
+
+class StaticCaptureDevice:
+    def __init__(self, frame) -> None:
+        self.frame = frame
+
+    def get_frame(self):
+        return self.frame
+
+
+def _p95(values: list[float]) -> float:
+    return statistics.quantiles(values, n=20)[18]
+
+
+def test_frame_source_latest_frame_copy_perf() -> None:
+    frame = np.zeros((720, 1280, 3), dtype=np.uint8)
+    source = CaptureFrameSourcePort(StaticCaptureDevice(frame))
+    samples: list[float] = []
+
+    for _ in range(30):
+        started = time.perf_counter()
+        source.latest_frame()
+        samples.append(time.perf_counter() - started)
+
+    assert _p95(samples) < 0.01
+
+
+def test_preview_runtime_frame_source_contention_perf() -> None:
+    frame = np.zeros((720, 1280, 3), dtype=np.uint8)
+    source = CaptureFrameSourcePort(StaticCaptureDevice(frame))
+    baseline: list[float] = []
+    contended: list[float] = []
+    preview_ticks: list[float] = []
+
+    for _ in range(30):
+        started = time.perf_counter()
+        source.latest_frame()
+        baseline.append(time.perf_counter() - started)
+
+    for _ in range(30):
+        preview_started = time.perf_counter()
+        source.try_latest_frame()
+        preview_ticks.append(time.perf_counter() - preview_started)
+
+        capture_started = time.perf_counter()
+        source.latest_frame()
+        contended.append(time.perf_counter() - capture_started)
+
+    assert sum(tick >= 0.016 for tick in preview_ticks) / len(preview_ticks) < 0.01
+    assert _p95(contended) < max(_p95(baseline) * 2, 0.01)

--- a/tests/support/fakes.py
+++ b/tests/support/fakes.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from datetime import datetime
 from io import BytesIO
 from pathlib import Path
+from threading import Lock
 
 import cv2
 import numpy as np
@@ -77,6 +78,7 @@ class FakeFrameSourcePort(FrameSourcePort):
         self.frame = frame if frame is not None else np.zeros((2, 2, 3), dtype=np.uint8)
         self.initialized = False
         self.closed = False
+        self.frame_lock = Lock()
 
     def initialize(self) -> None:
         self.initialized = True
@@ -89,7 +91,18 @@ class FakeFrameSourcePort(FrameSourcePort):
     def latest_frame(self) -> cv2.typing.MatLike:
         if not self.initialized:
             raise FrameNotReadyError()
-        return self.frame.copy()
+        with self.frame_lock:
+            return self.frame.copy()
+
+    def try_latest_frame(self) -> cv2.typing.MatLike | None:
+        if not self.initialized:
+            return None
+        if not self.frame_lock.acquire(blocking=False):
+            return None
+        try:
+            return self.frame.copy()
+        finally:
+            self.frame_lock.release()
 
     def close(self) -> None:
         self.closed = True

--- a/tests/unit/framework/io/test_adapters.py
+++ b/tests/unit/framework/io/test_adapters.py
@@ -6,6 +6,7 @@ import pytest
 from nyxpy.framework.core.constants import Button, KeyboardOp, KeyCode
 from nyxpy.framework.core.io.adapters import (
     CaptureFrameSourcePort,
+    DummyFrameSourcePort,
     NoopNotificationAdapter,
     NotificationHandlerAdapter,
     NotificationHandlerPort,
@@ -122,6 +123,41 @@ def test_frame_source_latest_frame_returns_copy_and_reports_not_ready() -> None:
 
     with pytest.raises(FrameNotReadyError):
         port.latest_frame()
+
+
+def test_frame_source_try_latest_frame_returns_copy_and_skips_not_ready() -> None:
+    frame = np.ones((2, 2, 3), dtype=np.uint8)
+    port = CaptureFrameSourcePort(CaptureDevice([frame, None]))
+
+    latest = port.try_latest_frame()
+
+    assert latest is not None
+    latest[0, 0, 0] = 0
+    assert frame[0, 0, 0] == 1
+    assert port.try_latest_frame() is None
+
+
+def test_frame_source_try_latest_frame_is_nonblocking() -> None:
+    port = CaptureFrameSourcePort(CaptureDevice([np.ones((2, 2, 3), dtype=np.uint8)]))
+
+    assert port._frame_lock.acquire(blocking=False)
+    try:
+        assert port.try_latest_frame() is None
+    finally:
+        port._frame_lock.release()
+
+
+def test_dummy_frame_source_port_is_ready_after_initialize() -> None:
+    port = DummyFrameSourcePort()
+
+    assert port.await_ready(0) is False
+    assert port.try_latest_frame() is None
+
+    port.initialize()
+
+    assert port.await_ready(0) is True
+    assert port.latest_frame().shape == (720, 1280, 3)
+    assert port.try_latest_frame() is not None
 
 
 def test_notification_port_forwards_to_handler() -> None:

--- a/tests/unit/framework/io/test_fake_ports.py
+++ b/tests/unit/framework/io/test_fake_ports.py
@@ -33,6 +33,21 @@ def test_fake_frame_source_readiness() -> None:
     latest = source.latest_frame()
     latest[0, 0, 0] = 99
     assert frame[0, 0, 0] == 7
+    preview_frame = source.try_latest_frame()
+    assert preview_frame is not None
+    preview_frame[0, 0, 0] = 88
+    assert frame[0, 0, 0] == 7
+
+
+def test_fake_frame_source_try_latest_frame_is_nonblocking() -> None:
+    source = FakeFrameSourcePort()
+    source.initialize()
+
+    assert source.frame_lock.acquire(blocking=False)
+    try:
+        assert source.try_latest_frame() is None
+    finally:
+        source.frame_lock.release()
 
 
 def test_fake_frame_source_rejects_invalid_timeout() -> None:

--- a/tests/unit/framework/runtime/test_removed_api_imports.py
+++ b/tests/unit/framework/runtime/test_removed_api_imports.py
@@ -1,0 +1,31 @@
+import ast
+from pathlib import Path
+
+FRAMEWORK_ROOT = Path(__file__).parents[4] / "src" / "nyxpy" / "framework" / "core"
+SCANNED_PACKAGES = ("runtime", "io", "macro")
+REMOVED_IMPORTS = (
+    "nyxpy.framework.core.logger.log_manager",
+    "nyxpy.framework.core.singletons",
+)
+REMOVED_NAMES = {"LogManager", "log_manager", "serial_manager", "capture_manager"}
+
+
+def test_framework_runtime_path_does_not_import_removed_apis() -> None:
+    violations: list[str] = []
+    for package in SCANNED_PACKAGES:
+        for path in (FRAMEWORK_ROOT / package).rglob("*.py"):
+            if path.name == "executor.py":
+                continue
+            tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+            for node in ast.walk(tree):
+                if isinstance(node, ast.Import):
+                    for alias in node.names:
+                        if alias.name in REMOVED_IMPORTS or alias.name.rsplit(".", 1)[-1] in REMOVED_NAMES:
+                            violations.append(f"{path}: import {alias.name}")
+                elif isinstance(node, ast.ImportFrom):
+                    module = node.module or ""
+                    imported_names = {alias.name for alias in node.names}
+                    if module in REMOVED_IMPORTS or imported_names & REMOVED_NAMES:
+                        violations.append(f"{path}: from {module} import {sorted(imported_names)}")
+
+    assert violations == []

--- a/tests/unit/framework/runtime/test_runtime_builder.py
+++ b/tests/unit/framework/runtime/test_runtime_builder.py
@@ -3,11 +3,23 @@ from pathlib import Path
 import pytest
 
 from nyxpy.framework.core.io.adapters import NoopNotificationAdapter, NotificationHandlerAdapter
+from nyxpy.framework.core.io.resources import MacroResourceScope
 from nyxpy.framework.core.macro.exceptions import ConfigurationError
 from nyxpy.framework.core.macro.registry import MacroDefinition
-from nyxpy.framework.core.runtime.builder import DUMMY_DEVICE_NAME, create_legacy_runtime_builder
+from nyxpy.framework.core.runtime.builder import (
+    DUMMY_DEVICE_NAME,
+    MacroRuntimeBuilder,
+    create_legacy_runtime_builder,
+)
 from nyxpy.framework.core.runtime.context import RuntimeBuildRequest
-from tests.support.fakes import FakeLoggerPort
+from tests.support.fakes import (
+    FakeControllerOutputPort,
+    FakeFrameSourcePort,
+    FakeLoggerPort,
+    FakeNotificationPort,
+    FakeResourceStore,
+    FakeRunArtifactStore,
+)
 
 
 class Registry:
@@ -184,3 +196,36 @@ def test_runtime_builder_rejects_mixed_direct_and_managed_devices(tmp_path: Path
             notification_handler=None,
             logger=FakeLoggerPort(),
         )
+
+
+def test_runtime_builder_exposes_and_shutdowns_gui_lifetime_ports(tmp_path: Path) -> None:
+    registry = Registry(definition(tmp_path))
+    preview_source = FakeFrameSourcePort()
+    manual_controller = FakeControllerOutputPort()
+    builder = MacroRuntimeBuilder(
+        project_root=tmp_path,
+        registry=registry,
+        controller_factory=lambda _request, _definition: FakeControllerOutputPort(),
+        frame_source_factory=lambda _request, _definition: FakeFrameSourcePort(),
+        resource_store_factory=lambda _request, definition: FakeResourceStore(
+            MacroResourceScope.from_definition(definition, tmp_path)
+        ),
+        artifact_store_factory=lambda _request, definition, run_id: FakeRunArtifactStore(
+            tmp_path / "runs" / run_id / "outputs",
+            macro_id=definition.id,
+            run_id=run_id,
+        ),
+        notification_factory=lambda _request, _definition: FakeNotificationPort(),
+        logger_factory=lambda _request, _definition: FakeLoggerPort(),
+        preview_frame_source_factory=lambda: preview_source,
+        manual_controller_factory=lambda: manual_controller,
+    )
+
+    assert builder.frame_source_for_preview() is preview_source
+    assert builder.frame_source_for_preview() is preview_source
+    assert builder.controller_output_for_manual_input() is manual_controller
+
+    builder.shutdown()
+
+    assert preview_source.closed is True
+    assert manual_controller.closed is True


### PR DESCRIPTION
## Summary
- FrameSourcePort に非ブロッキング取得 try_latest_frame を追加
- MacroRuntimeBuilder に GUI lifetime Port 取得と shutdown を追加
- PreviewPane を FrameSourcePort 経由に移行し、競合時は frame skip する
- framework followup spec の完了チェックと removal gate テストを追加

## Commit Log
- 037368c feat(framework): preview向けFrameSourcePortを追加

## Testing
- uv run pytest
- uv run ruff check .
- git --no-pager diff --check