### PR TITLE
feat(gui): キャプチャ入力設定を追加

### DIFF
--- a/spec/agent/complete/local_017/PONKAN_CAPTURE_SOURCE.md
+++ b/spec/agent/complete/local_017/PONKAN_CAPTURE_SOURCE.md
@@ -2,7 +2,7 @@
 
 > **対象モジュール**: `src/nyxpy/framework/core/hardware/`, `src/nyxpy/framework/core/io/`
 > **目的**: `ponkan-python` を利用し、直接接続型キャプチャデバイスから取得した画面を NyX の `FrameSourcePort` へ供給する。
-> **関連ドキュメント**: `spec/framework/rearchitecture/RUNTIME_AND_IO_PORTS.md`, `spec/agent/complete/local_007/NINTENDO_3DS_SCREEN_COORDINATES_AND_TOUCH.md`, `spec/agent/complete/local_008/SETTINGS_PREVIEW_CAPTURE_REFRESH.md`, `spec/agent/wip/local_018/CAPTURE_SOURCE_GUI_SETTINGS.md`
+> **関連ドキュメント**: `spec/framework/rearchitecture/RUNTIME_AND_IO_PORTS.md`, `spec/agent/complete/local_007/NINTENDO_3DS_SCREEN_COORDINATES_AND_TOUCH.md`, `spec/agent/complete/local_008/SETTINGS_PREVIEW_CAPTURE_REFRESH.md`, `spec/agent/complete/local_018/CAPTURE_SOURCE_GUI_SETTINGS.md`
 > **外部調査日**: 2026-06-13
 
 ## 1. 概要

--- a/spec/agent/complete/local_018/CAPTURE_SOURCE_GUI_SETTINGS.md
+++ b/spec/agent/complete/local_018/CAPTURE_SOURCE_GUI_SETTINGS.md
@@ -426,22 +426,22 @@ GUI は上記を握りつぶさない。`MainWindow.apply_app_settings()` は既
 - [x] local_017 との責務分担を確定
 - [x] GUI の source 名を「カメラ / ウィンドウ / キャプチャ」に確定
 - [x] GUI から保存する capture / ponkan / profile settings を確定
-- [ ] `GlobalSettings` schema に `capture` と capture / ponkan keys を追加
-- [ ] `DeviceSettingsTab` に source item data と capture 設定行を追加
-- [ ] `DeviceSettingsTab.apply()` で inactive source settings を保持
-- [ ] `MainWindow` 接続メニューに `キャプチャ > ponkan > n3dsxl` source tree を追加
-- [ ] `MainWindow` 接続メニューに `キャプチャ設定 > Ponkan Backend` submenu を追加
-- [ ] `n3dsxl` 配下に physical device action を追加しない
-- [ ] メニューバーの camera/window/capture action が inactive source settings を保持する
-- [ ] メニュー生成時に `ponkan` package を import しない
-- [ ] macro 非実行時の camera/window/capture source 切り替えを即時 preview 反映する
-- [ ] macro 実行中の source 切り替えを deferred apply にする
-- [ ] `MainWindow._update_connection_status()` を capture source に対応
-- [ ] `ponkan-python` 未導入時に dummy へ fallback せず preview error 表示にする
-- [ ] `GuiAppServices.FRAME_SOURCE_SETTING_KEYS` と `_frame_source_key()` を更新
-- [ ] `GuiAppServices._discard_unavailable_connection_settings()` を source 別 stale check に更新
-- [ ] GUI tests を追加・更新
-- [ ] settings schema tests を追加・更新
-- [ ] `uv run ruff check .`
-- [ ] `uv run ty check src/nyxpy --output-format concise --no-progress`
-- [ ] `uv run pytest tests/gui/test_device_settings_tab.py tests/gui/test_main_window.py tests/gui/test_app_services.py tests/unit/framework/settings/test_settings_schema.py`
+- [x] `GlobalSettings` schema に `capture` と capture / ponkan keys を追加
+- [x] `DeviceSettingsTab` に source item data と capture 設定行を追加
+- [x] `DeviceSettingsTab.apply()` で inactive source settings を保持
+- [x] `MainWindow` 接続メニューに `キャプチャ > ponkan > n3dsxl` source tree を追加
+- [x] `MainWindow` 接続メニューに `キャプチャ設定 > Ponkan Backend` submenu を追加
+- [x] `n3dsxl` 配下に physical device action を追加しない
+- [x] メニューバーの camera/window/capture action が inactive source settings を保持する
+- [x] メニュー生成時に `ponkan` package を import しない
+- [x] macro 非実行時の camera/window/capture source 切り替えを即時 preview 反映する
+- [x] macro 実行中の source 切り替えを deferred apply にする
+- [x] `MainWindow._update_connection_status()` を capture source に対応
+- [x] `ponkan-python` 未導入時に dummy へ fallback せず preview error 表示にする
+- [x] `GuiAppServices.FRAME_SOURCE_SETTING_KEYS` と `_frame_source_key()` を更新
+- [x] `GuiAppServices._discard_unavailable_connection_settings()` を source 別 stale check に更新
+- [x] GUI tests を追加・更新
+- [x] settings schema tests を追加・更新
+- [x] `uv run ruff check .`
+- [x] `uv run ty check src/nyxpy --output-format concise --no-progress`
+- [x] `uv run pytest tests/gui/test_device_settings_tab.py tests/gui/test_main_window.py tests/gui/test_app_services.py tests/unit/framework/settings/test_settings_schema.py`

--- a/src/nyxpy/gui/app_services.py
+++ b/src/nyxpy/gui/app_services.py
@@ -51,17 +51,35 @@ class SettingsApplyOutcome:
     deferred: bool = False
 
 
-FRAME_SOURCE_SETTING_KEYS = frozenset(
+PONKAN_FRAME_SOURCE_SETTING_KEYS = frozenset(
     {
-        "capture_source_type",
-        "capture_device",
-        "capture_window_title",
-        "capture_window_identifier",
-        "capture_window_match_mode",
-        "capture_backend",
-        "capture_fps",
-        "capture_aspect_box_enabled",
+        "capture_provider",
+        "capture_device_profile",
+        "ponkan_backend",
+        "ponkan_raw_slots",
+        "ponkan_output_queue_size",
+        "ponkan_drop_policy",
+        "ponkan_poll_interval",
+        "ponkan_read_timeout",
+        "ponkan_collect_timing",
+        "n3dsxl_hd_aspect_box_enabled",
     }
+)
+
+FRAME_SOURCE_SETTING_KEYS = (
+    frozenset(
+        {
+            "capture_source_type",
+            "capture_device",
+            "capture_window_title",
+            "capture_window_identifier",
+            "capture_window_match_mode",
+            "capture_backend",
+            "capture_fps",
+            "capture_aspect_box_enabled",
+        }
+    )
+    | PONKAN_FRAME_SOURCE_SETTING_KEYS
 )
 
 CONTROLLER_SETTING_KEYS = frozenset(
@@ -325,7 +343,7 @@ class GuiAppServices:
         source_type = str(self.global_settings.get("capture_source_type", "camera") or "camera")
         if source_type == "window":
             discarded_keys.extend(self._discard_unavailable_window_settings())
-        else:
+        elif source_type == "camera":
             capture_device = str(self.global_settings.get("capture_device", "") or "").strip()
             if (
                 capture_device
@@ -548,6 +566,20 @@ def _frame_source_key(settings: Mapping[str, Any]) -> tuple[object, ...]:
             _dotted_get(settings, "capture_backend", "auto"),
             capture_fps,
             aspect_box_enabled,
+        )
+    if source_type == "capture":
+        return (
+            "capture",
+            _dotted_get(settings, "capture_provider", "ponkan"),
+            _dotted_get(settings, "capture_device_profile", "n3dsxl"),
+            _dotted_get(settings, "ponkan_backend", "auto"),
+            _dotted_get(settings, "ponkan_raw_slots", 2),
+            _dotted_get(settings, "ponkan_output_queue_size", 2),
+            _dotted_get(settings, "ponkan_drop_policy", "drop_oldest"),
+            _dotted_get(settings, "ponkan_poll_interval", 0.004),
+            _dotted_get(settings, "ponkan_read_timeout", 1.0),
+            _dotted_get(settings, "ponkan_collect_timing", False),
+            _dotted_get(settings, "n3dsxl_hd_aspect_box_enabled", True),
         )
     return (
         "camera",

--- a/src/nyxpy/gui/dialogs/settings/device_tab.py
+++ b/src/nyxpy/gui/dialogs/settings/device_tab.py
@@ -3,11 +3,13 @@
 from PySide6.QtWidgets import (
     QCheckBox,
     QComboBox,
+    QDoubleSpinBox,
     QFormLayout,
     QGroupBox,
     QHBoxLayout,
     QLabel,
     QPushButton,
+    QSpinBox,
     QVBoxLayout,
     QWidget,
 )
@@ -17,6 +19,12 @@ from nyxpy.framework.core.hardware.protocol_factory import ProtocolFactory
 from nyxpy.framework.core.settings.global_settings import GlobalSettings
 from nyxpy.framework.core.settings.secrets_settings import SecretsSettings
 from nyxpy.gui.layout import WINDOW_SIZE_PRESETS, normalize_window_size_preset_key
+
+_CAPTURE_SOURCE_OPTIONS = (
+    ("カメラ", "camera"),
+    ("ウィンドウ", "window"),
+    ("キャプチャ", "capture"),
+)
 
 
 class DeviceSettingsTab(QWidget):
@@ -44,9 +52,12 @@ class DeviceSettingsTab(QWidget):
 
         source_row = QHBoxLayout()
         self.capture_source_type = QComboBox()
-        self.capture_source_type.addItems(["camera", "window"])
-        self.capture_source_type.setCurrentText(self.settings.get("capture_source_type", "camera"))
-        self.capture_source_type.currentTextChanged.connect(self._update_source_field_state)
+        for label, value in _CAPTURE_SOURCE_OPTIONS:
+            self.capture_source_type.addItem(label, value)
+        self._set_capture_source_type(self.settings.get("capture_source_type", "camera"))
+        self.capture_source_type.currentIndexChanged.connect(
+            lambda _index: self._update_source_field_state(self._capture_source_type())
+        )
         source_row.addWidget(self.capture_source_type)
         self.aspect_box_enabled = QCheckBox("レターボックス")
         self.aspect_box_enabled.setChecked(
@@ -102,7 +113,102 @@ class DeviceSettingsTab(QWidget):
         current_capture_fps = self.settings.get("capture_fps", None)
         if current_capture_fps not in (None, 0, 0.0):
             self.capture_fps.setCurrentText(str(int(float(current_capture_fps))))
-        cap_form.addRow(QLabel("Capture FPS:"), self.capture_fps)
+        self.capture_fps_label = QLabel("Capture FPS:")
+        cap_form.addRow(self.capture_fps_label, self.capture_fps)
+
+        self.capture_provider = QComboBox()
+        self.capture_provider.addItem("ponkan", "ponkan")
+        _set_combo_current_data(
+            self.capture_provider,
+            self.settings.get("capture_provider", "ponkan"),
+        )
+        self.capture_provider_label = QLabel("Capture Provider:")
+        cap_form.addRow(self.capture_provider_label, self.capture_provider)
+
+        self.capture_device_profile = QComboBox()
+        self.capture_device_profile.addItem("n3dsxl", "n3dsxl")
+        _set_combo_current_data(
+            self.capture_device_profile,
+            self.settings.get("capture_device_profile", "n3dsxl"),
+        )
+        self.capture_device_profile_label = QLabel("Device Profile:")
+        cap_form.addRow(self.capture_device_profile_label, self.capture_device_profile)
+
+        self.ponkan_backend = QComboBox()
+        for backend in ("auto", "d3xx", "d3xx-native"):
+            self.ponkan_backend.addItem(backend, backend)
+        _set_combo_current_data(self.ponkan_backend, self.settings.get("ponkan_backend", "auto"))
+        self.ponkan_backend_label = QLabel("Ponkan Backend:")
+        cap_form.addRow(self.ponkan_backend_label, self.ponkan_backend)
+
+        self.ponkan_raw_slots = QSpinBox()
+        self.ponkan_raw_slots.setRange(1, 16)
+        self.ponkan_raw_slots.setValue(int(self.settings.get("ponkan_raw_slots", 2)))
+        self.ponkan_raw_slots_label = QLabel("Raw Slots:")
+        cap_form.addRow(self.ponkan_raw_slots_label, self.ponkan_raw_slots)
+
+        self.ponkan_output_queue_size = QSpinBox()
+        self.ponkan_output_queue_size.setRange(1, 64)
+        self.ponkan_output_queue_size.setValue(
+            int(self.settings.get("ponkan_output_queue_size", 2))
+        )
+        self.ponkan_output_queue_size_label = QLabel("Output Queue Size:")
+        cap_form.addRow(self.ponkan_output_queue_size_label, self.ponkan_output_queue_size)
+
+        self.ponkan_drop_policy = QComboBox()
+        for policy in ("drop_oldest", "drop_newest", "block"):
+            self.ponkan_drop_policy.addItem(policy, policy)
+        _set_combo_current_data(
+            self.ponkan_drop_policy,
+            self.settings.get("ponkan_drop_policy", "drop_oldest"),
+        )
+        self.ponkan_drop_policy_label = QLabel("Drop Policy:")
+        cap_form.addRow(self.ponkan_drop_policy_label, self.ponkan_drop_policy)
+
+        self.ponkan_poll_interval = QDoubleSpinBox()
+        self.ponkan_poll_interval.setDecimals(6)
+        self.ponkan_poll_interval.setRange(0.000001, 1.0)
+        self.ponkan_poll_interval.setSingleStep(0.001)
+        self.ponkan_poll_interval.setValue(float(self.settings.get("ponkan_poll_interval", 0.004)))
+        self.ponkan_poll_interval_label = QLabel("Poll Interval:")
+        cap_form.addRow(self.ponkan_poll_interval_label, self.ponkan_poll_interval)
+
+        self.ponkan_read_timeout = QDoubleSpinBox()
+        self.ponkan_read_timeout.setDecimals(3)
+        self.ponkan_read_timeout.setRange(0.0, 60.0)
+        self.ponkan_read_timeout.setSingleStep(0.1)
+        self.ponkan_read_timeout.setValue(float(self.settings.get("ponkan_read_timeout", 1.0)))
+        self.ponkan_read_timeout_label = QLabel("Read Timeout:")
+        cap_form.addRow(self.ponkan_read_timeout_label, self.ponkan_read_timeout)
+
+        self.ponkan_collect_timing = QCheckBox("有効")
+        self.ponkan_collect_timing.setChecked(
+            bool(self.settings.get("ponkan_collect_timing", False))
+        )
+        self.ponkan_collect_timing_label = QLabel("Collect Timing:")
+        cap_form.addRow(self.ponkan_collect_timing_label, self.ponkan_collect_timing)
+
+        self.n3dsxl_hd_aspect_box_enabled = QCheckBox("有効")
+        self.n3dsxl_hd_aspect_box_enabled.setChecked(
+            bool(self.settings.get("n3dsxl_hd_aspect_box_enabled", True))
+        )
+        self.n3dsxl_hd_aspect_box_enabled_label = QLabel("HD Aspect Box:")
+        cap_form.addRow(
+            self.n3dsxl_hd_aspect_box_enabled_label,
+            self.n3dsxl_hd_aspect_box_enabled,
+        )
+        self.capture_setting_rows = (
+            (self.capture_provider_label, self.capture_provider),
+            (self.capture_device_profile_label, self.capture_device_profile),
+            (self.ponkan_backend_label, self.ponkan_backend),
+            (self.ponkan_raw_slots_label, self.ponkan_raw_slots),
+            (self.ponkan_output_queue_size_label, self.ponkan_output_queue_size),
+            (self.ponkan_drop_policy_label, self.ponkan_drop_policy),
+            (self.ponkan_poll_interval_label, self.ponkan_poll_interval),
+            (self.ponkan_read_timeout_label, self.ponkan_read_timeout),
+            (self.ponkan_collect_timing_label, self.ponkan_collect_timing),
+            (self.n3dsxl_hd_aspect_box_enabled_label, self.n3dsxl_hd_aspect_box_enabled),
+        )
 
         cap_group_layout.addLayout(cap_form)
         layout.addWidget(cap_group)
@@ -175,7 +281,7 @@ class DeviceSettingsTab(QWidget):
         layout.addWidget(appearance_group)
         layout.addStretch(1)
 
-        self._update_source_field_state(self.capture_source_type.currentText())
+        self._update_source_field_state(self._capture_source_type())
 
     def _apply_protocol_default_baud(self, protocol_name: str):
         default_baud = str(ProtocolFactory.get_default_baudrate(protocol_name))
@@ -222,20 +328,42 @@ class DeviceSettingsTab(QWidget):
                 return
 
     def apply(self):
-        self.settings.set("capture_source_type", self.capture_source_type.currentText())
-        self.settings.set("capture_device", self.cap_device.currentText())
-        window_data = self.window_source.currentData() or {}
-        window_title = self.window_source.currentText().strip()
-        selected_title = str(window_data.get("title", ""))
-        selected_identifier = str(window_data.get("identifier", ""))
-        if window_title != selected_title:
-            selected_identifier = ""
-        self.settings.set("capture_window_title", window_title or selected_title)
-        self.settings.set("capture_window_identifier", selected_identifier)
-        self.settings.set("capture_window_match_mode", self.window_match_mode.currentText())
-        self.settings.set("capture_backend", self.capture_backend.currentText())
-        self.settings.set("capture_fps", self.capture_fps.currentData())
-        self.settings.set("capture_aspect_box_enabled", self.aspect_box_enabled.isChecked())
+        source_type = self._capture_source_type()
+        self.settings.set("capture_source_type", source_type)
+        if source_type == "camera":
+            self.settings.set("capture_device", self.cap_device.currentText())
+            self.settings.set("capture_fps", self.capture_fps.currentData())
+            self.settings.set("capture_aspect_box_enabled", self.aspect_box_enabled.isChecked())
+        elif source_type == "window":
+            window_data = self.window_source.currentData() or {}
+            window_title = self.window_source.currentText().strip()
+            selected_title = str(window_data.get("title", ""))
+            selected_identifier = str(window_data.get("identifier", ""))
+            if window_title != selected_title:
+                selected_identifier = ""
+            self.settings.set("capture_window_title", window_title or selected_title)
+            self.settings.set("capture_window_identifier", selected_identifier)
+            self.settings.set("capture_window_match_mode", self.window_match_mode.currentText())
+            self.settings.set("capture_backend", self.capture_backend.currentText())
+            self.settings.set("capture_fps", self.capture_fps.currentData())
+            self.settings.set("capture_aspect_box_enabled", self.aspect_box_enabled.isChecked())
+        elif source_type == "capture":
+            self.settings.set("capture_provider", self.capture_provider.currentData())
+            self.settings.set("capture_device_profile", self.capture_device_profile.currentData())
+            self.settings.set("ponkan_backend", self.ponkan_backend.currentData())
+            self.settings.set("ponkan_raw_slots", self.ponkan_raw_slots.value())
+            self.settings.set(
+                "ponkan_output_queue_size",
+                self.ponkan_output_queue_size.value(),
+            )
+            self.settings.set("ponkan_drop_policy", self.ponkan_drop_policy.currentData())
+            self.settings.set("ponkan_poll_interval", self.ponkan_poll_interval.value())
+            self.settings.set("ponkan_read_timeout", self.ponkan_read_timeout.value())
+            self.settings.set("ponkan_collect_timing", self.ponkan_collect_timing.isChecked())
+            self.settings.set(
+                "n3dsxl_hd_aspect_box_enabled",
+                self.n3dsxl_hd_aspect_box_enabled.isChecked(),
+            )
         self.settings.set("preview_fps", int(self.preview_fps.currentText()))
         self.settings.set(
             "serial_device",
@@ -245,9 +373,18 @@ class DeviceSettingsTab(QWidget):
         self.settings.set("serial_baud", int(self.ser_baud.currentText()))
         self.settings.set("gui.window_size_preset", self.window_size_preset.currentData())
 
+    def _capture_source_type(self) -> str:
+        value = self.capture_source_type.currentData()
+        return str(value or "camera")
+
+    def _set_capture_source_type(self, value: object) -> None:
+        index = self.capture_source_type.findData(str(value or "camera"))
+        self.capture_source_type.setCurrentIndex(index if index >= 0 else 0)
+
     def _update_source_field_state(self, source_type: str) -> None:
         is_camera = source_type == "camera"
         is_window = source_type == "window"
+        is_capture = source_type == "capture"
         self.camera_label.setVisible(is_camera)
         self.camera_row.setVisible(is_camera)
         self.window_label.setVisible(is_window)
@@ -256,6 +393,12 @@ class DeviceSettingsTab(QWidget):
         self.window_match_mode.setVisible(is_window)
         self.backend_label.setVisible(is_window)
         self.capture_backend.setVisible(is_window)
+        self.aspect_box_enabled.setVisible(not is_capture)
+        self.capture_fps_label.setVisible(not is_capture)
+        self.capture_fps.setVisible(not is_capture)
+        for label, widget in self.capture_setting_rows:
+            label.setVisible(is_capture)
+            widget.setVisible(is_capture)
 
 
 def _layout_container(layout: QHBoxLayout) -> QWidget:
@@ -263,3 +406,8 @@ def _layout_container(layout: QHBoxLayout) -> QWidget:
     layout.setContentsMargins(0, 0, 0, 0)
     container.setLayout(layout)
     return container
+
+
+def _set_combo_current_data(combo: QComboBox, value: object) -> None:
+    index = combo.findData(value)
+    combo.setCurrentIndex(index if index >= 0 else 0)

--- a/src/nyxpy/gui/main_window.py
+++ b/src/nyxpy/gui/main_window.py
@@ -69,6 +69,7 @@ _CAPTURE_FPS_OPTIONS = (
     ("30", 30.0),
     ("60", 60.0),
 )
+_PONKAN_BACKEND_OPTIONS = ("auto", "d3xx", "d3xx-native")
 _SERIAL_BAUD_OPTIONS = (
     "1200",
     "2400",
@@ -179,9 +180,15 @@ class MainWindow(QMainWindow):
         self.capture_source_type_menu: QMenu | None = None
         self.camera_source_menu: QMenu | None = None
         self.window_source_menu: QMenu | None = None
+        self.capture_source_menu: QMenu | None = None
+        self.capture_provider_menu: QMenu | None = None
+        self.capture_settings_menu: QMenu | None = None
+        self.ponkan_backend_menu: QMenu | None = None
         self.capture_fps_menu: QMenu | None = None
         self.serial_baud_menu: QMenu | None = None
         self.capture_device_action_group: QActionGroup | None = None
+        self.capture_profile_action_group: QActionGroup | None = None
+        self.ponkan_backend_action_group: QActionGroup | None = None
         self.capture_fps_action_group: QActionGroup | None = None
         self.serial_device_action_group: QActionGroup | None = None
         self.serial_baud_action_group: QActionGroup | None = None
@@ -265,8 +272,17 @@ class MainWindow(QMainWindow):
             devices,
             windows,
         )
+        self.capture_settings_menu = QMenu("キャプチャ設定", menu)
+        self.capture_settings_menu.setEnabled(
+            self.global_settings.get("capture_source_type", "camera") == "capture"
+        )
+        menu.addMenu(self.capture_settings_menu)
+        self._populate_capture_settings_menu(self.capture_settings_menu)
         menu.addSeparator()
         self.capture_fps_menu = QMenu("FPS", menu)
+        self.capture_fps_menu.setEnabled(
+            self.global_settings.get("capture_source_type", "camera") != "capture"
+        )
         menu.addMenu(self.capture_fps_menu)
         self.capture_fps_action_group = QActionGroup(self)
         self.capture_fps_action_group.setExclusive(True)
@@ -293,10 +309,63 @@ class MainWindow(QMainWindow):
         menu.clear()
         self.camera_source_menu = QMenu("カメラ", menu)
         self.window_source_menu = QMenu("ウィンドウ", menu)
+        self.capture_source_menu = QMenu("キャプチャ", menu)
         menu.addMenu(self.camera_source_menu)
         menu.addMenu(self.window_source_menu)
+        menu.addMenu(self.capture_source_menu)
         self._populate_camera_source_menu(self.camera_source_menu, devices)
         self._populate_window_source_menu(self.window_source_menu, windows)
+        self._populate_direct_capture_source_menu(self.capture_source_menu)
+
+    def _populate_direct_capture_source_menu(self, menu: QMenu) -> None:
+        menu.clear()
+        self.capture_provider_menu = QMenu("ponkan", menu)
+        menu.addMenu(self.capture_provider_menu)
+        self.capture_profile_action_group = QActionGroup(self)
+        self.capture_profile_action_group.setExclusive(True)
+        action = QAction("n3dsxl", self)
+        action.setCheckable(True)
+        action.setData("n3dsxl")
+        action.setChecked(
+            self.global_settings.get("capture_source_type", "camera") == "capture"
+            and self.global_settings.get("capture_provider", "ponkan") == "ponkan"
+            and self.global_settings.get("capture_device_profile", "n3dsxl") == "n3dsxl"
+        )
+        action.triggered.connect(
+            lambda _checked=False: self._apply_connection_settings(
+                {
+                    "capture_source_type": "capture",
+                    "capture_provider": "ponkan",
+                    "capture_device_profile": "n3dsxl",
+                }
+            )
+        )
+        self.capture_profile_action_group.addAction(action)
+        self.capture_provider_menu.addAction(action)
+
+    def _populate_capture_settings_menu(self, menu: QMenu) -> None:
+        menu.clear()
+        self.ponkan_backend_menu = QMenu("Ponkan Backend", menu)
+        menu.addMenu(self.ponkan_backend_menu)
+        self._populate_ponkan_backend_menu(self.ponkan_backend_menu)
+
+    def _populate_ponkan_backend_menu(self, menu: QMenu) -> None:
+        menu.clear()
+        self.ponkan_backend_action_group = QActionGroup(self)
+        self.ponkan_backend_action_group.setExclusive(True)
+        current = self.global_settings.get("ponkan_backend", "auto")
+        for backend in _PONKAN_BACKEND_OPTIONS:
+            action = QAction(backend, self)
+            action.setCheckable(True)
+            action.setData(backend)
+            action.setChecked(current == backend)
+            action.triggered.connect(
+                lambda _checked=False, value=backend: self._apply_connection_settings(
+                    {"ponkan_backend": value}
+                )
+            )
+            self.ponkan_backend_action_group.addAction(action)
+            menu.addAction(action)
 
     def _populate_camera_source_menu(
         self,
@@ -628,12 +697,14 @@ class MainWindow(QMainWindow):
     def _update_connection_status(self) -> None:
         source_type = self.global_settings.get("capture_source_type", "camera")
         discovery_snapshot = _device_discovery_snapshot(self.device_discovery)
-        window_snapshot = _window_discovery_snapshot(self.device_discovery)
         if source_type == "window":
+            window_snapshot = _window_discovery_snapshot(self.device_discovery)
             capture_selection = _select_window_connection_status(
                 self.global_settings,
                 window_snapshot,
             )
+        elif source_type == "capture":
+            capture_selection = None
         else:
             capture_selection = select_capture_target(
                 ConnectionRequest(
@@ -645,7 +716,10 @@ class MainWindow(QMainWindow):
             )
         if self.preview_connection_error is not None:
             capture_status = f"映像: 接続失敗 ({self.preview_connection_error})"
+        elif source_type == "capture":
+            capture_status = "映像: キャプチャ (N3DSXL) 接続中"
         else:
+            assert capture_selection is not None
             capture_status = _format_connection_status("映像", capture_selection)
         serial_selection = select_serial_target(
             ConnectionRequest(

--- a/tests/gui/test_app_services.py
+++ b/tests/gui/test_app_services.py
@@ -6,7 +6,7 @@ from nyxpy.framework.core.hardware.device_discovery import (
     WindowDiscoveryResult,
 )
 from nyxpy.framework.core.hardware.window_discovery import WindowInfo
-from nyxpy.gui.app_services import GuiAppServices
+from nyxpy.gui.app_services import GuiAppServices, _frame_source_key
 
 
 class FakeSettings:
@@ -218,6 +218,87 @@ def test_app_services_ignores_window_title_change_while_camera_source_is_active(
     assert outcome.frame_source_changed is False
 
 
+def test_app_services_rebuilds_builder_when_ponkan_key_changes() -> None:
+    settings = {
+        "capture_source_type": "capture",
+        "capture_provider": "ponkan",
+        "capture_device_profile": "n3dsxl",
+        "ponkan_backend": "d3xx-native",
+        "ponkan_raw_slots": 2,
+        "ponkan_output_queue_size": 2,
+        "ponkan_drop_policy": "drop_oldest",
+        "ponkan_poll_interval": 0.004,
+        "ponkan_read_timeout": 1.0,
+        "ponkan_collect_timing": False,
+        "n3dsxl_hd_aspect_box_enabled": True,
+    }
+    services = make_services(
+        settings,
+        previous_builder_settings={
+            **settings,
+            "ponkan_backend": "auto",
+        },
+    )
+    services._active_frame_source_key = (
+        "capture",
+        "ponkan",
+        "n3dsxl",
+        "auto",
+        2,
+        2,
+        "drop_oldest",
+        0.004,
+        1.0,
+        False,
+        True,
+    )
+
+    outcome = services.apply_settings(is_run_active=False)
+
+    assert outcome.builder_replaced is True
+    assert outcome.frame_source_changed is True
+    assert outcome.preview_frame_source is services.runtime_builder.preview
+
+
+def test_app_services_frame_source_key_uses_ponkan_settings() -> None:
+    settings = {
+        "capture_source_type": "capture",
+        "capture_device": "Camera1",
+        "capture_window_title": "Viewer",
+        "capture_window_identifier": "hwnd-1",
+        "capture_provider": "ponkan",
+        "capture_device_profile": "n3dsxl",
+        "ponkan_backend": "d3xx",
+        "ponkan_raw_slots": 3,
+        "ponkan_output_queue_size": 4,
+        "ponkan_drop_policy": "block",
+        "ponkan_poll_interval": 0.01,
+        "ponkan_read_timeout": 0.5,
+        "ponkan_collect_timing": True,
+        "n3dsxl_hd_aspect_box_enabled": False,
+    }
+
+    key = _frame_source_key(settings)
+    settings["capture_device"] = "Camera2"
+    settings["capture_window_title"] = "Other Viewer"
+    settings["capture_window_identifier"] = "hwnd-2"
+
+    assert key == (
+        "capture",
+        "ponkan",
+        "n3dsxl",
+        "d3xx",
+        3,
+        4,
+        "block",
+        0.01,
+        0.5,
+        True,
+        False,
+    )
+    assert _frame_source_key(settings) == key
+
+
 def test_app_services_does_not_rebuild_for_gui_only_setting() -> None:
     settings = {
         "capture_source_type": "window",
@@ -383,3 +464,26 @@ def test_app_services_keeps_window_setting_when_window_discovery_raises() -> Non
 
     assert services.global_settings.get("capture_window_title") == "Viewer"
     assert services.global_settings.get("capture_window_identifier") == "hwnd-1"
+
+
+def test_app_services_keeps_camera_window_settings_for_capture_source() -> None:
+    settings = {
+        "capture_source_type": "capture",
+        "capture_device": "Missing Camera",
+        "capture_window_title": "Closed Viewer",
+        "capture_window_identifier": "hwnd-old",
+        "capture_window_match_mode": "exact",
+        "capture_provider": "ponkan",
+        "capture_device_profile": "n3dsxl",
+        "serial_device": "COM1",
+    }
+    services = make_services(
+        settings,
+        device_discovery=FakeDiscovery(serial=("COM1",), capture=(), windows=()),
+    )
+
+    services.apply_settings(is_run_active=False)
+
+    assert services.global_settings.get("capture_device") == "Missing Camera"
+    assert services.global_settings.get("capture_window_title") == "Closed Viewer"
+    assert services.global_settings.get("capture_window_identifier") == "hwnd-old"

--- a/tests/gui/test_device_settings_tab.py
+++ b/tests/gui/test_device_settings_tab.py
@@ -17,6 +17,16 @@ class FakeSettings:
             "capture_backend": "auto",
             "capture_fps": None,
             "capture_aspect_box_enabled": False,
+            "capture_provider": "ponkan",
+            "capture_device_profile": "n3dsxl",
+            "ponkan_backend": "auto",
+            "ponkan_raw_slots": 2,
+            "ponkan_output_queue_size": 2,
+            "ponkan_drop_policy": "drop_oldest",
+            "ponkan_poll_interval": 0.004,
+            "ponkan_read_timeout": 1.0,
+            "ponkan_collect_timing": False,
+            "n3dsxl_hd_aspect_box_enabled": True,
             "preview_fps": 60,
             "serial_device": "COM1",
             "serial_protocol": "CH552",
@@ -86,10 +96,18 @@ def test_device_settings_tab_shows_capture_source_type(qtbot):
     qtbot.addWidget(tab)
 
     assert [
-        tab.capture_source_type.itemText(i) for i in range(tab.capture_source_type.count())
+        tab.capture_source_type.itemData(i) for i in range(tab.capture_source_type.count())
     ] == [
         "camera",
         "window",
+        "capture",
+    ]
+    assert [
+        tab.capture_source_type.itemText(i) for i in range(tab.capture_source_type.count())
+    ] == [
+        "カメラ",
+        "ウィンドウ",
+        "キャプチャ",
     ]
 
 
@@ -98,7 +116,7 @@ def test_device_settings_tab_applies_window_capture_settings(qtbot):
     tab = DeviceSettingsTab(settings, None, device_discovery=FakeDiscovery())
     qtbot.addWidget(tab)
 
-    tab.capture_source_type.setCurrentText("window")
+    _set_capture_source(tab, "window")
     tab.window_source.setCurrentIndex(0)
     tab.window_match_mode.setCurrentText("contains")
     tab.capture_backend.setCurrentText("mss")
@@ -127,7 +145,7 @@ def test_device_settings_tab_saves_custom_window_title_without_identifier(qtbot)
     tab = DeviceSettingsTab(settings, None, device_discovery=FakeDiscovery())
     qtbot.addWidget(tab)
 
-    tab.capture_source_type.setCurrentText("window")
+    _set_capture_source(tab, "window")
     tab.window_source.setEditText("View")
     tab.window_match_mode.setCurrentText("contains")
     tab.apply()
@@ -157,16 +175,79 @@ def test_device_settings_tab_hides_irrelevant_source_fields(qtbot):
 
     assert not tab.cap_device.isHidden()
     assert tab.window_row.isHidden()
+    assert tab.capture_provider.isHidden()
 
-    tab.capture_source_type.setCurrentText("window")
+    _set_capture_source(tab, "window")
     assert tab.camera_row.isHidden()
     assert not tab.window_row.isHidden()
     assert not tab.window_match_mode.isHidden()
     assert not tab.capture_backend.isHidden()
+    assert tab.capture_provider.isHidden()
 
-    tab.capture_source_type.setCurrentText("camera")
+    _set_capture_source(tab, "camera")
     assert not tab.cap_device.isHidden()
     assert tab.window_row.isHidden()
+    assert tab.capture_provider.isHidden()
+
+    _set_capture_source(tab, "capture")
+    assert tab.camera_row.isHidden()
+    assert tab.window_row.isHidden()
+    assert tab.window_match_mode.isHidden()
+    assert tab.capture_backend.isHidden()
+    assert tab.capture_fps.isHidden()
+    assert tab.aspect_box_enabled.isHidden()
+    assert not tab.capture_provider.isHidden()
+    assert not tab.capture_device_profile.isHidden()
+    assert not tab.ponkan_backend.isHidden()
+
+
+def test_device_settings_tab_applies_ponkan_capture_settings(qtbot):
+    settings = FakeSettings()
+    tab = DeviceSettingsTab(settings, None, device_discovery=FakeDiscovery())
+    qtbot.addWidget(tab)
+
+    _set_capture_source(tab, "capture")
+    _set_combo_data(tab.ponkan_backend, "d3xx-native")
+    tab.ponkan_raw_slots.setValue(3)
+    tab.ponkan_output_queue_size.setValue(4)
+    _set_combo_data(tab.ponkan_drop_policy, "block")
+    tab.ponkan_poll_interval.setValue(0.01)
+    tab.ponkan_read_timeout.setValue(0.5)
+    tab.ponkan_collect_timing.setChecked(True)
+    tab.n3dsxl_hd_aspect_box_enabled.setChecked(False)
+    tab.apply()
+
+    assert settings.data["capture_source_type"] == "capture"
+    assert settings.data["capture_provider"] == "ponkan"
+    assert settings.data["capture_device_profile"] == "n3dsxl"
+    assert settings.data["ponkan_backend"] == "d3xx-native"
+    assert settings.data["ponkan_raw_slots"] == 3
+    assert settings.data["ponkan_output_queue_size"] == 4
+    assert settings.data["ponkan_drop_policy"] == "block"
+    assert settings.data["ponkan_poll_interval"] == 0.01
+    assert settings.data["ponkan_read_timeout"] == 0.5
+    assert settings.data["ponkan_collect_timing"] is True
+    assert settings.data["n3dsxl_hd_aspect_box_enabled"] is False
+
+
+def test_device_settings_tab_preserves_inactive_source_settings_for_capture(qtbot):
+    settings = FakeSettings()
+    settings.data["capture_device"] = "Camera1"
+    settings.data["capture_window_title"] = "Viewer"
+    settings.data["capture_window_identifier"] = "hwnd-1"
+    settings.data["capture_backend"] = "mss"
+    tab = DeviceSettingsTab(settings, None, device_discovery=FakeDiscovery())
+    qtbot.addWidget(tab)
+
+    _set_capture_source(tab, "capture")
+    tab.cap_device.clear()
+    tab.window_source.setEditText("")
+    tab.apply()
+
+    assert settings.data["capture_device"] == "Camera1"
+    assert settings.data["capture_window_title"] == "Viewer"
+    assert settings.data["capture_window_identifier"] == "hwnd-1"
+    assert settings.data["capture_backend"] == "mss"
 
 
 def test_device_settings_tab_saves_serial_identifier(qtbot):
@@ -222,3 +303,15 @@ def test_device_settings_tab_places_preview_fps_in_appearance_group(qtbot):
 
 def _label_texts(widget) -> list[str]:
     return [label.text() for label in widget.findChildren(QLabel)]
+
+
+def _set_capture_source(tab: DeviceSettingsTab, source_type: str) -> None:
+    index = tab.capture_source_type.findData(source_type)
+    assert index >= 0
+    tab.capture_source_type.setCurrentIndex(index)
+
+
+def _set_combo_data(combo, value: str) -> None:
+    index = combo.findData(value)
+    assert index >= 0
+    combo.setCurrentIndex(index)

--- a/tests/gui/test_main_window.py
+++ b/tests/gui/test_main_window.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import sys
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import MagicMock
@@ -71,6 +72,16 @@ class FakeSettings:
             "serial_protocol": "CH552",
             "serial_baud": 9600,
             "capture_fps": None,
+            "capture_provider": "ponkan",
+            "capture_device_profile": "n3dsxl",
+            "ponkan_backend": "auto",
+            "ponkan_raw_slots": 2,
+            "ponkan_output_queue_size": 2,
+            "ponkan_drop_policy": "drop_oldest",
+            "ponkan_poll_interval": 0.004,
+            "ponkan_read_timeout": 1.0,
+            "ponkan_collect_timing": False,
+            "n3dsxl_hd_aspect_box_enabled": True,
         }
 
     def get(self, key: str, default=None):
@@ -338,7 +349,79 @@ def test_capture_input_menu_nests_candidates_under_input_source(window: MainWind
         if action.menu() is not None
     ]
 
-    assert source_menus == ["カメラ", "ウィンドウ"]
+    assert source_menus == ["カメラ", "ウィンドウ", "キャプチャ"]
+
+
+def test_connection_menu_nests_capture_profiles_under_capture_source(
+    window: MainWindow,
+) -> None:
+    assert window.capture_source_menu is not None
+    capture_provider_menus = [
+        action.menu().title() for action in window.capture_source_menu.actions() if action.menu()
+    ]
+
+    assert capture_provider_menus == ["ponkan"]
+    assert window.capture_provider_menu is not None
+    assert [action.text() for action in window.capture_provider_menu.actions()] == ["n3dsxl"]
+
+
+def test_connection_menu_applies_capture_profile_source_setting(window: MainWindow) -> None:
+    assert window.capture_provider_menu is not None
+    action = next(
+        action for action in window.capture_provider_menu.actions() if action.text() == "n3dsxl"
+    )
+
+    action.trigger()
+
+    assert window.global_settings.get("capture_source_type") == "capture"
+    assert window.global_settings.get("capture_provider") == "ponkan"
+    assert window.global_settings.get("capture_device_profile") == "n3dsxl"
+    assert window.services.apply_calls[-1] is False
+
+
+def test_connection_menu_has_ponkan_backend_under_capture_settings(
+    window: MainWindow,
+) -> None:
+    assert window.capture_settings_menu is not None
+    assert window.ponkan_backend_menu is not None
+
+    backend_actions = window.ponkan_backend_menu.actions()
+    assert [action.text() for action in backend_actions] == ["auto", "d3xx", "d3xx-native"]
+    assert backend_actions[0].isChecked()
+
+    backend_actions[2].trigger()
+
+    assert window.global_settings.get("ponkan_backend") == "d3xx-native"
+    assert window.global_settings.get("capture_source_type") == "camera"
+
+
+def test_connection_menu_disables_capture_fps_for_capture_source(window: MainWindow) -> None:
+    window.global_settings.set("capture_source_type", "capture")
+    window._refresh_connection_menu()
+
+    assert window.capture_settings_menu is not None
+    assert window.capture_fps_menu is not None
+    assert window.capture_settings_menu.isEnabled()
+    assert not window.capture_fps_menu.isEnabled()
+
+
+def test_connection_menu_does_not_list_physical_ponkan_devices(window: MainWindow) -> None:
+    assert window.capture_provider_menu is not None
+
+    actions = window.capture_provider_menu.actions()
+
+    assert len(actions) == 1
+    assert actions[0].text() == "n3dsxl"
+
+
+def test_connection_menu_does_not_import_ponkan_when_populating_capture_actions(
+    window: MainWindow,
+) -> None:
+    sys.modules.pop("ponkan", None)
+
+    window._refresh_connection_menu()
+
+    assert "ponkan" not in sys.modules
 
 
 def test_connection_menu_lists_snapshot_without_detecting(window: MainWindow) -> None:
@@ -490,6 +573,24 @@ def test_connection_menu_applies_window_source_setting(window: MainWindow) -> No
     assert window.global_settings.get("capture_source_type") == "window"
     assert window.global_settings.get("capture_window_title") == "Viewer"
     assert window.global_settings.get("capture_window_identifier") == "hwnd-1"
+
+
+def test_connection_menu_preserves_inactive_source_settings(window: MainWindow) -> None:
+    window.global_settings.set("capture_device", "Camera1")
+    window.global_settings.set("capture_window_title", "Viewer")
+    window.global_settings.set("capture_window_identifier", "hwnd-1")
+    window.global_settings.set("ponkan_backend", "d3xx")
+    assert window.capture_provider_menu is not None
+    action = next(
+        action for action in window.capture_provider_menu.actions() if action.text() == "n3dsxl"
+    )
+
+    action.trigger()
+
+    assert window.global_settings.get("capture_device") == "Camera1"
+    assert window.global_settings.get("capture_window_title") == "Viewer"
+    assert window.global_settings.get("capture_window_identifier") == "hwnd-1"
+    assert window.global_settings.get("ponkan_backend") == "d3xx"
 
 
 def test_connection_menu_clamps_baudrate_when_protocol_changes(window: MainWindow) -> None:
@@ -672,6 +773,18 @@ def test_status_bar_resolves_window_status_by_title_when_identifier_is_stale(
     qtbot.addWidget(w)
 
     assert w.capture_status_label.text() == "映像: Viewer 接続中"
+    w.preview_pane.timer.stop()
+
+
+def test_status_bar_displays_capture_profile_state(qtbot, services: FakeServices):
+    services.global_settings.set("capture_source_type", "capture")
+    services.global_settings.set("serial_device", "COM1")
+
+    w = MainWindow(services=services)
+    qtbot.addWidget(w)
+
+    assert w.capture_status_label.text() == "映像: キャプチャ (N3DSXL) 接続中"
+    assert w.serial_status_label.text() == "シリアル: USB Serial Device (COM1) 接続中"
     w.preview_pane.timer.stop()
 
 


### PR DESCRIPTION
## Summary
- GUI 設定ダイアログから `capture` / `ponkan` / `n3dsxl` と ponkan 詳細設定を保存できるようにしました
- 接続メニューに `キャプチャ > ponkan > n3dsxl` と `キャプチャ設定 > Ponkan Backend` を追加しました
- capture source の再生成キー、stale 設定破棄、status bar 表示を source 別に更新しました
- local_018 仕様書を complete に移動し、local_017 からの関連リンクを更新しました

## Validation
- `uv lock --check`
- `uv run --no-sync ruff format --check .`
- `uv run --no-sync ruff check .`
- `uv run --no-sync ty check src/nyxpy --output-format concise --no-progress`
- `uv run --no-sync pytest tests/gui/test_device_settings_tab.py tests/gui/test_main_window.py tests/gui/test_app_services.py tests/unit/framework/settings/test_settings_schema.py`
- `uv run --no-sync pytest`