### PR TITLE
feat(settings): .nyxpy 配置を project root に固定

### DIFF
--- a/spec/agent/complete/local_003/NYXPY_CONFIG_ROOT.md
+++ b/spec/agent/complete/local_003/NYXPY_CONFIG_ROOT.md
@@ -50,7 +50,7 @@
 
 | ファイル | 変更種別 | 変更内容 |
 |----------|----------|----------|
-| `spec\agent\wip\local_003\NYXPY_CONFIG_ROOT.md` | 新規 | `.nyxpy` 配置と生成責務の仕様を定義する |
+| `spec\agent\complete\local_003\NYXPY_CONFIG_ROOT.md` | 新規 | `.nyxpy` 配置と生成責務の仕様を定義する |
 | `src\nyxpy\framework\core\settings\global_settings.py` | 変更 | `SettingsStore` / `GlobalSettings` の `config_dir` を必須化し、`Path.cwd()` fallback を削除する |
 | `src\nyxpy\framework\core\settings\secrets_settings.py` | 変更 | `SecretsStore` / `SecretsSettings` の `config_dir` を必須化し、`Path.cwd()` fallback を削除する |
 | `src\nyxpy\framework\core\settings\workspace.py` | 新規 | project root 解決と workspace 初期化の共通関数を定義する |
@@ -174,7 +174,7 @@ framework settings は GUI に依存しない。GUI は `WorkspacePaths` と sto
 | 3 | `allow_current_as_new=True` の cwd | 新規 workspace root として `ensure_workspace()` で生成する |
 | 4 | 上記なし | workspace 未決定として `ConfigurationError` を送出する |
 
-`nyxpy init` は `allow_current_as_new=True` で cwd を初期化する。GUI の初回起動は root 選択 UI がない間だけ `allow_current_as_new=True` で cwd を使う。CLI の macro 実行は明示 root または既存 workspace を優先し、未初期化 cwd を新規 workspace として扱うかどうかを実装時に CLI UX と合わせて決定する。
+`nyxpy init` は `allow_current_as_new=True` で cwd を初期化する。GUI の初回起動は root 選択 UI がない間だけ `allow_current_as_new=True` で cwd を使う。CLI の macro 実行は既存 workspace marker を探索し、未初期化 cwd では `NYX_WORKSPACE_NOT_FOUND` を返す。
 
 ### 生成タイミング
 
@@ -184,7 +184,7 @@ framework settings は GUI に依存しない。GUI は `WorkspacePaths` と sto
 |------------------|----------|------|
 | `nyxpy init` | 生成する | ユーザが cwd を workspace root として初期化する意思を示している |
 | GUI 初回起動 | 生成する | root 選択 UI がない現状では cwd を起動 root とする必要がある |
-| CLI macro 実行 | 条件付きで生成する | macro discovery の project root と同一である場合のみ一貫性がある |
+| CLI macro 実行 | 既存 workspace または明示 root でのみ生成する | 未初期化 cwd への暗黙 workspace 生成を避ける |
 | `SettingsStore(config_dir=...)` | 生成する | config_dir は呼び出し元が既に決定済みである |
 | `SettingsStore()` | 不可 | 保存先を推測しない |
 
@@ -252,7 +252,7 @@ def ensure_workspace(project_root: Path) -> WorkspacePaths:
 | `runs` | 実行成果物の保存先 |
 | `logs` | `create_default_logging()` の保存先 |
 
-`macros\__init__.py` の生成は既存 `init_app()` と同じく維持する。`static` は migration 後の旧ディレクトリであるため生成しない。
+`macros\__init__.py` は `ensure_workspace()` が `macros` を新規作成した場合に生成する。既存 `macros` ディレクトリには追加しない。`static` は migration 後の旧ディレクトリであるため生成しない。
 
 ### settings store
 
@@ -269,7 +269,7 @@ store は `Path.cwd()`、project root 探索、GUI 状態を参照しない。
 
 ### CLI / GUI wiring
 
-CLI は runtime builder 作成前に `WorkspacePaths` を得て、`SettingsStore(config_dir=paths.config_dir)` と `SecretsStore(config_dir=paths.config_dir)` を生成する。GUI は `run_gui.main()` または `MainWindow` 生成前に project root を決め、`GuiAppServices(project_root=paths.project_root)` が `GlobalSettings(config_dir=paths.config_dir)` と `SecretsSettings(config_dir=paths.config_dir)` を生成する。
+CLI は runtime builder 作成前に `WorkspacePaths` を得て、`SettingsStore(config_dir=paths.config_dir)` と `SecretsStore(config_dir=paths.config_dir)` を生成する。CLI logging は `paths.logs_dir` を使い、サブディレクトリ起動時にも `project_root\logs` へ揃える。GUI は `run_gui.main()` または `MainWindow` 生成前に project root を決め、`GuiAppServices(project_root=paths.project_root)` が `GlobalSettings(config_dir=paths.config_dir)` と `SecretsSettings(config_dir=paths.config_dir)` を生成する。
 
 `AppSettingsDialog` は原則として `MainWindow` から渡された store を使う。引数省略時に新しい `GlobalSettings()` / `SecretsSettings()` を作る fallback は削除する。
 
@@ -317,15 +317,15 @@ project root 未決定時の `ConfigurationError` は `code="NYX_WORKSPACE_NOT_F
 
 ## 6. 実装チェックリスト
 
-- [ ] `WorkspacePaths`, `resolve_project_root()`, `ensure_workspace()` のシグネチャ確定
-- [ ] `SettingsStore` / `SecretsStore` の `config_dir` 必須化
-- [ ] `GlobalSettings` / `SecretsSettings` の `config_dir` 必須化
-- [ ] CLI の workspace 解決と store wiring 更新
-- [ ] GUI の workspace 解決と store wiring 更新
-- [ ] `AppSettingsDialog` の引数なし store fallback 削除
-- [ ] `nyxpy init` の workspace 初期化処理更新
-- [ ] ユニットテスト作成・パス
-- [ ] GUI テスト作成・パス
-- [ ] 結合テスト作成・パス
-- [ ] `uv run ruff check .` パス
-- [ ] `uv run pytest tests\unit tests\gui tests\integration` パス
+- [x] `WorkspacePaths`, `resolve_project_root()`, `ensure_workspace()` のシグネチャ確定
+- [x] `SettingsStore` / `SecretsStore` の `config_dir` 必須化
+- [x] `GlobalSettings` / `SecretsSettings` の `config_dir` 必須化
+- [x] CLI の workspace 解決と store wiring 更新
+- [x] GUI の workspace 解決と store wiring 更新
+- [x] `AppSettingsDialog` の引数なし store fallback 削除
+- [x] `nyxpy init` の workspace 初期化処理更新
+- [x] ユニットテスト作成・パス
+- [x] GUI テスト作成・パス
+- [x] 結合テスト作成・パス
+- [x] `uv run ruff check .` パス
+- [x] `uv run pytest tests\unit tests\gui tests\integration` パス

--- a/spec/dev-journal.md
+++ b/spec/dev-journal.md
@@ -2,16 +2,16 @@
 
 実装中の設計上の気づき・疑問・バックログ送りタスクの記録。
 
-## 2026-05-12: `.nyxpy` 配置と project root の決定責務
+## 2026-05-13: PaddlePaddle を含む依存ライブラリ更新
 
 ### 現状
 
-`SettingsStore` / `SecretsStore` は `config_dir` 未指定時に `Path.cwd() / ".nyxpy"` を使い、CLI は `project_root / ".nyxpy"` を明示する一方で GUI の `GuiAppServices` は `GlobalSettings()` / `SecretsSettings()` を引数なしで生成している。
+`pyproject.toml` は `paddlepaddle>=3.0.0,<3.3.0` と `paddleocr>=3.0.0` を指定し、`uv.lock` は `paddlepaddle 3.2.2` / `paddleocr 3.4.0` を解決している。
 
 ### 観察
 
-再設計仕様ではマクロ settings / resource の `Path.cwd()` fallback を削除する方針だが、アプリ公開後に任意の場所で初期化してそこをアプリルートにする初期設計意図があった可能性があり、`.nyxpy` の配置先を cwd で決めるべきか project root で明示すべきかは別途整理が必要。
+`tests\unit\imgproc\test_ocr_processor.py::TestOCRProcessorInit::test_init_en_succeeds` で PaddlePaddle の `No ccache found` warning が出ており、PaddlePaddle 側では PR `PaddlePaddle/Paddle#77116` で通常 import 時の ccache 探索を遅延化している。
 
 ### 方針
 
-`spec\gui\rearchitecture\PHASE_5_LEGACY_ROUTE_AND_FW_CLEANUP.md` と `src\nyxpy\framework\core\settings\global_settings.py` / `secrets_settings.py` を見直し、アプリルート初期化モデルを維持するなら composition root が明示 `config_dir` を渡す形に寄せ、store 内部の暗黙 `Path.cwd()` 既定値を残す理由を仕様へ移す。
+PaddlePaddle / PaddleOCR を含む依存更新を別タスクで検討し、過去に `paddlepaddle` の上限を `<3.3.0` にした理由を確認したうえで OCR 初期化テストと CI warning の扱いを見直す。

--- a/src/nyxpy/__main__.py
+++ b/src/nyxpy/__main__.py
@@ -4,6 +4,8 @@ from pathlib import Path
 
 from nyxpy.cli.run_cli import cli_main
 from nyxpy.framework.core.settings.global_settings import GlobalSettings
+from nyxpy.framework.core.settings.secrets_settings import SecretsSettings
+from nyxpy.framework.core.settings.workspace import ensure_workspace
 from nyxpy.gui.run_gui import main as gui_main
 
 
@@ -11,15 +13,10 @@ def init_app() -> int:
     """
     Initialize the workspace for GUI/CLI: create macros, snapshots, resources, runs folders.
     """
-    dirs = ["macros", "snapshots", "resources", "runs"]
-    for d in dirs:
-        Path(d).mkdir(exist_ok=True)
-    # Ensure macros is a package
-    init_file = Path("macros") / "__init__.py"
-    if not init_file.exists():
-        init_file.write_text("")
-    # Initialize global settings directory and default config
-    GlobalSettings()
+    paths = ensure_workspace(Path.cwd())
+    GlobalSettings(config_dir=paths.config_dir)
+    SecretsSettings(config_dir=paths.config_dir)
+    dirs = ["macros", "snapshots", "resources", "runs", "logs"]
     print(f"Initialized directories: {', '.join(dirs)}, .nyxpy")
     return 0
 

--- a/src/nyxpy/cli/run_cli.py
+++ b/src/nyxpy/cli/run_cli.py
@@ -22,6 +22,7 @@ from nyxpy.framework.core.runtime.context import RuntimeBuildRequest
 from nyxpy.framework.core.runtime.result import RunResult, RunStatus
 from nyxpy.framework.core.settings.global_settings import SettingsStore
 from nyxpy.framework.core.settings.secrets_settings import SecretsStore
+from nyxpy.framework.core.settings.workspace import ensure_workspace, resolve_project_root
 from nyxpy.framework.core.utils.helper import parse_define_args
 
 
@@ -49,7 +50,12 @@ class CliPresenter:
         return 2
 
 
-def configure_logging(silence: bool = False, verbose: bool = False) -> LoggingComponents:
+def configure_logging(
+    silence: bool = False,
+    verbose: bool = False,
+    *,
+    base_dir: pathlib.Path | None = None,
+) -> LoggingComponents:
     """
     コマンドライン引数に基づいてログレベルを設定します。
 
@@ -57,7 +63,7 @@ def configure_logging(silence: bool = False, verbose: bool = False) -> LoggingCo
         silence: Trueの場合、ほとんどのログ出力を抑制します
         verbose: Trueの場合、デバッグレベルのログを有効にします
     """
-    logging = create_default_logging(base_dir=pathlib.Path.cwd() / "logs")
+    logging = create_default_logging(base_dir=base_dir or pathlib.Path.cwd() / "logs")
     if silence:
         print("Running in silent mode; logging is disabled.")
         logging.set_all_levels("ERROR")
@@ -88,8 +94,8 @@ def create_protocol(protocol_name: str) -> SerialProtocolInterface:
 def create_runtime_builder(
     protocol: SerialProtocolInterface,
     logger: LoggerPort,
-    resources_dir: pathlib.Path | None = None,
     *,
+    project_root: pathlib.Path | None = None,
     serial_name: str | None = None,
     capture_name: str | None = None,
     baudrate: int | None = None,
@@ -106,7 +112,7 @@ def create_runtime_builder(
     Args:
         protocol: 使用するプロトコル実装
         logger: Runtime に注入する logger
-        resources_dir: 旧互換引数。指定時はプロジェクトルートとして扱います。
+        project_root: 使用する NyX workspace root
         serial_name: 使用するシリアルデバイス名
         capture_name: 使用するキャプチャデバイス名
         baudrate: シリアルボーレート
@@ -114,12 +120,15 @@ def create_runtime_builder(
     Returns:
         設定済みの Runtime builder
     """
-    project_root = pathlib.Path.cwd() if resources_dir is None else resources_dir
-    registry = MacroRegistry(project_root=project_root)
+    resolved_root = resolve_project_root(
+        explicit_root=project_root,
+        allow_current_as_new=False,
+    )
+    paths = ensure_workspace(resolved_root)
+    registry = MacroRegistry(project_root=paths.project_root)
     registry.reload()
-    config_dir = project_root / ".nyxpy"
-    settings = settings_store or SettingsStore(config_dir=config_dir, strict_load=False)
-    secrets = secrets_store or SecretsStore(config_dir=config_dir, strict_load=False)
+    settings = settings_store or SettingsStore(config_dir=paths.config_dir, strict_load=False)
+    secrets = secrets_store or SecretsStore(config_dir=paths.config_dir, strict_load=False)
     discovery = device_discovery or DeviceDiscoveryService(logger=logger)
     controller_factory = controller_output_factory or ControllerOutputPortFactory(
         discovery=discovery,
@@ -133,7 +142,7 @@ def create_runtime_builder(
         secrets.snapshot(), logger=logger
     )
     return create_device_runtime_builder(
-        project_root=project_root,
+        project_root=paths.project_root,
         registry=registry,
         device_discovery=discovery,
         controller_output_factory=controller_factory,
@@ -232,8 +241,15 @@ def cli_main(args: argparse.Namespace) -> int:
         終了コード（0:成功、0以外:エラー）
     """
     try:
+        project_root = resolve_project_root(allow_current_as_new=False)
+        paths = ensure_workspace(project_root)
+
         # ログの設定
-        logging = configure_logging(silence=args.silence, verbose=args.verbose)
+        logging = configure_logging(
+            silence=args.silence,
+            verbose=args.verbose,
+            base_dir=paths.logs_dir,
+        )
         logger = logging.logger
 
         baudrate = ProtocolFactory.resolve_baudrate(args.protocol, getattr(args, "baud", None))
@@ -242,6 +258,7 @@ def cli_main(args: argparse.Namespace) -> int:
         runtime_builder = create_runtime_builder(
             protocol=protocol,
             logger=logger,
+            project_root=paths.project_root,
             serial_name=args.serial,
             capture_name=args.capture,
             baudrate=baudrate,

--- a/src/nyxpy/framework/core/settings/global_settings.py
+++ b/src/nyxpy/framework/core/settings/global_settings.py
@@ -52,7 +52,7 @@ class SettingsStore:
 
     def __init__(
         self,
-        config_dir: Path | None = None,
+        config_dir: Path,
         *,
         schema: SettingsSchema = GLOBAL_SETTINGS_SCHEMA,
         filename: str = "global.toml",
@@ -60,8 +60,8 @@ class SettingsStore:
     ) -> None:
         if any(field.secret for field in schema.fields.values()):
             raise SecretBoundaryError("SettingsStore schema must not contain secret fields")
-        self.config_dir = config_dir or Path.cwd() / ".nyxpy"
-        self.config_dir.mkdir(exist_ok=True)
+        self.config_dir = Path(config_dir)
+        self.config_dir.mkdir(parents=True, exist_ok=True)
         self.config_path = self.config_dir / filename
         self.schema = schema
         self.strict_load = strict_load
@@ -122,7 +122,7 @@ class SettingsStore:
 
 
 class GlobalSettings(SettingsStore):
-    """Compatibility shim for .nyxpy/global.toml under the working directory."""
+    """Schema-fixed store for non-secret global settings."""
 
-    def __init__(self, config_dir: Path | None = None) -> None:
+    def __init__(self, config_dir: Path) -> None:
         super().__init__(config_dir=config_dir, strict_load=False)

--- a/src/nyxpy/framework/core/settings/secrets_settings.py
+++ b/src/nyxpy/framework/core/settings/secrets_settings.py
@@ -43,14 +43,14 @@ class SecretsStore:
 
     def __init__(
         self,
-        config_dir: Path | None = None,
+        config_dir: Path,
         *,
         schema: SettingsSchema = SECRETS_SETTINGS_SCHEMA,
         filename: str = "secrets.toml",
         strict_load: bool = True,
     ) -> None:
-        self.config_dir = config_dir or Path.cwd() / ".nyxpy"
-        self.config_dir.mkdir(exist_ok=True)
+        self.config_dir = Path(config_dir)
+        self.config_dir.mkdir(parents=True, exist_ok=True)
         self.config_path = self.config_dir / filename
         self.schema = schema
         self.strict_load = strict_load
@@ -118,7 +118,7 @@ class SecretsStore:
 
 
 class SecretsSettings(SecretsStore):
-    """Compatibility shim for .nyxpy/secrets.toml under the working directory."""
+    """Schema-fixed store for notification secrets and flags."""
 
-    def __init__(self, config_dir: Path | None = None) -> None:
+    def __init__(self, config_dir: Path) -> None:
         super().__init__(config_dir=config_dir, strict_load=False)

--- a/src/nyxpy/framework/core/settings/workspace.py
+++ b/src/nyxpy/framework/core/settings/workspace.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from nyxpy.framework.core.macro.exceptions import ConfigurationError
+
+
+@dataclass(frozen=True)
+class WorkspacePaths:
+    project_root: Path
+    config_dir: Path
+    macros_dir: Path
+    resources_dir: Path
+    snapshots_dir: Path
+    runs_dir: Path
+    logs_dir: Path
+
+
+def resolve_project_root(
+    *,
+    explicit_root: Path | None = None,
+    start: Path | None = None,
+    allow_current_as_new: bool = False,
+) -> Path:
+    """Resolve the NyX project root without creating settings files."""
+    if explicit_root is not None:
+        return Path(explicit_root).resolve(strict=False)
+
+    start_path = Path.cwd() if start is None else Path(start)
+    start_path = start_path.resolve(strict=False)
+    search_root = start_path if start_path.is_dir() else start_path.parent
+
+    for candidate in (search_root, *search_root.parents):
+        if (candidate / ".nyxpy").is_dir():
+            return candidate
+
+    if allow_current_as_new:
+        return search_root
+
+    raise ConfigurationError(
+        "NyX workspace not found. Run `nyxpy init` in the project root.",
+        code="NYX_WORKSPACE_NOT_FOUND",
+        component="Workspace",
+        details={
+            "start": str(start_path),
+            "explicit_root": False,
+        },
+    )
+
+
+def ensure_workspace(project_root: Path) -> WorkspacePaths:
+    """Create workspace directories and return canonical paths."""
+    root = Path(project_root).resolve(strict=False)
+    paths = WorkspacePaths(
+        project_root=root,
+        config_dir=root / ".nyxpy",
+        macros_dir=root / "macros",
+        resources_dir=root / "resources",
+        snapshots_dir=root / "snapshots",
+        runs_dir=root / "runs",
+        logs_dir=root / "logs",
+    )
+
+    root.mkdir(parents=True, exist_ok=True)
+    macros_dir_existed = paths.macros_dir.exists()
+    for directory in (
+        paths.config_dir,
+        paths.macros_dir,
+        paths.resources_dir,
+        paths.snapshots_dir,
+        paths.runs_dir,
+        paths.logs_dir,
+    ):
+        directory.mkdir(parents=True, exist_ok=True)
+
+    init_file = paths.macros_dir / "__init__.py"
+    if not macros_dir_existed and not init_file.exists():
+        init_file.write_text("", encoding="utf-8")
+
+    return paths

--- a/src/nyxpy/gui/app_services.py
+++ b/src/nyxpy/gui/app_services.py
@@ -38,13 +38,14 @@ class SettingsApplyOutcome:
 class GuiAppServices:
     def __init__(self, *, project_root: Path) -> None:
         self.project_root = Path(project_root)
+        config_dir = self.project_root / ".nyxpy"
         self.logging = create_default_logging(
             base_dir=self.project_root / "logs",
             console_enabled=False,
         )
         self.logger = self.logging.logger
-        self.global_settings = GlobalSettings()
-        self.secrets_settings = SecretsSettings()
+        self.global_settings = GlobalSettings(config_dir=config_dir)
+        self.secrets_settings = SecretsSettings(config_dir=config_dir)
         self.device_discovery = DeviceDiscoveryService(logger=self.logger)
         self.registry = MacroRegistry(project_root=self.project_root)
         self.macro_catalog = MacroCatalog(self.registry)

--- a/src/nyxpy/gui/dialogs/app_settings_dialog.py
+++ b/src/nyxpy/gui/dialogs/app_settings_dialog.py
@@ -14,16 +14,16 @@ class AppSettingsDialog(QDialog):
     def __init__(
         self,
         parent,
-        settings: GlobalSettings = None,
-        secrets: SecretsSettings = None,
+        settings: GlobalSettings,
+        secrets: SecretsSettings,
         *,
         device_discovery: DeviceDiscoveryService | None = None,
     ):
         super().__init__(parent)
         self.setWindowTitle("デバイス・通知・一般設定")
         self.resize(500, 400)
-        self.settings = settings or GlobalSettings()
-        self.secrets = secrets or SecretsSettings()
+        self.settings = settings
+        self.secrets = secrets
         layout = QVBoxLayout(self)
 
         # タブウィジェット

--- a/src/nyxpy/gui/main_window.py
+++ b/src/nyxpy/gui/main_window.py
@@ -27,9 +27,19 @@ from nyxpy.gui.panes.virtual_controller_pane import VirtualControllerPane
 
 
 class MainWindow(QMainWindow):
-    def __init__(self, services: GuiAppServices | None = None):
+    def __init__(
+        self,
+        services: GuiAppServices | None = None,
+        *,
+        project_root: Path | None = None,
+    ):
         super().__init__()
-        self.project_root = Path.cwd()
+        if services is None:
+            self.project_root = Path.cwd() if project_root is None else Path(project_root)
+        else:
+            self.project_root = (
+                Path(project_root) if project_root is not None else services.project_root
+            )
         self.services = services or GuiAppServices(project_root=self.project_root)
         self.logging = self.services.logging
         self.logger = self.services.logger

--- a/src/nyxpy/gui/run_gui.py
+++ b/src/nyxpy/gui/run_gui.py
@@ -1,17 +1,16 @@
 import sys
-from pathlib import Path
 
 from PySide6.QtWidgets import QApplication
 
+from nyxpy.framework.core.settings.workspace import ensure_workspace, resolve_project_root
 from nyxpy.gui.main_window import MainWindow
 
 
 def main():
-    # Initialize required directories
-    for d in ("macros", "snapshots", "resources", "runs"):
-        Path(d).mkdir(exist_ok=True)
+    project_root = resolve_project_root(allow_current_as_new=True)
+    paths = ensure_workspace(project_root)
     app = QApplication(sys.argv)
-    window = MainWindow()
+    window = MainWindow(project_root=paths.project_root)
     window.show()
     sys.exit(app.exec())
 

--- a/tests/gui/test_main_window.py
+++ b/tests/gui/test_main_window.py
@@ -97,7 +97,8 @@ class FakeBuilder:
 
 
 class FakeServices:
-    def __init__(self) -> None:
+    def __init__(self, project_root: Path | None = None) -> None:
+        self.project_root = Path.cwd() if project_root is None else project_root
         self.logger = RecordingLogger()
         self.logging = FakeLogging(self.logger)
         self.global_settings = FakeSettings()
@@ -167,8 +168,8 @@ class FakeRunHandle:
 
 
 @pytest.fixture
-def services() -> FakeServices:
-    return FakeServices()
+def services(tmp_path) -> FakeServices:
+    return FakeServices(project_root=tmp_path)
 
 
 @pytest.fixture
@@ -179,6 +180,16 @@ def window(qtbot, services: FakeServices) -> MainWindow:
     w.status_label.setText("準備完了")
     yield w
     w.preview_pane.timer.stop()
+
+
+def test_main_window_accepts_injected_project_root(qtbot, tmp_path) -> None:
+    services = FakeServices(project_root=tmp_path / "service-root")
+    project_root = tmp_path / "explicit-root"
+
+    w = MainWindow(services=services, project_root=project_root)
+    qtbot.addWidget(w)
+
+    assert w.project_root == project_root
 
 
 def run_result(status: RunStatus, message: str = "") -> RunResult:

--- a/tests/integration/test_cli_runtime_adapter.py
+++ b/tests/integration/test_cli_runtime_adapter.py
@@ -85,7 +85,7 @@ def test_cli_notification_settings_source_is_secrets_store(monkeypatch, tmp_path
     run_cli.create_runtime_builder(
         MagicMock(),
         logger=logger,
-        resources_dir=tmp_path,
+        project_root=tmp_path,
         settings_store=settings_store,
         secrets_store=secrets_store,
         device_discovery=discovery,

--- a/tests/unit/cli/test_main.py
+++ b/tests/unit/cli/test_main.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import pytest
@@ -147,7 +148,7 @@ def test_create_runtime_builder_delegates_device_selection_to_builder(monkeypatc
     create_runtime_builder(
         MagicMock(),
         logger=logger,
-        resources_dir=tmp_path,
+        project_root=tmp_path,
         settings_store=settings_store,
         secrets_store=secrets_store,
         device_discovery=discovery,
@@ -163,6 +164,37 @@ def test_create_runtime_builder_delegates_device_selection_to_builder(monkeypatc
     assert mock_builder.call_args.kwargs["settings"] == {"runtime.allow_dummy": False}
     assert "serial_device" not in mock_builder.call_args.kwargs
     assert "capture_device" not in mock_builder.call_args.kwargs
+
+
+def test_create_runtime_builder_passes_project_config_dir_to_stores(monkeypatch, tmp_path):
+    mock_registry = MagicMock()
+    mock_registry.return_value = MagicMock(reload=lambda: None)
+    mock_builder = MagicMock()
+    settings_store = MagicMock(snapshot=MagicMock(return_value={}))
+    secrets_snapshot = object()
+    secrets_store = MagicMock(snapshot=MagicMock(return_value=secrets_snapshot))
+    mock_settings_store = MagicMock(return_value=settings_store)
+    mock_secrets_store = MagicMock(return_value=secrets_store)
+
+    monkeypatch.setattr("nyxpy.cli.run_cli.MacroRegistry", mock_registry)
+    monkeypatch.setattr("nyxpy.cli.run_cli.SettingsStore", mock_settings_store)
+    monkeypatch.setattr("nyxpy.cli.run_cli.SecretsStore", mock_secrets_store)
+    monkeypatch.setattr(
+        "nyxpy.cli.run_cli.create_notification_handler_from_settings",
+        lambda settings, logger: "notifier",
+    )
+    monkeypatch.setattr("nyxpy.cli.run_cli.create_device_runtime_builder", mock_builder)
+
+    create_runtime_builder(MagicMock(), logger=MockLogger(), project_root=tmp_path)
+
+    mock_settings_store.assert_called_once_with(
+        config_dir=tmp_path.resolve() / ".nyxpy",
+        strict_load=False,
+    )
+    mock_secrets_store.assert_called_once_with(
+        config_dir=tmp_path.resolve() / ".nyxpy",
+        strict_load=False,
+    )
 
 
 def test_execute_macro_success(monkeypatch, mock_log_manager):
@@ -222,8 +254,20 @@ def make_args():
     return args
 
 
-def test_cli_main_success(monkeypatch):
+def patch_cli_workspace(monkeypatch, tmp_path):
+    paths = SimpleNamespace(
+        project_root=tmp_path,
+        config_dir=tmp_path / ".nyxpy",
+        logs_dir=tmp_path / "logs",
+    )
+    monkeypatch.setattr("nyxpy.cli.run_cli.resolve_project_root", lambda **_kwargs: tmp_path)
+    monkeypatch.setattr("nyxpy.cli.run_cli.ensure_workspace", MagicMock(return_value=paths))
+    return paths
+
+
+def test_cli_main_success(monkeypatch, tmp_path):
     args = make_args()
+    paths = patch_cli_workspace(monkeypatch, tmp_path)
     mock_logging = MockLoggingComponents()
     mock_configure = MagicMock(return_value=mock_logging)
     mock_protocol = MagicMock()
@@ -241,10 +285,15 @@ def test_cli_main_success(monkeypatch):
     monkeypatch.setattr("nyxpy.cli.run_cli.execute_macro", mock_execute)
 
     assert cli_main(args) == 0
-    mock_configure.assert_called_once()
+    mock_configure.assert_called_once_with(
+        silence=False,
+        verbose=False,
+        base_dir=paths.logs_dir,
+    )
     mock_create_builder.assert_called_once_with(
         protocol=mock_protocol,
         logger=mock_logging.logger,
+        project_root=paths.project_root,
         serial_name="COM1",
         capture_name="Camera1",
         baudrate=9600,
@@ -257,9 +306,10 @@ def test_cli_main_success(monkeypatch):
     )
 
 
-def test_cli_main_uses_3ds_default_baudrate(monkeypatch):
+def test_cli_main_uses_3ds_default_baudrate(monkeypatch, tmp_path):
     args = make_args()
     args.protocol = "3DS"
+    patch_cli_workspace(monkeypatch, tmp_path)
 
     monkeypatch.setattr(
         "nyxpy.cli.run_cli.configure_logging",
@@ -282,10 +332,11 @@ def test_cli_main_uses_3ds_default_baudrate(monkeypatch):
     assert create_builder.call_args.kwargs["baudrate"] == 115200
 
 
-def test_cli_main_baud_override(monkeypatch):
+def test_cli_main_baud_override(monkeypatch, tmp_path):
     args = make_args()
     args.protocol = "3DS"
     args.baud = 9600
+    patch_cli_workspace(monkeypatch, tmp_path)
 
     monkeypatch.setattr(
         "nyxpy.cli.run_cli.configure_logging",
@@ -308,9 +359,10 @@ def test_cli_main_baud_override(monkeypatch):
     assert create_builder.call_args.kwargs["baudrate"] == 9600
 
 
-def test_cli_main_value_error(monkeypatch, mock_log_manager):
+def test_cli_main_value_error(monkeypatch, mock_log_manager, tmp_path):
     args = make_args()
     args.serial = "COM3"
+    patch_cli_workspace(monkeypatch, tmp_path)
 
     monkeypatch.setattr(
         "nyxpy.cli.run_cli.configure_logging", MagicMock(return_value=mock_log_manager)
@@ -324,8 +376,9 @@ def test_cli_main_value_error(monkeypatch, mock_log_manager):
     assert any(log[1] == "ERROR" for log in mock_log_manager.logger.logs)
 
 
-def test_cli_main_exception(monkeypatch, mock_log_manager):
+def test_cli_main_exception(monkeypatch, mock_log_manager, tmp_path):
     args = make_args()
+    patch_cli_workspace(monkeypatch, tmp_path)
     monkeypatch.setattr(
         "nyxpy.cli.run_cli.configure_logging", MagicMock(return_value=mock_log_manager)
     )
@@ -342,9 +395,10 @@ def test_cli_main_exception(monkeypatch, mock_log_manager):
 
 
 def test_cli_unhandled_exception_uses_fixed_user_message(
-    monkeypatch, mock_log_manager, capsys
+    monkeypatch, mock_log_manager, capsys, tmp_path
 ):
     args = make_args()
+    patch_cli_workspace(monkeypatch, tmp_path)
     monkeypatch.setattr(
         "nyxpy.cli.run_cli.configure_logging", MagicMock(return_value=mock_log_manager)
     )
@@ -364,8 +418,9 @@ def test_cli_unhandled_exception_uses_fixed_user_message(
     assert any(log[4] == "cli.unhandled" for log in mock_log_manager.logger.logs)
 
 
-def test_cli_configuration_error_returns_1(monkeypatch, mock_log_manager):
+def test_cli_configuration_error_returns_1(monkeypatch, mock_log_manager, tmp_path):
     args = make_args()
+    patch_cli_workspace(monkeypatch, tmp_path)
     monkeypatch.setattr(
         "nyxpy.cli.run_cli.configure_logging", MagicMock(return_value=mock_log_manager)
     )
@@ -378,8 +433,9 @@ def test_cli_configuration_error_returns_1(monkeypatch, mock_log_manager):
     assert any(log[4] == "configuration.invalid" for log in mock_log_manager.logger.logs)
 
 
-def test_cli_cleanup_failures_are_logged(monkeypatch):
+def test_cli_cleanup_failures_are_logged(monkeypatch, tmp_path):
     args = make_args()
+    patch_cli_workspace(monkeypatch, tmp_path)
     logging = FailingLoggingComponents()
     builder = MagicMock()
     builder.shutdown = MagicMock(side_effect=RuntimeError("shutdown failed"))

--- a/tests/unit/cli/test_run_cli_parser.py
+++ b/tests/unit/cli/test_run_cli_parser.py
@@ -93,7 +93,11 @@ def test_cli_does_not_accept_notification_secret_args() -> None:
 def test_cli_define_args_are_passed_to_request(monkeypatch) -> None:
     builder = RecordingBuilder()
 
-    monkeypatch.setattr(run_cli, "configure_logging", lambda *, silence, verbose: Logging(Logger()))
+    monkeypatch.setattr(
+        run_cli,
+        "configure_logging",
+        lambda *, silence, verbose, base_dir: Logging(Logger()),
+    )
     monkeypatch.setattr(run_cli, "create_protocol", lambda protocol_name: object())
     monkeypatch.setattr(run_cli.ProtocolFactory, "resolve_baudrate", lambda protocol, baud: baud)
     monkeypatch.setattr(
@@ -129,7 +133,11 @@ def test_cli_define_args_are_passed_to_request(monkeypatch) -> None:
 def test_cli_define_defaults_to_empty_request_args(monkeypatch) -> None:
     builder = RecordingBuilder()
 
-    monkeypatch.setattr(run_cli, "configure_logging", lambda *, silence, verbose: Logging(Logger()))
+    monkeypatch.setattr(
+        run_cli,
+        "configure_logging",
+        lambda *, silence, verbose, base_dir: Logging(Logger()),
+    )
     monkeypatch.setattr(run_cli, "create_protocol", lambda protocol_name: object())
     monkeypatch.setattr(run_cli.ProtocolFactory, "resolve_baudrate", lambda protocol, baud: baud)
     monkeypatch.setattr(run_cli, "create_runtime_builder", lambda **kwargs: builder)

--- a/tests/unit/framework/settings/test_settings_schema.py
+++ b/tests/unit/framework/settings/test_settings_schema.py
@@ -26,6 +26,27 @@ def test_settings_store_applies_defaults_and_returns_immutable_snapshot(tmp_path
         snapshot["runtime"]["allow_dummy"] = True
 
 
+def test_settings_store_requires_config_dir() -> None:
+    with pytest.raises(TypeError):
+        SettingsStore()
+    with pytest.raises(TypeError):
+        SecretsStore()
+
+
+def test_settings_store_writes_only_to_config_dir(tmp_path, monkeypatch) -> None:
+    cwd = tmp_path / "cwd"
+    config_dir = tmp_path / "workspace" / ".nyxpy"
+    cwd.mkdir()
+    monkeypatch.chdir(cwd)
+
+    SettingsStore(config_dir=config_dir)
+    SecretsStore(config_dir=config_dir)
+
+    assert (config_dir / "global.toml").exists()
+    assert (config_dir / "secrets.toml").exists()
+    assert not (cwd / ".nyxpy").exists()
+
+
 def test_settings_store_get_set_supports_dotted_keys(tmp_path) -> None:
     store = SettingsStore(config_dir=tmp_path)
 

--- a/tests/unit/framework/settings/test_workspace.py
+++ b/tests/unit/framework/settings/test_workspace.py
@@ -1,0 +1,52 @@
+import pytest
+
+from nyxpy.framework.core.macro.exceptions import ConfigurationError
+from nyxpy.framework.core.settings.workspace import ensure_workspace, resolve_project_root
+
+
+def test_resolve_project_root_prefers_explicit_root(tmp_path) -> None:
+    explicit = tmp_path / "explicit"
+    nested = tmp_path / "workspace" / "macros" / "sample"
+    (tmp_path / "workspace" / ".nyxpy").mkdir(parents=True)
+    nested.mkdir(parents=True)
+
+    assert resolve_project_root(explicit_root=explicit, start=nested) == explicit.resolve()
+
+
+def test_resolve_project_root_finds_parent_marker_without_creating_marker(tmp_path) -> None:
+    workspace = tmp_path / "workspace"
+    nested = workspace / "macros" / "sample"
+    (workspace / ".nyxpy").mkdir(parents=True)
+    nested.mkdir(parents=True)
+
+    assert resolve_project_root(start=nested) == workspace.resolve()
+    assert not (nested / ".nyxpy").exists()
+
+
+def test_resolve_project_root_rejects_unknown_workspace(tmp_path) -> None:
+    with pytest.raises(ConfigurationError) as exc_info:
+        resolve_project_root(start=tmp_path)
+
+    assert exc_info.value.code == "NYX_WORKSPACE_NOT_FOUND"
+    assert exc_info.value.details["start"] == str(tmp_path.resolve())
+
+
+def test_resolve_project_root_allows_current_as_new(tmp_path) -> None:
+    assert resolve_project_root(start=tmp_path, allow_current_as_new=True) == tmp_path.resolve()
+
+
+def test_ensure_workspace_creates_expected_directories_without_static(tmp_path) -> None:
+    paths = ensure_workspace(tmp_path)
+
+    assert paths.project_root == tmp_path.resolve()
+    for directory in (
+        paths.config_dir,
+        paths.macros_dir,
+        paths.resources_dir,
+        paths.snapshots_dir,
+        paths.runs_dir,
+        paths.logs_dir,
+    ):
+        assert directory.exists()
+    assert (paths.macros_dir / "__init__.py").exists()
+    assert not (tmp_path / "static").exists()

--- a/tests/unit/test_workspace_initialization.py
+++ b/tests/unit/test_workspace_initialization.py
@@ -10,8 +10,10 @@ def test_init_app_creates_resource_io_directories_without_static(tmp_path, monke
     result = nyx_main.init_app()
 
     assert result == 0
-    for name in ("macros", "snapshots", "resources", "runs", ".nyxpy"):
+    for name in ("macros", "snapshots", "resources", "runs", "logs", ".nyxpy"):
         assert (tmp_path / name).exists()
+    assert (tmp_path / ".nyxpy" / "global.toml").exists()
+    assert (tmp_path / ".nyxpy" / "secrets.toml").exists()
     assert not (tmp_path / "static").exists()
 
 
@@ -23,7 +25,12 @@ def test_gui_startup_creates_resource_io_directories_without_static(tmp_path, mo
         def exec(self):
             return 0
 
+    captured = {}
+
     class FakeMainWindow:
+        def __init__(self, *, project_root):
+            captured["project_root"] = project_root
+
         def show(self):
             pass
 
@@ -35,6 +42,7 @@ def test_gui_startup_creates_resource_io_directories_without_static(tmp_path, mo
         run_gui.main()
 
     assert exc_info.value.code == 0
-    for name in ("macros", "snapshots", "resources", "runs"):
+    for name in ("macros", "snapshots", "resources", "runs", "logs", ".nyxpy"):
         assert (tmp_path / name).exists()
+    assert captured["project_root"] == tmp_path.resolve()
     assert not (tmp_path / "static").exists()


### PR DESCRIPTION
## Summary
- `.nyxpy` の project root 解決と workspace 初期化 helper を追加
- settings / secrets store の `config_dir` を必須化し、CLI / GUI / init の wiring を project root 明示へ更新
- 仕様書チェックリストを完了化して `spec\agent\complete\local_003\NYXPY_CONFIG_ROOT.md` へ移動
- `spec\dev-journal.md` から解消済み `.nyxpy` 論点を削除し、PaddlePaddle / PaddleOCR を含む依存更新の検討事項を記録

## Commit Log
- e419f59 docs(dev-journal): 依存更新の検討事項を記録
- 6566398 feat(settings): .nyxpy 配置を project root に固定

## Testing
- `uv run ruff check .`
- `uv run pytest tests\unit tests\gui tests\integration` → 488 passed, 1 warning