### PR TITLE
fix(test): Linux CIでWin32列挙テストを通す

### DIFF
--- a/src/nyxpy/framework/core/hardware/window_discovery.py
+++ b/src/nyxpy/framework/core/hardware/window_discovery.py
@@ -120,7 +120,7 @@ def _list_windows_win32(user32=None) -> tuple[WindowInfo, ...]:
     user32 = user32 or ctypes.windll.user32
     windows: list[WindowInfo] = []
 
-    enum_windows_proc = ctypes.WINFUNCTYPE(ctypes.c_bool, ctypes.c_void_p, ctypes.c_void_p)
+    enum_windows_proc = _win32_callback_type(ctypes.c_bool, ctypes.c_void_p, ctypes.c_void_p)
 
     def callback(hwnd, _lparam) -> bool:
         window = _window_info_from_hwnd(hwnd, user32)
@@ -130,6 +130,10 @@ def _list_windows_win32(user32=None) -> tuple[WindowInfo, ...]:
 
     user32.EnumWindows(enum_windows_proc(callback), 0)
     return tuple(windows)
+
+
+def _win32_callback_type(*args):
+    return getattr(ctypes, "WINFUNCTYPE", ctypes.CFUNCTYPE)(*args)
 
 
 def _window_info_from_hwnd(hwnd: int, user32=None) -> WindowInfo | None:

--- a/tests/unit/framework/hardware/test_window_discovery.py
+++ b/tests/unit/framework/hardware/test_window_discovery.py
@@ -1,3 +1,4 @@
+import ctypes
 import os
 
 import pytest
@@ -102,6 +103,18 @@ def test_windows_list_uses_client_rect_in_screen_coordinates(monkeypatch) -> Non
             window_rect=CaptureRect(left=100, top=200, width=1300, height=760),
         ),
     )
+
+
+def test_windows_list_works_without_windows_callback_type(monkeypatch) -> None:
+    monkeypatch.delattr(ctypes, "WINFUNCTYPE", raising=False)
+    monkeypatch.setattr(
+        "nyxpy.framework.core.hardware.window_discovery.ensure_capture_coordinate_space",
+        lambda: None,
+    )
+
+    detected = _list_windows_win32(FakeUser32())
+
+    assert detected[0].identifier == "100"
 
 
 def test_default_windows_resolve_uses_identifier_without_enumerating(monkeypatch) -> None:


### PR DESCRIPTION
## Summary

Linux CI で `tests/unit/framework/hardware/test_window_discovery.py` が `ctypes.WINFUNCTYPE` 不在により失敗していた問題を修正します。

## Related

- fixes CI failure on `master`: https://github.com/niart120/Project_NyX/actions/runs/25808098347

## Changes

- Win32 callback type の生成を helper 化し、実 Windows では `ctypes.WINFUNCTYPE`、非 Windows の Fake user32 テスト環境では `ctypes.CFUNCTYPE` を使う
- Linux runner 上でも同じ単体テストが通ることを検証する回帰テストを追加

## Commit Log

```
038aea3 fix(test): Linux CIでWin32列挙テストを通す
```

## Testing

```
uv run ruff check src\nyxpy\framework\core\hardware\window_discovery.py tests\unit\framework\hardware\test_window_discovery.py
uv run pytest tests\unit\framework\hardware\test_window_discovery.py
uv run pytest tests\unit tests\integration -v
uv run ruff check .
gh workflow run test.yml --ref fix/ci-window-capture
gh run watch 25860483486 --exit-status
```

## Checklist

- [x] lint / format チェック通過
- [x] 既存テスト通過
- [x] コミット prefix (feat/fix 等) が変更の動機と一致している
- [x] 新規・変更コードに対するテスト追加（該当する場合）
- [x] 型チェック通過
