### PR TITLE
test: 公開マクロのテスト配置を移す

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -30,10 +30,15 @@ src/nyxpy/
   gui/           — PySide6 GUI
   cli/           — CLI エントリポイント
 macros/
-  shared/        — マクロ間共通部品 (timer, image_utils, ocr_utils)
-  {macro_name}/  — マクロパッケージ (macro.py, config.py, recognizer.py 等)
-static/
-  {macro_name}/  — 設定ファイル (settings.toml) ・画像リソース
+  {macro_id}/    — ローカル作業用マクロ。Git 管理外だが pytest 対象
+resources/
+  {macro_id}/    — ローカル作業用リソース。Git 管理外
+examples/
+  macros/        — 公開用マクロ本体
+    shared/      — 公開用マクロ間共通部品
+    {macro_id}/  — 公開用マクロパッケージ
+  resources/     — 公開用マクロの設定ファイル・画像リソース
+  tests/         — 公開用マクロのテスト
 tests/
   unit/          — 単体テスト
   gui/           — GUI テスト (pytest-qt)
@@ -45,9 +50,12 @@ spec/macro/      — マクロ仕様書
 
 **依存方向の制約:**
 ```
-macros/xxx/  →  nyxpy.framework.*   OK
-macros/xxx/  →  macros/shared/*     OK
-macros/xxx/  →  macros/yyy/*        NG (マクロ間の直接依存禁止)
+macros/xxx/           →  nyxpy.framework.*           OK
+macros/xxx/           →  macros/shared/*             OK
+macros/xxx/           →  macros/yyy/*                NG (マクロ間の直接依存禁止)
+examples/macros/xxx/  →  nyxpy.framework.*           OK
+examples/macros/xxx/  →  examples/macros/shared/*    OK
+examples/macros/xxx/  →  examples/macros/yyy/*       NG (マクロ間の直接依存禁止)
 ```
 
 ## コーディング規約

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ uv run nyx-cli sample_macro --serial COM3 --capture 0
 
 ## 4. マクロ開発
 
-マクロはローカル作業用の `macros\` に配置された Python スクリプトです。`macros\` と `resources\` はディレクトリだけ Git 管理し、中身のマクロ・設定・画像資産は Git 管理外です。ユーザー向けの例は `examples\macro` と `examples\resources` に置きますが、実行時に自動探索される場所ではありません。
+マクロはローカル作業用の `macros\` に配置された Python スクリプトです。本リポジトリでは `macros\` と `resources\` はディレクトリだけ Git 管理対象としており、中身のマクロ・設定・画像資産は Git 管理外です。ユーザー向けの例は `examples\macros` と `examples\resources` に配置してあります。
 
 ### 基本的なマクロ構造
 
@@ -158,7 +158,7 @@ class SampleMacro(MacroBase):
         pass
 ```
 
-軽量マクロは `macros\<macro_id>.py` または `macros\<macro_id>\macro.py` に `MacroBase` 派生クラスを1つ置けば自動検出されます。複数 entrypoint や明示 metadata が必要な場合だけ `macro.toml` を追加します。`examples\macro` の例を実行したい場合は、対象ファイルを `macros\` へコピーしてください。
+軽量マクロは `macros\<macro_id>.py` または `macros\<macro_id>\macro.py` に `MacroBase` 派生クラスを1つ置けば自動検出されます。複数 entrypoint や明示 metadata が必要な場合だけ `macro.toml` を追加します。`examples\macros` の例を実行したい場合は、対象ファイルを `macros\` へコピーしてください。
 
 ```toml
 [macro]

--- a/conftest.py
+++ b/conftest.py
@@ -1,11 +1,4 @@
-import sys
-from pathlib import Path
-
 import pytest
-
-_root = Path(__file__).resolve().parent.parent
-sys.path.insert(0, str(_root / "src"))
-sys.path.insert(0, str(_root / "examples"))
 
 
 def pytest_addoption(parser: pytest.Parser) -> None:

--- a/examples/tests/perf/test_nsmb_sort_or_splode_perf.py
+++ b/examples/tests/perf/test_nsmb_sort_or_splode_perf.py
@@ -2,17 +2,17 @@ import time
 from pathlib import Path
 
 import cv2
-from macro.nsmb_sort_or_splode.config import NsmbSortOrSplodeConfig
-from macro.nsmb_sort_or_splode.recognizer import (
+
+from examples.macros.nsmb_sort_or_splode.config import NsmbSortOrSplodeConfig
+from examples.macros.nsmb_sort_or_splode.recognizer import (
     BombColor,
     classify_bombs,
     find_bombs,
     paint_ignored_rects,
 )
-
 from nyxpy.framework.core.constants import THREEDS_HD_BOTTOM_SCREEN
 
-ROOT = Path(__file__).resolve().parents[2]
+ROOT = Path(__file__).resolve().parents[3]
 CLASSIFIED_DETECTION_THRESHOLD_S = 0.04
 
 

--- a/examples/tests/unit/macros/test_frlg_gorgeous_resort.py
+++ b/examples/tests/unit/macros/test_frlg_gorgeous_resort.py
@@ -6,23 +6,24 @@ species_data / selphy_logic / frame_search / recognizer / config のテストを
 from __future__ import annotations
 
 import pytest
-from macro.frlg_gorgeous_resort.config import FrlgGorgeousResortConfig
-from macro.frlg_gorgeous_resort.frame_search import (
+
+from examples.macros.frlg_gorgeous_resort.config import FrlgGorgeousResortConfig
+from examples.macros.frlg_gorgeous_resort.frame_search import (
     AkihoResult,
     find_consecutive_runs,
     search_akiho_frames,
 )
-from macro.frlg_gorgeous_resort.recognizer import (
+from examples.macros.frlg_gorgeous_resort.recognizer import (
     match_item,
     matches_any_target,
 )
-from macro.frlg_gorgeous_resort.selphy_logic import (
+from examples.macros.frlg_gorgeous_resort.selphy_logic import (
     ITEM_TABLE,
     LUXURY_BALL,
     determine_item,
     determine_pokemon,
 )
-from macro.frlg_gorgeous_resort.species_data import (
+from examples.macros.frlg_gorgeous_resort.species_data import (
     DUMMY_CODE_END,
     DUMMY_CODE_START,
     INTERNAL_TO_NAME,
@@ -33,7 +34,7 @@ from macro.frlg_gorgeous_resort.species_data import (
     NUM_SPECIES_CODES,
     is_dummy,
 )
-from macro.frlg_initial_seed.lcg32 import LCG32
+from examples.macros.frlg_initial_seed.lcg32 import LCG32
 
 # ============================================================
 # species_data テスト

--- a/examples/tests/unit/macros/test_frlg_id_rng.py
+++ b/examples/tests/unit/macros/test_frlg_id_rng.py
@@ -14,7 +14,7 @@ import pytest
 # ============================================================
 # frame_sweep テスト
 # ============================================================
-from macro.frlg_id_rng.frame_sweep import (
+from examples.macros.frlg_id_rng.frame_sweep import (
     dual_frame_sweep,
     frame_sweep,
     single_value_iterator,
@@ -62,7 +62,7 @@ class TestFrameSweep:
 # keyboard_layout テスト
 # ============================================================
 
-from macro.frlg_id_rng.keyboard_layout import (
+from examples.macros.frlg_id_rng.keyboard_layout import (
     ENG_KEYBOARD,
     JPN_KEYBOARD,
     REGION_KEYBOARDS,
@@ -139,7 +139,7 @@ class TestKeyboardLayout:
 # region_timing テスト
 # ============================================================
 
-from macro.frlg_id_rng.region_timing import REGION_TIMINGS
+from examples.macros.frlg_id_rng.region_timing import REGION_TIMINGS
 
 
 class TestRegionTiming:
@@ -185,8 +185,8 @@ class TestRegionTiming:
 # FrlgIdRngMacro テスト
 # ============================================================
 
-# examples/macro/frlg_id_rng/ パッケージからインポート
-from macro.frlg_id_rng import FrlgIdRngMacro
+# examples/macros/frlg_id_rng/ パッケージからインポート
+from examples.macros.frlg_id_rng import FrlgIdRngMacro
 
 
 def _make_cmd_mock() -> MagicMock:

--- a/examples/tests/unit/macros/test_frlg_initial_seed.py
+++ b/examples/tests/unit/macros/test_frlg_initial_seed.py
@@ -14,7 +14,7 @@ import pytest
 # ============================================================
 # LCG32 テスト
 # ============================================================
-from macro.frlg_initial_seed.lcg32 import LCG32
+from examples.macros.frlg_initial_seed.lcg32 import LCG32
 
 
 class TestLCG32:
@@ -96,7 +96,7 @@ class TestLCG32:
 # nature テスト
 # ============================================================
 
-from macro.frlg_initial_seed.nature import (
+from examples.macros.frlg_initial_seed.nature import (
     NATURE_JPN_TO_EN,
     NATURE_NAMES,
     NATURE_TO_ID,
@@ -150,7 +150,7 @@ class TestNature:
 # pokemon_gen テスト
 # ============================================================
 
-from macro.frlg_initial_seed.pokemon_gen import Pokemon, generate_pokemon
+from examples.macros.frlg_initial_seed.pokemon_gen import Pokemon, generate_pokemon
 
 
 class TestPokemonGen:
@@ -220,7 +220,7 @@ class TestPokemonGen:
 # seed_solver テスト
 # ============================================================
 
-from macro.frlg_initial_seed.seed_solver import solve_initial_seed
+from examples.macros.frlg_initial_seed.seed_solver import solve_initial_seed
 
 
 class TestSeedSolver:
@@ -446,7 +446,7 @@ class TestSeedSolver:
 # config テスト
 # ============================================================
 
-from macro.frlg_initial_seed.config import FrlgInitialSeedConfig, Hardware, KeyInput
+from examples.macros.frlg_initial_seed.config import FrlgInitialSeedConfig, Hardware, KeyInput
 
 
 class TestConfig:
@@ -515,7 +515,7 @@ class TestConfig:
 # CSV ヘルパーテスト
 # ============================================================
 
-from macro.frlg_initial_seed.csv_helper import (
+from examples.macros.frlg_initial_seed.csv_helper import (
     CSV_DETAIL_FIELDNAMES,
     CSV_DETAIL_FILENAME,
     CSV_FIELDNAMES,
@@ -527,7 +527,6 @@ from macro.frlg_initial_seed.csv_helper import (
     build_debug_image_dir,
     build_detail_csv_path,
 )
-
 from nyxpy.framework.core.io.resources import LocalRunArtifactStore
 
 

--- a/examples/tests/unit/macros/test_frlg_wild_rng.py
+++ b/examples/tests/unit/macros/test_frlg_wild_rng.py
@@ -12,7 +12,7 @@ import pytest
 # ============================================================
 # config テスト
 # ============================================================
-from macro.frlg_wild_rng.config import FrlgWildRngConfig
+from examples.macros.frlg_wild_rng.config import FrlgWildRngConfig
 
 
 class TestConfigFromArgsDefaults:
@@ -160,7 +160,7 @@ class TestTeachyTvAdvanceCalculation:
 
     def test_effective_advance_negative_raises(self):
         """teachy_tv_consumption 超過で effective_advance < 0 のとき ValueError"""
-        from macro.frlg_wild_rng.macro import FrlgWildRngMacro
+        from examples.macros.frlg_wild_rng.macro import FrlgWildRngMacro
 
         macro = FrlgWildRngMacro()
         cmd = _make_mock_cmd()
@@ -238,7 +238,7 @@ class TestRestartGameReturnsTimer:
     """restart_game() が float を返し start_timer() 相当の時刻であること"""
 
     def test_returns_float(self):
-        from macro.shared.game_restart import restart_game
+        from examples.macros.shared.game_restart import restart_game
 
         cmd = _make_mock_cmd()
         result = restart_game(cmd)
@@ -246,7 +246,7 @@ class TestRestartGameReturnsTimer:
         assert result > 0
 
     def test_calls_press_five_times(self):
-        from macro.shared.game_restart import restart_game
+        from examples.macros.shared.game_restart import restart_game
 
         cmd = _make_mock_cmd()
         restart_game(cmd)
@@ -257,7 +257,7 @@ class TestSkipOpeningReturnsTimer:
     """skip_opening_and_continue() が float を返し start_timer() 相当の時刻であること"""
 
     def test_returns_float(self):
-        from macro.shared.frlg_opening import skip_opening_and_continue
+        from examples.macros.shared.frlg_opening import skip_opening_and_continue
 
         cmd = _make_mock_cmd()
         result = skip_opening_and_continue(cmd)
@@ -265,7 +265,7 @@ class TestSkipOpeningReturnsTimer:
         assert result > 0
 
     def test_calls_press_three_times(self):
-        from macro.shared.frlg_opening import skip_opening_and_continue
+        from examples.macros.shared.frlg_opening import skip_opening_and_continue
 
         cmd = _make_mock_cmd()
         skip_opening_and_continue(cmd)

--- a/examples/tests/unit/macros/test_nsmb_sort_or_splode.py
+++ b/examples/tests/unit/macros/test_nsmb_sort_or_splode.py
@@ -3,9 +3,10 @@ from pathlib import Path
 import cv2
 import numpy as np
 import pytest
-from macro.nsmb_sort_or_splode.config import NsmbSortOrSplodeConfig, TouchRect
-from macro.nsmb_sort_or_splode.macro import NsmbSortOrSplodeMacro
-from macro.nsmb_sort_or_splode.recognizer import (
+
+from examples.macros.nsmb_sort_or_splode.config import NsmbSortOrSplodeConfig, TouchRect
+from examples.macros.nsmb_sort_or_splode.macro import NsmbSortOrSplodeMacro
+from examples.macros.nsmb_sort_or_splode.recognizer import (
     BombColor,
     DetectedBomb,
     build_drag_path,
@@ -15,10 +16,9 @@ from macro.nsmb_sort_or_splode.recognizer import (
     paint_ignored_rects,
     touch_rect_to_cropped_hd_rect,
 )
-
 from nyxpy.framework.core.constants import THREEDS_HD_BOTTOM_SCREEN, TouchPoint
 
-ROOT = Path(__file__).resolve().parents[3]
+ROOT = Path(__file__).resolve().parents[4]
 
 
 class FakeCommand:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,8 @@ build-backend = "hatchling.build"
 targets.wheel.packages = ["src/nyxpy"]
 
 [tool.pytest.ini_options]
-testpaths = ["tests"]
+pythonpath = ["src", "."]
+testpaths = ["tests", "macros", "examples/tests"]
 python_files = "test_*.py"
 python_functions = "test_*"
 markers = [
@@ -81,4 +82,5 @@ ignore = [
 
 [tool.ruff.lint.per-file-ignores]
 "tests/**" = ["E402"]  # pytest.importorskip / sys.path.insert 後の import を許容
+"examples/tests/**" = ["E402"]
 

--- a/tests/integration/test_migrated_macro_compat.py
+++ b/tests/integration/test_migrated_macro_compat.py
@@ -21,7 +21,10 @@ from tests.support.fakes import (
 
 def _clear_macro_modules() -> None:
     for module_name in list(sys.modules):
-        if module_name in {"macro", "macros"} or module_name.startswith(("macro.", "macros.")):
+        if (
+            module_name in {"macro", "macros", "examples.macros"}
+            or module_name.startswith(("macro.", "macros.", "examples.macros."))
+        ):
             del sys.modules[module_name]
 
 
@@ -193,17 +196,15 @@ def test_file_settings_and_exec_args_are_merged_with_exec_args_precedence(
 @pytest.mark.parametrize(
     ("module_name", "class_name"),
     [
-        ("macro.frlg_id_rng.macro", "FrlgIdRngMacro"),
-        ("macro.frlg_initial_seed.macro", "FrlgInitialSeedMacro"),
-        ("macro.frlg_gorgeous_resort.macro", "FrlgGorgeousResortMacro"),
-        ("macro.frlg_wild_rng.macro", "FrlgWildRngMacro"),
+        ("examples.macros.frlg_id_rng.macro", "FrlgIdRngMacro"),
+        ("examples.macros.frlg_initial_seed.macro", "FrlgInitialSeedMacro"),
+        ("examples.macros.frlg_gorgeous_resort.macro", "FrlgGorgeousResortMacro"),
+        ("examples.macros.frlg_wild_rng.macro", "FrlgWildRngMacro"),
     ],
 )
 def test_repository_representative_macros_keep_lifecycle_contract(
-    module_name: str, class_name: str, monkeypatch: pytest.MonkeyPatch
+    module_name: str, class_name: str
 ) -> None:
-    repo_root = Path(__file__).resolve().parents[2]
-    monkeypatch.syspath_prepend(repo_root)
     _clear_macro_modules()
 
     module = importlib.import_module(module_name)

--- a/tests/integration/test_resource_file_io_migration.py
+++ b/tests/integration/test_resource_file_io_migration.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 from pathlib import Path
 
 import numpy as np
-from macro.sample_turbo_a_macro import SampleTurboAMacro
 
+from examples.macros.sample_turbo_a_macro import SampleTurboAMacro
 from nyxpy.framework.core.io.resources import (
     LocalResourceStore,
     LocalRunArtifactStore,

--- a/tests/unit/framework/test_dependency_boundaries.py
+++ b/tests/unit/framework/test_dependency_boundaries.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 PROJECT_ROOT = Path(__file__).parents[3]
 FRAMEWORK_ROOT = PROJECT_ROOT / "src" / "nyxpy" / "framework"
-PUBLIC_MACROS_ROOT = PROJECT_ROOT / "examples" / "macro"
+PUBLIC_MACROS_ROOT = PROJECT_ROOT / "examples" / "macros"
 
 
 def _imported_modules(path: Path) -> set[str]:

--- a/tests/unit/macro/conftest.py
+++ b/tests/unit/macro/conftest.py
@@ -1,7 +1,0 @@
-import sys
-from pathlib import Path
-
-# examples/macro をパッケージ import できるよう examples/ を追加する
-_examples_dir = str(Path(__file__).resolve().parent.parent.parent.parent / "examples")
-if _examples_dir not in sys.path:
-    sys.path.insert(0, _examples_dir)


### PR DESCRIPTION
## Summary

公開マクロのテストを `examples\tests` に移し、ローカルの `macros\` 配下テストも `uv run pytest` で収集される構成にしました。

## Related

- Copilot CLI session request

## Changes

- 公開マクロ固有の単体・性能テストを `tests\...` から `examples\tests\...` に移管
- 公開マクロテストの import を `examples.macros.*` に更新
- pytest の収集対象を `tests`, `macros`, `examples/tests` に整理
- README と `.github/copilot-instructions.md` のプロジェクト構造を現行配置に更新

## Commit Log

```
5febad3 test: 公開マクロのテスト配置を移す
```

## Testing

```
uv run ruff check .
uv run pytest -q
```

## Checklist

- [x] lint / format チェック通過
- [x] 既存テスト通過
- [x] コミット prefix (feat/fix 等) が変更の動機と一致している
- [x] 新規・変更コードに対するテスト追加（既存テストの移管）
- [ ] 型チェック通過（専用コマンドなし）

## Review Notes

特になし。