### PR TITLE
fix(nsmb-sort): タッチ仕分けの安定性を改善

### DIFF
--- a/examples/macros/nsmb_sort_or_splode/config.py
+++ b/examples/macros/nsmb_sort_or_splode/config.py
@@ -25,23 +25,23 @@ class TouchRect:
 
 @dataclass(frozen=True, slots=True)
 class NsmbSortOrSplodeConfig:
-    scan_interval_seconds: float = 0.05
-    post_drop_wait_seconds: float = 0.02
+    scan_interval_seconds: float = 0.15
+    post_drop_wait_seconds: float = 0.10
     max_sorted_count: int = 0
     red_template_path: Path = Path("templates/red_bob_omb.png")
     black_template_path: Path = Path("templates/black_bob_omb.png")
     mask_fill_bgr: tuple[int, int, int] = (0, 255, 0)
     match_method: str = "TM_CCOEFF_NORMED"
-    red_match_threshold: float = 0.83
-    black_match_threshold: float = 0.83
-    template_score_margin: float = 0.08
+    red_match_threshold: float = 0.90
+    black_match_threshold: float = 0.90
+    template_score_margin: float = 0.01
     color_sample_size: int = 28
-    red_min_ratio: float = 0.20
-    black_min_dark_ratio: float = 0.35
-    black_max_red_ratio: float = 0.10
-    duplicate_suppression_radius: int = 18
-    drag_steps: int = 4
-    drag_duration_seconds: float = 0.10
+    red_min_ratio: float = 0.50
+    black_min_dark_ratio: float = 0.50
+    black_max_red_ratio: float = 0.01
+    duplicate_suppression_radius: int = 8
+    drag_steps: int = 1
+    drag_duration_seconds: float = 0.034
     red_goal_touch: TouchPoint = TouchPoint(24, 122)
     black_goal_touch: TouchPoint = TouchPoint(296, 122)
     ignore_touch_rects: tuple[TouchRect, ...] = (

--- a/examples/macros/nsmb_sort_or_splode/macro.py
+++ b/examples/macros/nsmb_sort_or_splode/macro.py
@@ -1,3 +1,5 @@
+from time import monotonic
+
 import cv2
 
 from nyxpy.framework.core.constants import THREEDS_HD_BOTTOM_SCREEN, TouchPoint
@@ -13,6 +15,13 @@ from .recognizer import (
     find_bombs,
     paint_ignored_rects,
 )
+
+_DEBUG_DETECTED_FRAME_PATH = "nsmb_sort_or_splode/latest_detected_bomb.png"
+_DEBUG_MARKER_BGR_BY_COLOR = {
+    BombColor.RED: (0, 0, 255),
+    BombColor.BLACK: (0, 0, 0),
+}
+_DEBUG_MARKER_OUTLINE_BGR = (255, 255, 255)
 
 
 class NsmbSortOrSplodeMacro(MacroBase):
@@ -37,9 +46,14 @@ class NsmbSortOrSplodeMacro(MacroBase):
 
     def run(self, cmd: Command) -> None:
         while not self._finished:
+            iteration_started_at = monotonic()
             self.run_iteration(cmd)
             if self._cfg.scan_interval_seconds > 0 and not self._finished:
-                cmd.wait(self._cfg.scan_interval_seconds)
+                remaining_wait = self._cfg.scan_interval_seconds - (
+                    monotonic() - iteration_started_at
+                )
+                if remaining_wait > 0:
+                    cmd.wait(remaining_wait)
 
     def finalize(self, cmd: Command) -> None:
         pass
@@ -90,10 +104,11 @@ class NsmbSortOrSplodeMacro(MacroBase):
         goal = (
             self._cfg.red_goal_touch if bomb.color is BombColor.RED else self._cfg.black_goal_touch
         )
+        self._log_detected_bomb(cmd, bomb)
         self._drag(cmd, bomb.touch_point, goal)
         self._sorted_count += 1
         if self._cfg.save_debug_frames:
-            self._save_debug_frame(cmd, masked, bomb, goal)
+            self._save_debug_frame(cmd, frame, bomb, goal)
         if self._cfg.post_drop_wait_seconds > 0:
             cmd.wait(self._cfg.post_drop_wait_seconds)
         if self._cfg.max_sorted_count > 0 and self._sorted_count >= self._cfg.max_sorted_count:
@@ -126,11 +141,62 @@ class NsmbSortOrSplodeMacro(MacroBase):
         debug = frame.copy()
         cropped_x = bomb.hd_center_x - THREEDS_HD_BOTTOM_SCREEN.x
         cropped_y = bomb.hd_center_y - THREEDS_HD_BOTTOM_SCREEN.y
-        cv2.circle(debug, (cropped_x, cropped_y), 8, (255, 0, 255), thickness=2)
+        marker_bgr = _DEBUG_MARKER_BGR_BY_COLOR[bomb.color]
+        cv2.circle(
+            debug,
+            (cropped_x, cropped_y),
+            10,
+            _DEBUG_MARKER_OUTLINE_BGR,
+            thickness=4,
+        )
+        cv2.circle(debug, (cropped_x, cropped_y), 10, marker_bgr, thickness=2)
         goal_hd_x = round(goal.x * THREEDS_HD_BOTTOM_SCREEN.width / 320)
         goal_hd_y = round(goal.y * THREEDS_HD_BOTTOM_SCREEN.height / 240)
-        cv2.line(debug, (cropped_x, cropped_y), (goal_hd_x, goal_hd_y), (255, 0, 255), 2)
-        cmd.save_img(
-            f"nsmb_sort_or_splode/debug_{self._sorted_count:04d}_{bomb.color}.png",
+        cv2.line(
             debug,
+            (cropped_x, cropped_y),
+            (goal_hd_x, goal_hd_y),
+            _DEBUG_MARKER_OUTLINE_BGR,
+            4,
+        )
+        cv2.line(debug, (cropped_x, cropped_y), (goal_hd_x, goal_hd_y), marker_bgr, 2)
+        text_origin = (min(cropped_x + 14, debug.shape[1] - 48), max(cropped_y - 12, 16))
+        cv2.putText(
+            debug,
+            bomb.color.value,
+            text_origin,
+            cv2.FONT_HERSHEY_SIMPLEX,
+            0.5,
+            _DEBUG_MARKER_OUTLINE_BGR,
+            3,
+            cv2.LINE_AA,
+        )
+        cv2.putText(
+            debug,
+            bomb.color.value,
+            text_origin,
+            cv2.FONT_HERSHEY_SIMPLEX,
+            0.5,
+            marker_bgr,
+            1,
+            cv2.LINE_AA,
+        )
+        cmd.save_img(_DEBUG_DETECTED_FRAME_PATH, debug)
+
+    def _log_detected_bomb(self, cmd: Command, bomb: DetectedBomb) -> None:
+        features = bomb.color_features
+        feature_log = ""
+        if features is not None:
+            feature_log = (
+                f", red_ratio={features.red_ratio:.3f}, dark_ratio={features.dark_ratio:.3f}"
+            )
+        cmd.log(
+            "Sort or 'Splode detected bomb: "
+            f"color={bomb.color.value}, "
+            f"score={bomb.score:.3f}, "
+            f"red_score={bomb.red_score:.3f}, "
+            f"black_score={bomb.black_score:.3f}, "
+            f"touch=({bomb.touch_x}, {bomb.touch_y})"
+            f"{feature_log}",
+            level="DEBUG",
         )

--- a/examples/macros/nsmb_sort_or_splode/recognizer.py
+++ b/examples/macros/nsmb_sort_or_splode/recognizer.py
@@ -7,6 +7,7 @@ import numpy as np
 
 from nyxpy.framework.core.constants import (
     THREEDS_HD_BOTTOM_SCREEN,
+    THREEDS_TOUCH_SIZE,
     ScreenPoint,
     ScreenRect,
     TouchPoint,
@@ -132,7 +133,6 @@ def classify_bombs(
         reverse=True,
     )
     consumed = [False] * len(candidates)
-    duplicate_suppression_radius_sq = duplicate_suppression_radius * duplicate_suppression_radius
     for index, anchor in enumerate(candidates):
         if consumed[index]:
             continue
@@ -140,7 +140,8 @@ def classify_bombs(
             group_index
             for group_index, candidate in enumerate(candidates)
             if not consumed[group_index]
-            and _touch_distance_sq(anchor, candidate) <= duplicate_suppression_radius_sq
+            and _touch_distance_sq(anchor, candidate)
+            <= _candidate_group_radius(anchor, candidate, duplicate_suppression_radius) ** 2
         ]
         for group_index in group_indices:
             consumed[group_index] = True
@@ -149,20 +150,26 @@ def classify_bombs(
         black = _best_color_candidate(group, BombColor.BLACK)
         red_score = red.score if red is not None else 0.0
         black_score = black.score if black is not None else 0.0
-        features = measure_color_features(
-            frame_bgr,
-            anchor.hd_center_x - THREEDS_HD_BOTTOM_SCREEN.x,
-            anchor.hd_center_y - THREEDS_HD_BOTTOM_SCREEN.y,
-            color_sample_size,
+        red_features = (
+            _measure_candidate_color_features(frame_bgr, red, color_sample_size)
+            if red is not None
+            else None
         )
-        red_gate = features.red_ratio >= red_min_ratio
+        black_features = (
+            _measure_candidate_color_features(frame_bgr, black, color_sample_size)
+            if black is not None
+            else None
+        )
+        red_gate = red_features is not None and red_features.red_ratio >= red_min_ratio
         black_gate = (
-            features.dark_ratio >= black_min_dark_ratio
-            and features.red_ratio <= black_max_red_ratio
+            black_features is not None
+            and black_features.dark_ratio >= black_min_dark_ratio
+            and black_features.red_ratio <= black_max_red_ratio
         )
 
         selected: DetectedBomb | None = None
         selected_color: BombColor | None = None
+        selected_features: ColorFeatures | None = None
         if (
             red is not None
             and red.score >= red_threshold
@@ -171,6 +178,7 @@ def classify_bombs(
         ):
             selected = red
             selected_color = BombColor.RED
+            selected_features = red_features
         elif (
             black is not None
             and black.score >= black_threshold
@@ -179,13 +187,16 @@ def classify_bombs(
         ):
             selected = black
             selected_color = BombColor.BLACK
+            selected_features = black_features
         elif red_gate != black_gate:
             if red_gate and red is not None and red.score >= red_threshold:
                 selected = red
                 selected_color = BombColor.RED
+                selected_features = red_features
             elif black_gate and black is not None and black.score >= black_threshold:
                 selected = black
                 selected_color = BombColor.BLACK
+                selected_features = black_features
 
         if selected is not None and selected_color is not None:
             classified.append(
@@ -200,7 +211,7 @@ def classify_bombs(
                     height=selected.height,
                     red_score=red_score,
                     black_score=black_score,
-                    color_features=features,
+                    color_features=selected_features,
                 )
             )
     classified.sort(key=lambda item: item.score, reverse=True)
@@ -233,6 +244,19 @@ def measure_color_features(
     return ColorFeatures(
         red_ratio=float(red.sum() / total),
         dark_ratio=float(dark.sum() / total),
+    )
+
+
+def _measure_candidate_color_features(
+    frame_bgr: np.ndarray,
+    candidate: DetectedBomb,
+    sample_size: int,
+) -> ColorFeatures:
+    return measure_color_features(
+        frame_bgr,
+        candidate.hd_center_x - THREEDS_HD_BOTTOM_SCREEN.x,
+        candidate.hd_center_y - THREEDS_HD_BOTTOM_SCREEN.y,
+        sample_size,
     )
 
 
@@ -298,6 +322,23 @@ def _best_color_candidate(candidates: list[DetectedBomb], color: BombColor) -> D
     if not same_color:
         return None
     return max(same_color, key=lambda item: item.score)
+
+
+def _candidate_group_radius(
+    first: DetectedBomb,
+    second: DetectedBomb,
+    duplicate_suppression_radius: int,
+) -> int:
+    if first.color is second.color:
+        return duplicate_suppression_radius
+    first_width_touch = round(
+        first.width * THREEDS_TOUCH_SIZE.width / THREEDS_HD_BOTTOM_SCREEN.width
+    )
+    second_width_touch = round(
+        second.width * THREEDS_TOUCH_SIZE.width / THREEDS_HD_BOTTOM_SCREEN.width
+    )
+    same_bomb_radius = max(4, min(first_width_touch, second_width_touch))
+    return min(duplicate_suppression_radius, same_bomb_radius)
 
 
 def _touch_distance_sq(first: DetectedBomb, second: DetectedBomb) -> int:

--- a/examples/resources/nsmb_sort_or_splode/settings.toml
+++ b/examples/resources/nsmb_sort_or_splode/settings.toml
@@ -1,7 +1,7 @@
 # NSMB Sort or 'Splode 繝槭け繝ｭ險ｭ螳壹ヵ繧｡繧､繝ｫ
 
-scan_interval_seconds = 0.05
-post_drop_wait_seconds = 0.02
+scan_interval_seconds = 0.15
+post_drop_wait_seconds = 0.10
 max_sorted_count = 0
 
 red_template_path = "templates/red_bob_omb.png"
@@ -9,17 +9,17 @@ black_template_path = "templates/black_bob_omb.png"
 mask_fill_bgr = [0, 255, 0]
 
 match_method = "TM_CCOEFF_NORMED"
-red_match_threshold = 0.83
-black_match_threshold = 0.83
-template_score_margin = 0.08
+red_match_threshold = 0.9
+black_match_threshold = 0.9
+template_score_margin = 0.01
 color_sample_size = 28
-red_min_ratio = 0.20
-black_min_dark_ratio = 0.35
-black_max_red_ratio = 0.10
-duplicate_suppression_radius = 18
+red_min_ratio = 0.50
+black_min_dark_ratio = 0.5
+black_max_red_ratio = 0.01
+duplicate_suppression_radius = 8
 
-drag_steps = 4
-drag_duration_seconds = 0.10
+drag_steps = 1
+drag_duration_seconds = 0.034
 red_goal_touch = [24, 122]
 black_goal_touch = [296, 122]
 ignore_touch_rects = [

--- a/examples/tests/unit/macros/test_nsmb_sort_or_splode.py
+++ b/examples/tests/unit/macros/test_nsmb_sort_or_splode.py
@@ -1,9 +1,11 @@
 from pathlib import Path
+from types import SimpleNamespace
 
 import cv2
 import numpy as np
 import pytest
 
+import examples.macros.nsmb_sort_or_splode.macro as macro_module
 from examples.macros.nsmb_sort_or_splode.config import NsmbSortOrSplodeConfig, TouchRect
 from examples.macros.nsmb_sort_or_splode.macro import NsmbSortOrSplodeMacro
 from examples.macros.nsmb_sort_or_splode.recognizer import (
@@ -80,14 +82,21 @@ def _template_images() -> dict[str, np.ndarray]:
 def test_config_accepts_default_settings() -> None:
     cfg = NsmbSortOrSplodeConfig.from_args({})
 
+    assert cfg.scan_interval_seconds == 0.15
+    assert cfg.post_drop_wait_seconds == 0.10
     assert cfg.red_goal_touch == TouchPoint(24, 122)
     assert cfg.black_goal_touch == TouchPoint(296, 122)
     assert cfg.mask_fill_bgr == (0, 255, 0)
     assert cfg.notify_on_finish is False
-    assert cfg.template_score_margin == 0.08
-    assert cfg.red_min_ratio == 0.20
-    assert cfg.black_min_dark_ratio == 0.35
-    assert cfg.black_max_red_ratio == 0.10
+    assert cfg.red_match_threshold == 0.90
+    assert cfg.black_match_threshold == 0.90
+    assert cfg.template_score_margin == 0.01
+    assert cfg.red_min_ratio == 0.50
+    assert cfg.black_min_dark_ratio == 0.50
+    assert cfg.black_max_red_ratio == 0.01
+    assert cfg.duplicate_suppression_radius == 8
+    assert cfg.drag_steps == 1
+    assert cfg.drag_duration_seconds == 0.034
 
 
 def test_config_rejects_invalid_touch_goal() -> None:
@@ -241,6 +250,39 @@ def test_classify_bombs_keeps_nearby_opposite_colors_outside_radius() -> None:
     assert {bomb.color for bomb in classified} == {BombColor.RED, BombColor.BLACK}
 
 
+def test_classify_bombs_keeps_nearby_opposite_colors_outside_same_bomb_radius() -> None:
+    red_template = _load_template("red_bob_omb.png")
+    black_template = _load_template("black_bob_omb.png")
+    frame = np.zeros((160, 180, 3), dtype=np.uint8)
+    frame[40 : 40 + red_template.shape[0], 30 : 30 + red_template.shape[1]] = red_template
+    frame[40 : 40 + black_template.shape[0], 70 : 70 + black_template.shape[1]] = black_template
+    red_x, red_y = _template_center(30, 40, red_template)
+    black_x, black_y = _template_center(70, 40, black_template)
+    red_candidate = _detected_bomb(BombColor.RED, score=0.99, cropped_x=red_x, cropped_y=red_y)
+    black_candidate = _detected_bomb(
+        BombColor.BLACK,
+        score=0.99,
+        cropped_x=black_x,
+        cropped_y=black_y,
+    )
+
+    classified = classify_bombs(
+        frame,
+        [red_candidate],
+        [black_candidate],
+        red_threshold=0.90,
+        black_threshold=0.90,
+        duplicate_suppression_radius=32,
+        template_score_margin=0.01,
+        color_sample_size=28,
+        red_min_ratio=0.20,
+        black_min_dark_ratio=0.35,
+        black_max_red_ratio=0.10,
+    )
+
+    assert {bomb.color for bomb in classified} == {BombColor.RED, BombColor.BLACK}
+
+
 def test_macro_sends_touch_drag_for_detected_bomb() -> None:
     images = _template_images()
     frame = np.zeros((720, 1280, 3), dtype=np.uint8)
@@ -259,6 +301,7 @@ def test_macro_sends_touch_drag_for_detected_bomb() -> None:
             "post_drop_wait_seconds": 0,
             "max_sorted_count": 1,
             "red_match_threshold": 0.95,
+            "red_min_ratio": 0.20,
             "notify_on_finish": True,
         },
     )
@@ -270,6 +313,67 @@ def test_macro_sends_touch_drag_for_detected_bomb() -> None:
     assert any(event[0] == "touch_down" for event in cmd.events)
     assert ("touch_up", None) in cmd.events
     assert any(event[0] == "notify" for event in cmd.events)
+    assert any(
+        event[0] == "log" and event[1][0] == "DEBUG" and "color=red" in event[1][1]
+        for event in cmd.events
+    )
+
+
+def test_macro_saves_latest_debug_frame_when_enabled() -> None:
+    images = _template_images()
+    frame = np.zeros((720, 1280, 3), dtype=np.uint8)
+    bottom = THREEDS_HD_BOTTOM_SCREEN
+    template = images["templates/red_bob_omb.png"]
+    frame[
+        bottom.y + 40 : bottom.y + 40 + template.shape[0],
+        bottom.x + 30 : bottom.x + 30 + template.shape[1],
+    ] = template
+    cmd = FakeCommand(frame, images)
+    macro = NsmbSortOrSplodeMacro()
+    macro.initialize(
+        cmd,
+        {
+            "scan_interval_seconds": 0,
+            "post_drop_wait_seconds": 0,
+            "max_sorted_count": 1,
+            "red_match_threshold": 0.95,
+            "red_min_ratio": 0.20,
+            "save_debug_frames": True,
+        },
+    )
+
+    bomb = macro.run_iteration(cmd)
+
+    assert bomb is not None
+    assert list(cmd.saved_images) == ["nsmb_sort_or_splode/latest_detected_bomb.png"]
+    assert cmd.saved_images["nsmb_sort_or_splode/latest_detected_bomb.png"].shape == (
+        THREEDS_HD_BOTTOM_SCREEN.height,
+        THREEDS_HD_BOTTOM_SCREEN.width,
+        3,
+    )
+
+
+def test_run_subtracts_iteration_time_from_scan_interval(monkeypatch: pytest.MonkeyPatch) -> None:
+    class ProbeMacro(NsmbSortOrSplodeMacro):
+        def __init__(self) -> None:
+            self._cfg = SimpleNamespace(scan_interval_seconds=0.15)
+            self._finished = False
+            self.iterations = 0
+
+        def run_iteration(self, cmd) -> None:
+            self.iterations += 1
+            if self.iterations >= 2:
+                self._finished = True
+
+    values = iter([10.000, 10.040, 10.150])
+    monkeypatch.setattr(macro_module, "monotonic", lambda: next(values))
+    cmd = FakeCommand(np.zeros((1, 1, 3), dtype=np.uint8), {})
+    macro = ProbeMacro()
+
+    macro.run(cmd)
+
+    assert macro.iterations == 2
+    assert cmd.events == [("wait", pytest.approx(0.11))]
 
 
 def test_macro_detects_red_and_black_on_same_frame() -> None:

--- a/spec/macro/nsmb_sort_or_splode/spec.md
+++ b/spec/macro/nsmb_sort_or_splode/spec.md
@@ -30,21 +30,21 @@
 |----------|----------|----------|
 | `spec/macro/nsmb_sort_or_splode/spec.md` | 新規 | 本仕様書 |
 | `spec/macro/nsmb_sort_or_splode/masked_preview.png` | 新規 | 除外矩形を緑で塗りつぶしたプレビュー |
-| `macros/nsmb_sort_or_splode/__init__.py` | 新規 | マクロパッケージ初期化 |
-| `macros/nsmb_sort_or_splode/config.py` | 新規 | 設定 dataclass と入力検証 |
-| `macros/nsmb_sort_or_splode/recognizer.py` | 新規 | テンプレートマッチング、矩形マスク適用、座標変換 |
-| `macros/nsmb_sort_or_splode/macro.py` | 新規 | メインマクロ。キャプチャ、検出周期制御、タッチドラッグを担当 |
-| `resources/nsmb_sort_or_splode/settings.toml` | 新規 | 既定設定 |
-| `resources/nsmb_sort_or_splode/assets/templates/red_bob_omb.png` | 新規 | 赤いボムへいの検出テンプレート |
-| `resources/nsmb_sort_or_splode/assets/templates/black_bob_omb.png` | 新規 | 黒いボムへいの検出テンプレート |
-| `tests/unit/macro/test_nsmb_sort_or_splode.py` | 新規 | 設定、認識、マクロ実行の単体テスト |
-| `tests/perf/test_nsmb_sort_or_splode_perf.py` | 新規 | 検出処理の性能テスト |
+| `examples/macros/nsmb_sort_or_splode/__init__.py` | 新規 | マクロパッケージ初期化 |
+| `examples/macros/nsmb_sort_or_splode/config.py` | 変更 | 設定 dataclass と入力検証 |
+| `examples/macros/nsmb_sort_or_splode/recognizer.py` | 変更 | テンプレートマッチング、矩形マスク適用、座標変換、色分類 |
+| `examples/macros/nsmb_sort_or_splode/macro.py` | 変更 | メインマクロ。キャプチャ、周期制御、タッチドラッグ、デバッグ保存を担当 |
+| `examples/resources/nsmb_sort_or_splode/settings.toml` | 変更 | 安定動作用の既定設定 |
+| `examples/resources/nsmb_sort_or_splode/assets/templates/red_bob_omb.png` | 新規 | 赤いボムへいの検出テンプレート |
+| `examples/resources/nsmb_sort_or_splode/assets/templates/black_bob_omb.png` | 新規 | 黒いボムへいの検出テンプレート |
+| `examples/tests/unit/macros/test_nsmb_sort_or_splode.py` | 変更 | 設定、認識、マクロ実行の単体テスト |
+| `examples/tests/perf/test_nsmb_sort_or_splode_perf.py` | 新規 | 検出処理の性能テスト |
 
 ## 3. 設計方針
 
 ### アルゴリズム概要
 
-下画面実領域だけを切り出し、赤テンプレートと黒テンプレートを `scan_interval_seconds = 0.05` 秒ごとに同時に照合する。照合前に赤陣地・黒陣地・スコア表示などの矩形を `cv2.rectangle(frame, pt1, pt2, (0, 255, 0), thickness=-1)` で塗りつぶし、ボムへいの投入先や誤検出源をテンプレートマッチングから除外する。
+下画面実領域だけを切り出し、赤テンプレートと黒テンプレートを `scan_interval_seconds = 0.15` 秒周期で同時に照合する。周期は単純な後置 wait ではなく、キャプチャ、検出、ドラッグ、後処理にかかった時間を差し引いた残り時間だけ待つ。照合前に赤陣地・黒陣地・スコア表示などの矩形を `cv2.rectangle(frame, pt1, pt2, (0, 255, 0), thickness=-1)` で塗りつぶし、ボムへいの投入先や誤検出源をテンプレートマッチングから除外する。
 
 座標変換は 3DS 画面座標仕様に従う。実装では `THREEDS_HD_BOTTOM_SCREEN`、`ScreenPoint`、`ScreenRect`、`TouchPoint`、`hd_capture_point_to_3ds_touch()`、`touch_point_to_3ds_hd_capture()`、`validate_3ds_touch_point()` を使い、手書きの座標補正を増やさない。3DS HD キャプチャ座標 `(hd_x, hd_y)` からタッチ座標 `(touch_x, touch_y)` への変換式は確認用に以下で表せる。
 
@@ -53,7 +53,7 @@ touch_x = floor((hd_x - 400 + 0.5) * 320 / 480)
 touch_y = floor((hd_y - 360 + 0.5) * 240 / 360)
 ```
 
-検出したテンプレート矩形の中心をタッチ座標へ変換し、`duplicate_suppression_radius` 内の赤・黒候補を同一位置の候補として束ねる。同一位置の候補はテンプレートスコア差と HSV 色特徴で最終色を決め、色に対応する投入先へ直線補間でドラッグする。しきい値を超えた周辺ピクセルをすべて候補化するとボムへいが多い場面で候補数が増えるため、テンプレート照合結果から局所最大だけを候補化してから重複除去する。
+検出したテンプレート矩形の中心をタッチ座標へ変換し、同一色候補は `duplicate_suppression_radius` 内で重複除去する。赤候補と黒候補を同一ボムとして比較する半径はテンプレート幅から算出した小さい値に制限し、同じゲート付近に並ぶ別色ボムを同一候補として混ぜない。同一位置の候補はテンプレートスコア差と候補ごとの HSV 色特徴で最終色を決め、色に対応する投入先へ直線補間でドラッグする。しきい値を超えた周辺ピクセルをすべて候補化するとボムへいが多い場面で候補数が増えるため、テンプレート照合結果から局所最大だけを候補化してから重複除去する。
 
 ```text
 path_i = start + (goal - start) * i / drag_steps
@@ -79,9 +79,9 @@ path_i = start + (goal - start) * i / drag_steps
 
 | 指標 | 目標値 |
 |------|--------|
-| 検出周期 | 50 ms ごとに赤 / 黒を各 1 回照合 |
+| 検出周期 | 150 ms ごとに赤 / 黒を各 1 回照合。処理時間を周期に含める |
 | 1 回の画像処理 | 下画面切り出し、マスク適用、赤黒テンプレート照合、HSV 分類を 40 ms 未満で完了 |
-| ドラッグ時間 | 1 個あたり `0.18` 秒以内を既定値にする |
+| ドラッグ時間 | 1 個あたり `0.034` 秒を既定値にする |
 | 検出対象 | 陣地領域を除く下画面実領域 |
 | 誤投入抑制 | しきい値未満、またはスコア差と色特徴が一致しない場合はタッチ操作しない |
 
@@ -127,23 +127,23 @@ macros/nsmb_sort_or_splode/ -> macros/other/*      # 禁止
 
 | パラメータ | 型 | デフォルト | 説明 |
 |------------|-----|-----------|------|
-| `scan_interval_seconds` | `float` | `0.05` | テンプレート照合周期。赤 / 黒を同じ周期で照合する |
-| `post_drop_wait_seconds` | `float` | `0.02` | ドラッグ完了後の短期待機 |
+| `scan_interval_seconds` | `float` | `0.15` | テンプレート照合周期。処理時間を差し引いた残り時間だけ待つ |
+| `post_drop_wait_seconds` | `float` | `0.10` | ドラッグ完了後の短期待機 |
 | `max_sorted_count` | `int` | `0` | 仕分け数の上限。`0` は無制限 |
 | `red_template_path` | `str` | `"templates/red_bob_omb.png"` | 赤いボムへいのテンプレートパス |
 | `black_template_path` | `str` | `"templates/black_bob_omb.png"` | 黒いボムへいのテンプレートパス |
 | `mask_fill_bgr` | `list[int]` | `[0, 255, 0]` | 除外矩形を塗りつぶす BGR 色 |
 | `match_method` | `str` | `"TM_CCOEFF_NORMED"` | OpenCV のテンプレートマッチング方式 |
-| `red_match_threshold` | `float` | `0.83` | 赤テンプレートの採用しきい値 |
-| `black_match_threshold` | `float` | `0.83` | 黒テンプレートの採用しきい値 |
-| `template_score_margin` | `float` | `0.08` | 赤黒テンプレートスコアの差がこの値以上ならテンプレート判定を優先する |
+| `red_match_threshold` | `float` | `0.90` | 赤テンプレートの採用しきい値 |
+| `black_match_threshold` | `float` | `0.90` | 黒テンプレートの採用しきい値 |
+| `template_score_margin` | `float` | `0.01` | 赤黒テンプレートスコアの差がこの値以上ならテンプレート判定を優先する |
 | `color_sample_size` | `int` | `28` | HSV 色特徴を測る正方形 ROI の一辺。単位は下画面切り出し後 px |
-| `red_min_ratio` | `float` | `0.20` | 赤判定に必要な赤系画素比率 |
-| `black_min_dark_ratio` | `float` | `0.35` | 黒判定に必要な暗色画素比率 |
-| `black_max_red_ratio` | `float` | `0.10` | 黒判定時に許容する赤系画素比率の上限 |
-| `duplicate_suppression_radius` | `int` | `18` | 同一ボムへい候補をまとめる半径。単位はタッチ座標 px |
-| `drag_steps` | `int` | `4` | 1 回のドラッグで送信する中間点数 |
-| `drag_duration_seconds` | `float` | `0.10` | 1 回のドラッグ総時間 |
+| `red_min_ratio` | `float` | `0.50` | 赤判定に必要な赤系画素比率 |
+| `black_min_dark_ratio` | `float` | `0.50` | 黒判定に必要な暗色画素比率 |
+| `black_max_red_ratio` | `float` | `0.01` | 黒判定時に許容する赤系画素比率の上限 |
+| `duplicate_suppression_radius` | `int` | `8` | 同一色の同一ボムへい候補をまとめる半径。単位はタッチ座標 px |
+| `drag_steps` | `int` | `1` | 1 回のドラッグで送信する中間点数 |
+| `drag_duration_seconds` | `float` | `0.034` | 1 回のドラッグ総時間 |
 | `red_goal_touch` | `list[int]` | `[24, 122]` | 赤いボムへいの投入先タッチ座標 |
 | `black_goal_touch` | `list[int]` | `[296, 122]` | 黒いボムへいの投入先タッチ座標 |
 | `ignore_touch_rects` | `list[list[int]]` | `[[9, 70, 82, 100], [230, 72, 82, 98]]` | テンプレート照合から除外する矩形。単位はタッチ座標 |
@@ -153,9 +153,9 @@ macros/nsmb_sort_or_splode/ -> macros/other/*      # 禁止
 ### リソース形式
 
 ```toml
-# resources/nsmb_sort_or_splode/settings.toml
-scan_interval_seconds = 0.05
-post_drop_wait_seconds = 0.02
+# examples/resources/nsmb_sort_or_splode/settings.toml
+scan_interval_seconds = 0.15
+post_drop_wait_seconds = 0.10
 max_sorted_count = 0
 
 red_template_path = "templates/red_bob_omb.png"
@@ -163,17 +163,17 @@ black_template_path = "templates/black_bob_omb.png"
 mask_fill_bgr = [0, 255, 0]
 
 match_method = "TM_CCOEFF_NORMED"
-red_match_threshold = 0.83
-black_match_threshold = 0.83
-template_score_margin = 0.08
+red_match_threshold = 0.9
+black_match_threshold = 0.9
+template_score_margin = 0.01
 color_sample_size = 28
-red_min_ratio = 0.20
-black_min_dark_ratio = 0.35
-black_max_red_ratio = 0.10
-duplicate_suppression_radius = 18
+red_min_ratio = 0.50
+black_min_dark_ratio = 0.5
+black_max_red_ratio = 0.01
+duplicate_suppression_radius = 8
 
-drag_steps = 4
-drag_duration_seconds = 0.10
+drag_steps = 1
+drag_duration_seconds = 0.034
 red_goal_touch = [24, 122]
 black_goal_touch = [296, 122]
 ignore_touch_rects = [
@@ -323,8 +323,9 @@ def build_drag_path(
 - 下画面実領域、投入先、除外矩形がタッチ座標範囲内であることを検証する。
 
 **Step 1**: 検出ループ開始  
-- タイミング: `scan_interval_seconds = 0.05` 秒。
+- タイミング: `scan_interval_seconds = 0.15` 秒周期。
 - 各周期で赤テンプレートと黒テンプレートを同じフレームに対して照合する。
+- 周期待機は `max(0, scan_interval_seconds - elapsed_seconds)` とし、操作時間を含めた周期を維持する。
 
 **Step 2**: 画面取得  
 - `cmd.capture()` で `1280x720` のフレームを取得する。
@@ -336,8 +337,9 @@ def build_drag_path(
 - `paint_ignored_rects()` で陣地領域を BGR `(0, 255, 0)` に塗りつぶしたフレームを照合する。
 - 色別しきい値未満の候補は操作しない。
 - しきい値以上の照合結果のうち、3x3 近傍で局所最大の座標だけを候補化する。
-- `duplicate_suppression_radius` 内の赤・黒候補を同一位置候補としてまとめる。
-- テンプレートスコア差が `template_score_margin` 以上で、かつ HSV 色ゲートが一致した場合はその色で操作する。
+- 同一色候補は `duplicate_suppression_radius` 内で重複除去する。
+- 赤・黒候補を同一位置候補としてまとめる半径はテンプレート幅ベースに制限し、同じゲート付近の別ボムを混ぜない。
+- テンプレートスコア差が `template_score_margin` 以上で、かつ候補ごとの HSV 色ゲートが一致した場合はその色で操作する。
 - スコア差が小さい場合でも、赤または黒の HSV 色ゲートだけが通る場合はその色で操作する。
 - どちらの色ゲートも通る、またはどちらも通らない候補は操作しない。
 
@@ -351,7 +353,8 @@ def build_drag_path(
 **Step 5**: 後処理  
 - `post_drop_wait_seconds` だけ待機する。
 - `sorted_count` を加算する。
-- `save_debug_frames = true` の場合、検出矩形とドラッグ先を描画した画像を artifacts に保存する。
+- `save_debug_frames = true` の場合、検出種別の色、ラベル、ドラッグ先を描画した画像を `nsmb_sort_or_splode/latest_detected_bomb.png` に上書き保存する。
+- 検出種別、テンプレートスコア、タッチ座標、HSV 色特徴を DEBUG ログへ出力する。
 
 **Step 6**: 終了判定  
 - `max_sorted_count > 0` かつ `sorted_count >= max_sorted_count` なら終了する。
@@ -379,9 +382,12 @@ def build_drag_path(
 | ユニット | `test_measure_color_features_separates_red_and_black_templates` | 赤テンプレートと黒テンプレートの HSV 色特徴が分離できる |
 | ユニット | `test_classify_bombs_uses_hsv_gate_for_same_position_candidates` | 同一位置候補で赤テンプレートが高くても HSV が黒なら黒に分類する |
 | ユニット | `test_classify_bombs_keeps_nearby_opposite_colors_outside_radius` | `duplicate_suppression_radius` 外の赤黒候補を別個に残す |
+| ユニット | `test_classify_bombs_keeps_nearby_opposite_colors_outside_same_bomb_radius` | `duplicate_suppression_radius` 内でも別位置の赤黒候補を混ぜない |
 | ユニット | `test_build_drag_path_includes_start_and_goal` | ドラッグ経路が開始点と終点を含み、点数が設定通りになる |
 | ユニット | `test_macro_detects_red_and_black_on_same_frame` | fake `Command` で赤 / 黒候補を同一フレームから検出できる |
 | ユニット | `test_macro_sends_touch_drag_for_detected_bomb` | 検出時に `touch_down()` 群と `touch_up()` が送信される |
+| ユニット | `test_macro_saves_latest_debug_frame_when_enabled` | デバッグ画像を固定ファイル名へ上書き保存する |
+| ユニット | `test_run_subtracts_iteration_time_from_scan_interval` | 検出周期から処理時間を差し引いて待機する |
 | ユニット | `test_macro_touches_up_when_drag_fails` | ドラッグ中の例外でも `touch_up()` が送信される |
 | パフォーマンス | `test_nsmb_sort_or_splode_classified_detection_perf` | マスク適用、赤黒テンプレート照合、HSV 分類が 40 ms 未満で完了する |
 | 実機 | `test_nsmb_sort_or_splode_realdevice` | 3DS 実機または DS 互換環境で赤 / 黒の仕分けが成功する |


### PR DESCRIPTION
## Summary
- NSMB Sort or 'Splode の安定動作用パラメータを examples 側の既定値へ反映
- 検出周期を処理時間込みの周期制御に変更
- 近接した赤黒候補の混同を抑え、デバッグ画像と検知ログを改善
- 仕様書とユニットテストを更新

## Commit Log
- dfce84c fix(nsmb-sort): タッチ仕分けの安定性を改善

## Testing
- `uv run ruff check .` passed
- `uv run pytest -q` passed (654 passed, 8 skipped)