### PR TITLE
fix(deps): idna の脆弱性を修正

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,6 +104,7 @@ docstring-code-format = true
 constraint-dependencies = [
     "urllib3>=2.7.0",  # CVE-2026-21441 / CVE-2026-44432 対策
     "ujson>=5.12.0",  # CVE-2026-32875 / CVE-2026-32874 対策
+    "idna>=3.15",  # CVE-2026-45409 対策
 ]
 
 [tool.ruff.lint]

--- a/uv.lock
+++ b/uv.lock
@@ -11,6 +11,7 @@ resolution-markers = [
 
 [manifest]
 constraints = [
+    { name = "idna", specifier = ">=3.15" },
     { name = "ujson", specifier = ">=5.12.0" },
     { name = "urllib3", specifier = ">=2.7.0" },
 ]
@@ -403,11 +404,11 @@ wheels = [
 
 [[package]]
 name = "idna"
-version = "3.14"
+version = "3.17"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/05/b1/efac073e0c297ecf2fb33c346989a529d4e19164f1759102dee5953ee17e/idna-3.14.tar.gz", hash = "sha256:466d810d7a2cc1022bea9b037c39728d51ae7dad40d480fc9b7d7ecf98ba8ee3", size = 198272, upload-time = "2026-05-10T20:32:15.935Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b9/28/99c51f664567218d824af024c0251650fb27e4ca066df188dab0769c5b91/idna-3.17.tar.gz", hash = "sha256:5eb0cb53bc467c12eadcf6de83163ad8527cec9416f44b9b61b19caedad2b87f", size = 196048, upload-time = "2026-05-28T14:32:38.55Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6c/3c/3f62dee257eb3d6b2c1ef2a09d36d9793c7111156a73b5654d2c2305e5ce/idna-3.14-py3-none-any.whl", hash = "sha256:e677eaf072e290f7b725f9acf0b3a2bd55f9fd6f7c70abe5f0e34823d0accf69", size = 72184, upload-time = "2026-05-10T20:32:14.295Z" },
+    { url = "https://files.pythonhosted.org/packages/de/a7/f76514cc40ad6234098ecdebda08732d75964776c51a42845b7da10649e2/idna-3.17-py3-none-any.whl", hash = "sha256:466e48829084efe2548012b855df21540b96f2e20e51bd124c851536556a592c", size = 65316, upload-time = "2026-05-28T14:32:37.035Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- idna の CVE-2026-45409 対策として constraint-dependencies に idna>=3.15 を追加
- uv.lock を idna 3.17 へ更新

## Commit Log
- 2483f34 fix(deps): idna の脆弱性を修正

## Testing
- uv lock --check: PASS
- uvx pip-audit -r .tmp-audit-runtime.txt --progress-spinner off --aliases: PASS (No known vulnerabilities found)
- uvx pip-audit -r .tmp-audit-all.txt --progress-spinner off --aliases: PASS (No known vulnerabilities found)
- git diff --check: PASS (CRLF warning only)