### PR TITLE
feat(gui): キャプチャ入力の依存表示を整理

### DIFF
--- a/spec/agent/complete/local_018/CAPTURE_SOURCE_GUI_SETTINGS.md
+++ b/spec/agent/complete/local_018/CAPTURE_SOURCE_GUI_SETTINGS.md
@@ -2,7 +2,7 @@
 
 > **対象モジュール**: `src/nyxpy/gui/`, `src/nyxpy/framework/core/settings/`
 > **目的**: 直接接続型キャプチャ source を GUI から選択・設定・再接続できるようにし、`ponkan-python` 統合を利用者の操作導線へ接続する。
-> **関連ドキュメント**: `spec/agent/complete/local_017/PONKAN_CAPTURE_SOURCE.md`, `spec/agent/complete/local_008/SETTINGS_PREVIEW_CAPTURE_REFRESH.md`
+> **関連ドキュメント**: `spec/agent/complete/local_017/PONKAN_CAPTURE_SOURCE.md`, `spec/agent/complete/local_008/SETTINGS_PREVIEW_CAPTURE_REFRESH.md`, `spec/agent/complete/local_019/CAPTURE_SOURCE_GUI_DEPENDENCY_AND_SIMPLIFICATION.md`
 > **既存ソース**: `src/nyxpy/gui/dialogs/settings/device_tab.py`, `src/nyxpy/gui/main_window.py`, `src/nyxpy/gui/app_services.py`
 > **破壊的変更**: なし。既存 `camera` / `window` source の設定値と操作導線は維持する。
 

--- a/spec/agent/complete/local_019/CAPTURE_SOURCE_GUI_DEPENDENCY_AND_SIMPLIFICATION.md
+++ b/spec/agent/complete/local_019/CAPTURE_SOURCE_GUI_DEPENDENCY_AND_SIMPLIFICATION.md
@@ -1,0 +1,329 @@
+# キャプチャ入力 GUI 依存可視性と簡素化 仕様書
+
+> **対象モジュール**: `src/nyxpy/gui/`, `src/nyxpy/framework/core/settings/`
+> **目的**: `ponkan-python` 未導入環境では直接接続型キャプチャ導線を GUI に表示せず、導入済み環境でも通常設定画面へ露出する項目を利用者が判断すべき最小限へ絞る。
+> **関連ドキュメント**: `spec/agent/complete/local_017/PONKAN_CAPTURE_SOURCE.md`, `spec/agent/complete/local_018/CAPTURE_SOURCE_GUI_SETTINGS.md`
+> **既存ソース**: `src/nyxpy/gui/dialogs/settings/device_tab.py`, `src/nyxpy/gui/main_window.py`, `src/nyxpy/gui/app_services.py`, `src/nyxpy/framework/core/hardware/ponkan_capture.py`
+> **破壊的変更**: なし。既存 settings key は維持し、GUI の表示・保存対象だけを絞る。
+
+## 1. 概要
+
+### 1.1 目的
+
+local_018 で追加した capture source GUI を、通常利用者向けの操作導線として再整理する。`ponkan-python` が現在の Python 環境に入っていない場合は、メニューバーと設定ダイアログの capture 選択肢を不可視にする。導入済み環境では、provider / profile / queue / timeout / timing などの high-level API 詳細を GUI に出さず、N3DSXL capture source の選択と NyX 側の表示補正だけを扱う。
+
+### 1.2 用語定義
+
+| 用語 | 定義 |
+|------|------|
+| capture availability | 現在の GUI 実行環境で `ponkan-python` の import package `ponkan` が見つかり、capture source を利用者に選択肢として提示できる状態 |
+| optional dependency gate | `ponkan-python` 未導入環境で capture source の GUI 導線を隠す判定 |
+| simple capture UI | 通常設定画面に出す capture source の最小 UI。source 選択と N3DSXL HD aspect box だけを含む |
+| advanced ponkan settings | `ponkan_backend`、`ponkan_raw_slots`、`ponkan_output_queue_size`、`ponkan_drop_policy`、`ponkan_poll_interval`、`ponkan_read_timeout`、`ponkan_collect_timing` など、設定ファイルでは保持するが通常 GUI には出さない項目 |
+| hidden source settings | GUI に表示しないが、既存 settings 値として保持し runtime builder が引き続き読む項目 |
+
+### 1.3 背景・問題
+
+local_018 は `capture` source を GUI から選べる状態にしたが、`ponkan-python` 未導入環境でも「キャプチャ」メニューと設定項目を表示する設計だった。この場合、利用者は GUI 上では選択できるように見えるが、preview 起動時に依存不足で失敗するため、未接続・未認識と誤解しやすい。
+
+また、設定ダイアログには `Capture Provider`、`Device Profile`、`Raw Slots`、`Output Queue Size`、`Drop Policy`、`Poll Interval`、`Read Timeout`、`Collect Timing`、`Ponkan Backend` が直接露出している。これらは `ponkan-python` の high-level API を NyX が内部で使うための調整値であり、通常の GUI 利用者が毎回判断する項目ではない。結果として、キャプチャ入力設定が camera / window と比べて過度に複雑になっている。
+
+### 1.4 期待効果
+
+| 指標 | 現状 | 目標 |
+|------|------|------|
+| 依存未導入環境の capture 導線 | メニューと source combo に表示され、preview 起動時に失敗する | `ponkan` package が見つからない場合はメニュー・source combo に capture を表示しない |
+| 通常設定画面の capture 詳細項目数 | 10 項目 | 2 項目以下。source 選択と N3DSXL HD aspect box だけを表示する |
+| advanced ponkan settings の扱い | GUI から直接編集する | settings schema と設定ファイル上は維持し、GUI からは原則編集しない |
+| 既存設定値の保持 | GUI 操作で hidden combo が上書きされ得る | 非表示項目は GUI apply で上書きしない |
+| dependency blast radius | GUI 表示だけで dependency 有無を説明しない | `importlib.util.find_spec("ponkan")` 相当の軽量判定だけで表示可否を決め、`ponkan` 本体は import しない |
+
+### 1.5 着手条件
+
+- local_017 / local_018 が `master` に merge 済みであること。
+- 通常 `.venv` に `ponkan-python` が未導入でも GUI テストを実行できること。
+- `ponkan` 本体を import せずに dependency availability を判定できること。
+- 変更後に `uv run --no-sync ruff check .`、`uv run --no-sync ty check src/nyxpy --output-format concise --no-progress`、対象 GUI pytest が通ること。
+
+## 2. 対象ファイル
+
+| ファイル | 変更種別 | 変更内容 |
+|----------|----------|----------|
+| `src/nyxpy/gui/app_services.py` | 変更 | GUI 用 capture availability 判定を追加し、capture source が unavailable のときの active source fallback を定義する |
+| `src/nyxpy/gui/dialogs/settings/device_tab.py` | 変更 | `ponkan` unavailable 時は source combo から capture を除外し、available 時も詳細 ponkan 設定 row を表示しない |
+| `src/nyxpy/gui/main_window.py` | 変更 | `ponkan` unavailable 時は接続メニューの `キャプチャ` subtree と `キャプチャ設定` submenu を表示しない。available 時も `Ponkan Backend` submenu は通常表示しない |
+| `src/nyxpy/framework/core/settings/global_settings.py` | 変更なし | 既存 capture / ponkan settings key は維持する |
+| `src/nyxpy/framework/core/hardware/capture_source.py` | 変更なし | hidden advanced settings は設定ファイル値として引き続き runtime に反映する |
+| `tests/gui/test_device_settings_tab.py` | 変更 | dependency availability 別の source options と、非表示 ponkan settings を apply で上書きしないことを検証する |
+| `tests/gui/test_main_window.py` | 変更 | dependency unavailable 時の capture menu 非表示、available 時の `キャプチャ > N3DSXL (ponkan-python)` 階層、backend submenu 非表示を検証する |
+| `tests/gui/test_app_services.py` | 変更 | capture source active かつ dependency unavailable のときに camera へ fallback し、ponkan settings を保持することを検証する |
+
+## 3. 設計方針
+
+### 3.1 アーキテクチャ上の位置づけ
+
+GUI は capture source を「選べるか」を判断するために package availability だけを確認する。`ponkan.open_capture()`、D3XX runtime、実機接続可否は従来どおり framework hardware adapter の責務とする。
+
+依存方向は次を維持する。
+
+| レイヤー | 許可する依存 | 禁止する依存 |
+|----------|--------------|--------------|
+| `nyxpy.gui` | `importlib.util.find_spec("ponkan")` などの lightweight availability check | `ponkan` 本体 import、device open、D3XX runtime 初期化 |
+| `framework/core/hardware` | `ponkan` 遅延 import と capture reader open | GUI widget |
+| `framework/core/settings` | settings schema | GUI visibility policy |
+
+### 3.2 Dependency gate 方針
+
+`ponkan-python` 未導入環境では、capture source は「壊れた選択肢」ではなく「利用できない機能」として扱う。GUI は `ponkan` package が見つからない場合、次を実施する。
+
+| UI | unavailable 時の動作 |
+|----|----------------------|
+| DeviceSettingsTab source combo | `キャプチャ` option を追加しない |
+| MainWindow 接続メニュー | `入力ソース > キャプチャ` subtree を追加しない |
+| MainWindow キャプチャ設定 | submenu 自体を追加しない |
+| Status bar | active source が fallback された場合は camera/window の通常表示に従う |
+
+availability 判定は `find_spec("ponkan") is not None` 相当でよい。これは package の存在確認に限定し、driver runtime や実機接続までは確認しない。`ponkan` が見つかるが D3XX runtime が使えない、または device open に失敗する場合は、従来どおり preview 起動時の `preview_error` として表示する。
+
+### 3.3 Saved capture source の fallback
+
+settings file に `capture_source_type = "capture"` が保存されているが、現在の GUI 実行環境に `ponkan-python` がない場合、GUI 起動時または settings apply 時に active source を `camera` へ戻す。これは dependency unavailable な capture source を選択中にし続けると、不可視の設定が preview failure を起こし続けるためである。
+
+fallback 時の扱いは次のとおりである。
+
+| 設定キー | 扱い |
+|----------|------|
+| `capture_source_type` | `"camera"` に変更する |
+| `capture_provider` | 変更しない |
+| `capture_device_profile` | 変更しない |
+| `ponkan_*` | 変更しない |
+| `n3dsxl_hd_aspect_box_enabled` | 変更しない |
+| camera/window settings | 変更しない。ただし既存 stale check の範囲では破棄され得る |
+
+fallback は user log に残す。ログメッセージは、`ponkan-python` を導入すれば capture source を再び選べることが分かる内容にする。
+
+### 3.4 UI 簡素化方針
+
+通常 GUI は provider / profile の設定値を編集対象として見せない。初期対応では support target が N3DSXL + ponkan だけであるため、接続メニューでは `キャプチャ > N3DSXL (ponkan-python)` の階層を残す。これは「キャプチャ」という入力種別と、具体的な capture adapter / device profile を区別して表示するためであり、provider や profile を任意に変更できる UI ではない。保存値は既存どおり `capture_source_type="capture"`、`capture_provider="ponkan"`、`capture_device_profile="n3dsxl"` を設定する。
+
+DeviceSettingsTab の capture 選択時に表示する項目は次に限定する。
+
+| UI control | settings key | 表示理由 |
+|------------|--------------|----------|
+| Source | `capture_source_type` | camera / window / capture の切替 |
+| HD Aspect Box | `n3dsxl_hd_aspect_box_enabled` | NyX 側の座標・表示補正であり、capture reader の低レベル調整ではない |
+
+次の項目は GUI に表示しない。
+
+| settings key | 非表示理由 |
+|--------------|------------|
+| `capture_provider` | provider は現時点で `ponkan` 固定で、利用者の選択肢ではない |
+| `capture_device_profile` | profile は現時点で `n3dsxl` 固定で、利用者の選択肢ではない |
+| `ponkan_backend` | driver/backend 調整であり、通常利用者の設定画面から外す。既存設定ファイル値は尊重する |
+| `ponkan_raw_slots` | reader queue tuning であり、通常利用者の設定対象ではない |
+| `ponkan_output_queue_size` | reader queue tuning であり、通常利用者の設定対象ではない |
+| `ponkan_drop_policy` | frame queue policy であり、通常利用者の設定対象ではない |
+| `ponkan_poll_interval` | reader loop tuning であり、通常利用者の設定対象ではない |
+| `ponkan_read_timeout` | reader timeout tuning であり、通常利用者の設定対象ではない |
+| `ponkan_collect_timing` | diagnostics 用であり、通常利用者の設定対象ではない |
+
+`ponkan_backend` を GUI から完全に削除しても、既存 settings value は `capture_source_from_settings()` が読み続ける。backend を切り替えたい開発者は設定ファイルを編集する。将来 GUI に advanced mode を作る場合は、この仕様とは別に「詳細設定表示を明示的に有効化する」仕様を追加する。
+
+### 3.5 メニューバー方針
+
+`ponkan` available 時の接続メニューは次のように簡素化する。
+
+```text
+接続
+  キャプチャ入力
+    入力ソース
+      カメラ >
+      ウィンドウ >
+      キャプチャ >
+        N3DSXL (ponkan-python)
+    FPS >
+      source default
+      15
+      30
+      60
+```
+
+`キャプチャ > N3DSXL (ponkan-python)` は leaf action とする。local_018 の `キャプチャ > ponkan > n3dsxl` のように provider と profile を別々の階層として露出する構造は使わない。action trigger は次の settings を更新する。
+
+| 操作 | 更新する settings | 更新しない settings |
+|------|-------------------|----------------------|
+| `キャプチャ > N3DSXL (ponkan-python)` | `capture_source_type="capture"`、`capture_provider="ponkan"`、`capture_device_profile="n3dsxl"` | `ponkan_backend`、queue、timeout、timing、camera/window settings |
+
+`キャプチャ設定 > Ponkan Backend` は通常表示から削除する。`FPS` submenu は capture source active 時は従来どおり disabled にする。
+
+### 3.6 Runtime 反映方針
+
+runtime builder の内部 key は local_018 の方針を維持する。GUI 非表示になった advanced settings も、設定ファイルから変更された場合は builder 再生成対象であり続ける。つまり `FRAME_SOURCE_SETTING_KEYS` と `_frame_source_key()` から `ponkan_*` を削らない。
+
+GUI の `apply()` は表示していない advanced settings を set しない。これにより、設定ファイルで調整した値を GUI が既定値で上書きしない。
+
+### 3.7 後方互換性
+
+既存 settings key は削除しない。local_018 で保存済みの `capture_provider`、`capture_device_profile`、`ponkan_*`、`n3dsxl_hd_aspect_box_enabled` は引き続き schema と runtime で有効である。
+
+GUI から消すのは表示と編集導線だけであり、設定ファイル互換性は維持する。ただし dependency unavailable 時に `capture_source_type` は `camera` へ fallback するため、`ponkan-python` を後から導入した利用者は再度 GUI で `キャプチャ > N3DSXL (ponkan-python)` を選ぶ必要がある。
+
+### 3.8 シングルトン管理
+
+新規グローバル singleton は追加しない。availability 判定は `GuiAppServices` または GUI widget 初期化時に注入可能な関数として扱い、テストでは fake を渡せる形にする。
+
+## 4. 実装仕様
+
+### 4.1 Availability helper
+
+GUI 用の availability 判定は、`ponkan` を import せずに package の存在だけを見る。
+
+```python
+from importlib.util import find_spec
+
+
+def is_ponkan_capture_available() -> bool:
+    return find_spec("ponkan") is not None
+```
+
+実装場所は `src/nyxpy/gui/app_services.py` 内の private helper、または `src/nyxpy/gui/capture_availability.py` の小さな module とする。後者にする場合も framework から GUI へ依存させてはならない。
+
+### 4.2 DeviceSettingsTab
+
+`DeviceSettingsTab` は availability を受け取り、source combo の候補を構築する。
+
+```python
+class DeviceSettingsTab(QWidget):
+    def __init__(
+        self,
+        settings: GlobalSettings,
+        secrets: SecretsSettings,
+        parent=None,
+        *,
+        device_discovery: DeviceDiscoveryService | None = None,
+        ponkan_capture_available: bool | None = None,
+    ): ...
+```
+
+`ponkan_capture_available is None` の場合は default helper を呼ぶ。テストでは bool を直接渡せるようにする。
+
+Source combo の候補は次のとおりである。
+
+| availability | options |
+|--------------|---------|
+| unavailable | `カメラ`, `ウィンドウ` |
+| available | `カメラ`, `ウィンドウ`, `キャプチャ` |
+
+capture available 時も、capture source で表示する row は source row と `n3dsxl_hd_aspect_box_enabled` だけにする。`apply()` は source type が `capture` の場合、次だけを保存する。
+
+```python
+self.settings.set("capture_source_type", "capture")
+self.settings.set("capture_provider", "ponkan")
+self.settings.set("capture_device_profile", "n3dsxl")
+self.settings.set(
+    "n3dsxl_hd_aspect_box_enabled",
+    self.n3dsxl_hd_aspect_box_enabled.isChecked(),
+)
+```
+
+`ponkan_backend`、queue、drop policy、poll interval、read timeout、collect timing は `apply()` で set しない。
+
+### 4.3 MainWindow 接続メニュー
+
+`MainWindow` は capture availability を参照し、unavailable 時は capture subtree と capture settings submenu を追加しない。
+
+```python
+def _populate_capture_source_type_menu(...):
+    self._populate_camera_source_menu(...)
+    self._populate_window_source_menu(...)
+    if self.services.ponkan_capture_available:
+        self._populate_direct_capture_source_action(...)
+```
+
+`キャプチャ` は `QMenu` として `入力ソース` menu 直下に追加し、その配下に `N3DSXL (ponkan-python)` action を 1 つ置く。provider 名と profile 名を別々の submenu に分ける nested structure は作らない。
+
+`Ponkan Backend` submenu は削除する。既存 attributes は削除してよい。テストや型チェックで参照される場合は期待値を更新する。
+
+### 4.4 GuiAppServices
+
+`GuiAppServices` は availability を保持し、settings apply 前に dependency unavailable な active capture source を camera へ fallback する。
+
+```python
+class GuiAppServices:
+    @property
+    def ponkan_capture_available(self) -> bool: ...
+
+    def _discard_unavailable_connection_settings(self) -> None:
+        ...
+        if source_type == "capture" and not self.ponkan_capture_available:
+            self.global_settings.set("capture_source_type", "camera")
+```
+
+この処理は `capture_provider` や `ponkan_*` を消さない。user log には `ponkan-python` extra が未導入であるため capture source を camera に戻したことを残す。
+
+### 4.5 設定パラメータ
+
+| パラメータ | 型 | デフォルト | 説明 |
+|------------|-----|-----------|------|
+| `capture_source_type` | `str` | `"camera"` | GUI からは dependency available 時だけ `"capture"` を選べる |
+| `capture_provider` | `str` | `"ponkan"` | GUI では固定値として保存する。通常表示しない |
+| `capture_device_profile` | `str` | `"n3dsxl"` | GUI では固定値として保存する。通常表示しない |
+| `ponkan_backend` | `str` | `"auto"` | 設定ファイル向け advanced setting。GUI では通常表示しない |
+| `ponkan_raw_slots` | `int` | `2` | 設定ファイル向け advanced setting |
+| `ponkan_output_queue_size` | `int` | `2` | 設定ファイル向け advanced setting |
+| `ponkan_drop_policy` | `str` | `"drop_oldest"` | 設定ファイル向け advanced setting |
+| `ponkan_poll_interval` | `float` | `0.004` | 設定ファイル向け advanced setting |
+| `ponkan_read_timeout` | `float | None` | `1.0` | 設定ファイル向け advanced setting |
+| `ponkan_collect_timing` | `bool` | `false` | 設定ファイル向け diagnostics setting |
+| `n3dsxl_hd_aspect_box_enabled` | `bool` | `true` | GUI に表示する NyX 側の表示補正 |
+
+### 4.6 エラーハンドリング
+
+| 例外・状態 | 発生条件 | GUI の扱い |
+|------------|----------|------------|
+| package unavailable | `find_spec("ponkan") is None` | capture 導線を非表示。active source が capture なら camera へ fallback |
+| `NYX_PONKAN_CAPTURE_DEPENDENCY_UNAVAILABLE` | package はあるが D3XX runtime が使えない | capture 導線は表示する。preview 起動失敗として status bar に表示 |
+| `NYX_PONKAN_CAPTURE_OPEN_FAILED` | device open に失敗 | capture 導線は表示する。preview 起動失敗として status bar に表示 |
+
+### 4.7 シングルトン管理
+
+該当なし。新規 singleton は追加しない。
+
+## 5. テスト方針
+
+| テスト種別 | テスト名 | 検証内容 |
+|------------|----------|----------|
+| GUI | `test_device_settings_tab_hides_capture_option_when_ponkan_unavailable` | availability false では source combo に `capture` item data がない |
+| GUI | `test_device_settings_tab_shows_simple_capture_option_when_ponkan_available` | availability true では source combo に `キャプチャ` が表示される |
+| GUI | `test_device_settings_tab_shows_only_hd_aspect_for_capture` | capture 選択時に provider/profile/backend/queue/timing row が表示されない |
+| GUI | `test_device_settings_tab_does_not_overwrite_hidden_ponkan_settings` | capture apply が `ponkan_backend` などの hidden settings を変更しない |
+| GUI | `test_connection_menu_hides_capture_when_ponkan_unavailable` | availability false では `入力ソース` に capture submenu がない |
+| GUI | `test_connection_menu_shows_n3dsxl_action_under_capture_when_ponkan_available` | availability true では `キャプチャ > N3DSXL (ponkan-python)` action がある |
+| GUI | `test_connection_menu_removes_ponkan_backend_submenu` | `キャプチャ設定 > Ponkan Backend` が表示されない |
+| GUI | `test_connection_menu_applies_fixed_ponkan_profile` | capture action trigger で source/provider/profile が固定値として保存される |
+| GUI | `test_app_services_falls_back_from_capture_when_ponkan_unavailable` | active capture source かつ availability false で `capture_source_type` が `camera` になる |
+| GUI | `test_app_services_preserves_hidden_ponkan_settings_on_fallback` | fallback 時に `ponkan_*` と `n3dsxl_hd_aspect_box_enabled` が保持される |
+| GUI | `test_availability_check_does_not_import_ponkan` | availability 判定で `ponkan` 本体が `sys.modules` に入らない |
+
+実機テストは不要である。本仕様は GUI 表示と settings apply の整理であり、`ponkan-python` が導入済みの場合の実機 capture open は local_017 の hardware test scope とする。
+
+## 6. 実装チェックリスト
+
+- [x] local_018 の GUI 露出項目と dependency 未導入時の挙動を確認
+- [x] dependency unavailable 時は capture 導線を不可視にする方針を確定
+- [x] 通常 GUI から削る advanced ponkan settings を確定
+- [x] availability helper を追加
+- [x] `DeviceSettingsTab` の source options を availability で分岐
+- [x] `DeviceSettingsTab` の capture 表示を source と HD aspect box に限定
+- [x] `DeviceSettingsTab.apply()` が hidden ponkan settings を上書きしないよう更新
+- [x] `MainWindow` で unavailable 時の capture menu を非表示
+- [x] `MainWindow` の capture menu を `キャプチャ > N3DSXL (ponkan-python)` に簡素化
+- [x] `MainWindow` から `Ponkan Backend` submenu を通常表示しないよう削除
+- [x] `GuiAppServices` で unavailable active capture source を camera fallback
+- [x] fallback 時に `ponkan_*` settings を保持
+- [x] GUI tests を追加・更新
+- [x] `uv run --no-sync ruff format --check .`
+- [x] `uv run --no-sync ruff check .`
+- [x] `uv run --no-sync ty check src/nyxpy --output-format concise --no-progress`
+- [x] `uv run --no-sync pytest tests/gui/test_device_settings_tab.py tests/gui/test_main_window.py tests/gui/test_app_services.py`
+- [x] `uv run --no-sync pytest`

--- a/src/nyxpy/gui/app_services.py
+++ b/src/nyxpy/gui/app_services.py
@@ -34,6 +34,7 @@ from nyxpy.framework.core.runtime.builder import (
 )
 from nyxpy.framework.core.settings.global_settings import GlobalSettings
 from nyxpy.framework.core.settings.secrets_settings import SecretsSettings
+from nyxpy.gui.capture_availability import is_ponkan_capture_available
 from nyxpy.gui.macro_catalog import MacroCatalog
 
 
@@ -124,6 +125,7 @@ class GuiAppServices:
         )
         self.logger = self.logging.logger
         self.device_discovery = DeviceDiscoveryService(logger=self.logger)
+        self.ponkan_capture_available = is_ponkan_capture_available()
         self.registry = MacroRegistry(project_root=self.project_root)
         self.macro_catalog = MacroCatalog(self.registry)
         self.runtime_builder: MacroRuntimeBuilder | None = None
@@ -320,6 +322,21 @@ class GuiAppServices:
             )
 
     def _discard_unavailable_connection_settings(self) -> None:
+        discarded_keys: list[str] = []
+        source_type = str(self.global_settings.get("capture_source_type", "camera") or "camera")
+        if source_type == "capture" and not self._is_ponkan_capture_available():
+            self.global_settings.set("capture_source_type", "camera")
+            self.logger.user(
+                "INFO",
+                "ponkan-python が未導入のためキャプチャ入力をカメラへ戻しました。",
+                component="GuiAppServices",
+                event="configuration.connection_discarded",
+                extra={
+                    "keys": "capture_source_type",
+                    "reason": "ponkan_unavailable",
+                },
+            )
+
         discovery = getattr(self, "device_discovery", None)
         detect = getattr(discovery, "detect", None)
         if not callable(detect):
@@ -328,7 +345,6 @@ class GuiAppServices:
         if not isinstance(result, DeviceDiscoveryResult):
             return
 
-        discarded_keys: list[str] = []
         serial_device = str(self.global_settings.get("serial_device", "") or "").strip()
         if (
             serial_device
@@ -340,7 +356,6 @@ class GuiAppServices:
             self.global_settings.set("serial_device", "")
             discarded_keys.append("serial_device")
 
-        source_type = str(self.global_settings.get("capture_source_type", "camera") or "camera")
         if source_type == "window":
             discarded_keys.extend(self._discard_unavailable_window_settings())
         elif source_type == "camera":
@@ -363,6 +378,12 @@ class GuiAppServices:
                 event="configuration.connection_discarded",
                 extra={"keys": ", ".join(discarded_keys)},
             )
+
+    def _is_ponkan_capture_available(self) -> bool:
+        value = getattr(self, "ponkan_capture_available", None)
+        if value is None:
+            return is_ponkan_capture_available()
+        return bool(value)
 
     def _discard_unavailable_window_settings(self) -> list[str]:
         title = str(self.global_settings.get("capture_window_title", "") or "").strip()

--- a/src/nyxpy/gui/capture_availability.py
+++ b/src/nyxpy/gui/capture_availability.py
@@ -1,0 +1,8 @@
+"""GUI capture source availability helpers."""
+
+from importlib.util import find_spec
+
+
+def is_ponkan_capture_available() -> bool:
+    """Return whether ponkan-python is installed without importing it."""
+    return find_spec("ponkan") is not None

--- a/src/nyxpy/gui/dialogs/app_settings_dialog.py
+++ b/src/nyxpy/gui/dialogs/app_settings_dialog.py
@@ -22,6 +22,7 @@ class AppSettingsDialog(QDialog):
         secrets: SecretsSettings,
         *,
         device_discovery: DeviceDiscoveryService | None = None,
+        ponkan_capture_available: bool | None = None,
     ):
         """Settings tab を構築し、適用ボタンの signal を接続します。"""
         super().__init__(parent)
@@ -37,6 +38,7 @@ class AppSettingsDialog(QDialog):
             self.settings,
             self.secrets,
             device_discovery=device_discovery,
+            ponkan_capture_available=ponkan_capture_available,
         )
         layout.addWidget(self.tab_widget)
 

--- a/src/nyxpy/gui/dialogs/settings/device_tab.py
+++ b/src/nyxpy/gui/dialogs/settings/device_tab.py
@@ -3,13 +3,11 @@
 from PySide6.QtWidgets import (
     QCheckBox,
     QComboBox,
-    QDoubleSpinBox,
     QFormLayout,
     QGroupBox,
     QHBoxLayout,
     QLabel,
     QPushButton,
-    QSpinBox,
     QVBoxLayout,
     QWidget,
 )
@@ -18,13 +16,14 @@ from nyxpy.framework.core.hardware.device_discovery import DeviceDiscoveryServic
 from nyxpy.framework.core.hardware.protocol_factory import ProtocolFactory
 from nyxpy.framework.core.settings.global_settings import GlobalSettings
 from nyxpy.framework.core.settings.secrets_settings import SecretsSettings
+from nyxpy.gui.capture_availability import is_ponkan_capture_available
 from nyxpy.gui.layout import WINDOW_SIZE_PRESETS, normalize_window_size_preset_key
 
 _CAPTURE_SOURCE_OPTIONS = (
     ("カメラ", "camera"),
     ("ウィンドウ", "window"),
-    ("キャプチャ", "capture"),
 )
+_CAPTURE_SOURCE_OPTION = ("キャプチャ", "capture")
 
 
 class DeviceSettingsTab(QWidget):
@@ -37,12 +36,18 @@ class DeviceSettingsTab(QWidget):
         parent=None,
         *,
         device_discovery: DeviceDiscoveryService | None = None,
+        ponkan_capture_available: bool | None = None,
     ):
         """Settings store と device discovery service を保持し、選択 UI を作ります。"""
         super().__init__(parent)
         self.settings = settings
         self.secrets = secrets
         self.device_discovery = device_discovery or DeviceDiscoveryService()
+        self.ponkan_capture_available = (
+            is_ponkan_capture_available()
+            if ponkan_capture_available is None
+            else bool(ponkan_capture_available)
+        )
         layout = QVBoxLayout(self)
 
         self.cap_group = QGroupBox("キャプチャ入力")
@@ -54,6 +59,8 @@ class DeviceSettingsTab(QWidget):
         self.capture_source_type = QComboBox()
         for label, value in _CAPTURE_SOURCE_OPTIONS:
             self.capture_source_type.addItem(label, value)
+        if self.ponkan_capture_available:
+            self.capture_source_type.addItem(*_CAPTURE_SOURCE_OPTION)
         self._set_capture_source_type(self.settings.get("capture_source_type", "camera"))
         self.capture_source_type.currentIndexChanged.connect(
             lambda _index: self._update_source_field_state(self._capture_source_type())
@@ -116,78 +123,6 @@ class DeviceSettingsTab(QWidget):
         self.capture_fps_label = QLabel("Capture FPS:")
         cap_form.addRow(self.capture_fps_label, self.capture_fps)
 
-        self.capture_provider = QComboBox()
-        self.capture_provider.addItem("ponkan", "ponkan")
-        _set_combo_current_data(
-            self.capture_provider,
-            self.settings.get("capture_provider", "ponkan"),
-        )
-        self.capture_provider_label = QLabel("Capture Provider:")
-        cap_form.addRow(self.capture_provider_label, self.capture_provider)
-
-        self.capture_device_profile = QComboBox()
-        self.capture_device_profile.addItem("n3dsxl", "n3dsxl")
-        _set_combo_current_data(
-            self.capture_device_profile,
-            self.settings.get("capture_device_profile", "n3dsxl"),
-        )
-        self.capture_device_profile_label = QLabel("Device Profile:")
-        cap_form.addRow(self.capture_device_profile_label, self.capture_device_profile)
-
-        self.ponkan_backend = QComboBox()
-        for backend in ("auto", "d3xx", "d3xx-native"):
-            self.ponkan_backend.addItem(backend, backend)
-        _set_combo_current_data(self.ponkan_backend, self.settings.get("ponkan_backend", "auto"))
-        self.ponkan_backend_label = QLabel("Ponkan Backend:")
-        cap_form.addRow(self.ponkan_backend_label, self.ponkan_backend)
-
-        self.ponkan_raw_slots = QSpinBox()
-        self.ponkan_raw_slots.setRange(1, 16)
-        self.ponkan_raw_slots.setValue(int(self.settings.get("ponkan_raw_slots", 2)))
-        self.ponkan_raw_slots_label = QLabel("Raw Slots:")
-        cap_form.addRow(self.ponkan_raw_slots_label, self.ponkan_raw_slots)
-
-        self.ponkan_output_queue_size = QSpinBox()
-        self.ponkan_output_queue_size.setRange(1, 64)
-        self.ponkan_output_queue_size.setValue(
-            int(self.settings.get("ponkan_output_queue_size", 2))
-        )
-        self.ponkan_output_queue_size_label = QLabel("Output Queue Size:")
-        cap_form.addRow(self.ponkan_output_queue_size_label, self.ponkan_output_queue_size)
-
-        self.ponkan_drop_policy = QComboBox()
-        for policy in ("drop_oldest", "drop_newest", "block"):
-            self.ponkan_drop_policy.addItem(policy, policy)
-        _set_combo_current_data(
-            self.ponkan_drop_policy,
-            self.settings.get("ponkan_drop_policy", "drop_oldest"),
-        )
-        self.ponkan_drop_policy_label = QLabel("Drop Policy:")
-        cap_form.addRow(self.ponkan_drop_policy_label, self.ponkan_drop_policy)
-
-        self.ponkan_poll_interval = QDoubleSpinBox()
-        self.ponkan_poll_interval.setDecimals(6)
-        self.ponkan_poll_interval.setRange(0.000001, 1.0)
-        self.ponkan_poll_interval.setSingleStep(0.001)
-        self.ponkan_poll_interval.setValue(float(self.settings.get("ponkan_poll_interval", 0.004)))
-        self.ponkan_poll_interval_label = QLabel("Poll Interval:")
-        cap_form.addRow(self.ponkan_poll_interval_label, self.ponkan_poll_interval)
-
-        self.ponkan_read_timeout = QDoubleSpinBox()
-        self.ponkan_read_timeout.setDecimals(3)
-        self.ponkan_read_timeout.setRange(0.0, 60.0)
-        self.ponkan_read_timeout.setSingleStep(0.1)
-        self.ponkan_read_timeout.setValue(float(self.settings.get("ponkan_read_timeout", 1.0)))
-        self.ponkan_read_timeout_label = QLabel("Read Timeout:")
-        cap_form.addRow(self.ponkan_read_timeout_label, self.ponkan_read_timeout)
-
-        self.ponkan_collect_timing = QCheckBox("有効")
-        self.ponkan_collect_timing.setChecked(
-            bool(self.settings.get("ponkan_collect_timing", False))
-        )
-        self.ponkan_collect_timing_label = QLabel("Collect Timing:")
-        cap_form.addRow(self.ponkan_collect_timing_label, self.ponkan_collect_timing)
-
         self.n3dsxl_hd_aspect_box_enabled = QCheckBox("有効")
         self.n3dsxl_hd_aspect_box_enabled.setChecked(
             bool(self.settings.get("n3dsxl_hd_aspect_box_enabled", True))
@@ -198,15 +133,6 @@ class DeviceSettingsTab(QWidget):
             self.n3dsxl_hd_aspect_box_enabled,
         )
         self.capture_setting_rows = (
-            (self.capture_provider_label, self.capture_provider),
-            (self.capture_device_profile_label, self.capture_device_profile),
-            (self.ponkan_backend_label, self.ponkan_backend),
-            (self.ponkan_raw_slots_label, self.ponkan_raw_slots),
-            (self.ponkan_output_queue_size_label, self.ponkan_output_queue_size),
-            (self.ponkan_drop_policy_label, self.ponkan_drop_policy),
-            (self.ponkan_poll_interval_label, self.ponkan_poll_interval),
-            (self.ponkan_read_timeout_label, self.ponkan_read_timeout),
-            (self.ponkan_collect_timing_label, self.ponkan_collect_timing),
             (self.n3dsxl_hd_aspect_box_enabled_label, self.n3dsxl_hd_aspect_box_enabled),
         )
 
@@ -348,18 +274,8 @@ class DeviceSettingsTab(QWidget):
             self.settings.set("capture_fps", self.capture_fps.currentData())
             self.settings.set("capture_aspect_box_enabled", self.aspect_box_enabled.isChecked())
         elif source_type == "capture":
-            self.settings.set("capture_provider", self.capture_provider.currentData())
-            self.settings.set("capture_device_profile", self.capture_device_profile.currentData())
-            self.settings.set("ponkan_backend", self.ponkan_backend.currentData())
-            self.settings.set("ponkan_raw_slots", self.ponkan_raw_slots.value())
-            self.settings.set(
-                "ponkan_output_queue_size",
-                self.ponkan_output_queue_size.value(),
-            )
-            self.settings.set("ponkan_drop_policy", self.ponkan_drop_policy.currentData())
-            self.settings.set("ponkan_poll_interval", self.ponkan_poll_interval.value())
-            self.settings.set("ponkan_read_timeout", self.ponkan_read_timeout.value())
-            self.settings.set("ponkan_collect_timing", self.ponkan_collect_timing.isChecked())
+            self.settings.set("capture_provider", "ponkan")
+            self.settings.set("capture_device_profile", "n3dsxl")
             self.settings.set(
                 "n3dsxl_hd_aspect_box_enabled",
                 self.n3dsxl_hd_aspect_box_enabled.isChecked(),
@@ -406,8 +322,3 @@ def _layout_container(layout: QHBoxLayout) -> QWidget:
     layout.setContentsMargins(0, 0, 0, 0)
     container.setLayout(layout)
     return container
-
-
-def _set_combo_current_data(combo: QComboBox, value: object) -> None:
-    index = combo.findData(value)
-    combo.setCurrentIndex(index if index >= 0 else 0)

--- a/src/nyxpy/gui/dialogs/settings/tab_widget.py
+++ b/src/nyxpy/gui/dialogs/settings/tab_widget.py
@@ -20,6 +20,7 @@ class SettingsTabWidget(QTabWidget):
         secrets: SecretsSettings,
         *,
         device_discovery: DeviceDiscoveryService | None = None,
+        ponkan_capture_available: bool | None = None,
     ):
         """Device/notification tab を生成し、store と discovery service を渡します。"""
         super().__init__(parent)
@@ -27,6 +28,7 @@ class SettingsTabWidget(QTabWidget):
             settings,
             secrets,
             device_discovery=device_discovery,
+            ponkan_capture_available=ponkan_capture_available,
         )
         self.notification_tab = NotificationSettingsTab(settings, secrets)
 

--- a/src/nyxpy/gui/main_window.py
+++ b/src/nyxpy/gui/main_window.py
@@ -69,7 +69,6 @@ _CAPTURE_FPS_OPTIONS = (
     ("30", 30.0),
     ("60", 60.0),
 )
-_PONKAN_BACKEND_OPTIONS = ("auto", "d3xx", "d3xx-native")
 _SERIAL_BAUD_OPTIONS = (
     "1200",
     "2400",
@@ -258,6 +257,12 @@ class MainWindow(QMainWindow):
         if self.protocol_menu is not None:
             self._populate_protocol_menu(self.protocol_menu)
 
+    def _ponkan_capture_available(self) -> bool:
+        value = getattr(self.services, "ponkan_capture_available", False)
+        if callable(value):
+            return bool(value())
+        return bool(value)
+
     def _populate_capture_input_menu(
         self,
         menu: QMenu,
@@ -272,12 +277,9 @@ class MainWindow(QMainWindow):
             devices,
             windows,
         )
-        self.capture_settings_menu = QMenu("キャプチャ設定", menu)
-        self.capture_settings_menu.setEnabled(
-            self.global_settings.get("capture_source_type", "camera") == "capture"
-        )
-        menu.addMenu(self.capture_settings_menu)
-        self._populate_capture_settings_menu(self.capture_settings_menu)
+        self.capture_settings_menu = None
+        self.ponkan_backend_menu = None
+        self.ponkan_backend_action_group = None
         menu.addSeparator()
         self.capture_fps_menu = QMenu("FPS", menu)
         self.capture_fps_menu.setEnabled(
@@ -309,21 +311,23 @@ class MainWindow(QMainWindow):
         menu.clear()
         self.camera_source_menu = QMenu("カメラ", menu)
         self.window_source_menu = QMenu("ウィンドウ", menu)
-        self.capture_source_menu = QMenu("キャプチャ", menu)
+        self.capture_source_menu = None
+        self.capture_provider_menu = None
+        self.capture_profile_action_group = None
         menu.addMenu(self.camera_source_menu)
         menu.addMenu(self.window_source_menu)
-        menu.addMenu(self.capture_source_menu)
         self._populate_camera_source_menu(self.camera_source_menu, devices)
         self._populate_window_source_menu(self.window_source_menu, windows)
-        self._populate_direct_capture_source_menu(self.capture_source_menu)
+        if self._ponkan_capture_available():
+            self.capture_source_menu = QMenu("キャプチャ", menu)
+            menu.addMenu(self.capture_source_menu)
+            self._populate_direct_capture_source_menu(self.capture_source_menu)
 
     def _populate_direct_capture_source_menu(self, menu: QMenu) -> None:
         menu.clear()
-        self.capture_provider_menu = QMenu("ponkan", menu)
-        menu.addMenu(self.capture_provider_menu)
         self.capture_profile_action_group = QActionGroup(self)
         self.capture_profile_action_group.setExclusive(True)
-        action = QAction("n3dsxl", self)
+        action = QAction("N3DSXL (ponkan-python)", self)
         action.setCheckable(True)
         action.setData("n3dsxl")
         action.setChecked(
@@ -341,31 +345,7 @@ class MainWindow(QMainWindow):
             )
         )
         self.capture_profile_action_group.addAction(action)
-        self.capture_provider_menu.addAction(action)
-
-    def _populate_capture_settings_menu(self, menu: QMenu) -> None:
-        menu.clear()
-        self.ponkan_backend_menu = QMenu("Ponkan Backend", menu)
-        menu.addMenu(self.ponkan_backend_menu)
-        self._populate_ponkan_backend_menu(self.ponkan_backend_menu)
-
-    def _populate_ponkan_backend_menu(self, menu: QMenu) -> None:
-        menu.clear()
-        self.ponkan_backend_action_group = QActionGroup(self)
-        self.ponkan_backend_action_group.setExclusive(True)
-        current = self.global_settings.get("ponkan_backend", "auto")
-        for backend in _PONKAN_BACKEND_OPTIONS:
-            action = QAction(backend, self)
-            action.setCheckable(True)
-            action.setData(backend)
-            action.setChecked(current == backend)
-            action.triggered.connect(
-                lambda _checked=False, value=backend: self._apply_connection_settings(
-                    {"ponkan_backend": value}
-                )
-            )
-            self.ponkan_backend_action_group.addAction(action)
-            menu.addAction(action)
+        menu.addAction(action)
 
     def _populate_camera_source_menu(
         self,
@@ -803,6 +783,7 @@ class MainWindow(QMainWindow):
             self.global_settings,
             self.secrets_settings,
             device_discovery=self.device_discovery,
+            ponkan_capture_available=self._ponkan_capture_available(),
         )
         dlg.settings_applied.connect(self.apply_app_settings)
         if dlg.exec() != QDialog.DialogCode.Accepted:

--- a/tests/gui/test_app_services.py
+++ b/tests/gui/test_app_services.py
@@ -22,10 +22,11 @@ class FakeSettings:
 
 class FakeLogger:
     def __init__(self) -> None:
+        self.user_events = []
         self.technical_events = []
 
     def user(self, *args, **kwargs):
-        pass
+        self.user_events.append((args, kwargs))
 
     def technical(self, *args, **kwargs):
         self.technical_events.append((args, kwargs))
@@ -94,7 +95,13 @@ class FakeBuilder:
         return self.controller
 
 
-def make_services(settings, *, previous_builder_settings=None, device_discovery=None):
+def make_services(
+    settings,
+    *,
+    previous_builder_settings=None,
+    device_discovery=None,
+    ponkan_capture_available=True,
+):
     services = object.__new__(GuiAppServices)
     services.global_settings = FakeSettings(settings)
     services.secrets_settings = FakeSettings({})
@@ -104,6 +111,7 @@ def make_services(settings, *, previous_builder_settings=None, device_discovery=
         capture=("Camera1",),
         windows=(WindowInfo("Viewer", "hwnd-1", None),),
     )
+    services.ponkan_capture_available = ponkan_capture_available
     services.runtime_builder = FakeBuilder()
     services._last_settings = dict(settings)
     services._last_secrets = {}
@@ -487,3 +495,64 @@ def test_app_services_keeps_camera_window_settings_for_capture_source() -> None:
     assert services.global_settings.get("capture_device") == "Missing Camera"
     assert services.global_settings.get("capture_window_title") == "Closed Viewer"
     assert services.global_settings.get("capture_window_identifier") == "hwnd-old"
+
+
+def test_app_services_falls_back_from_capture_when_ponkan_unavailable() -> None:
+    settings = {
+        "capture_source_type": "capture",
+        "capture_device": "Camera1",
+        "capture_provider": "ponkan",
+        "capture_device_profile": "n3dsxl",
+        "serial_device": "COM1",
+    }
+    services = make_services(
+        settings,
+        device_discovery=FakeDiscovery(serial=("COM1",), capture=("Camera1",)),
+        ponkan_capture_available=False,
+    )
+
+    outcome = services.apply_settings(is_run_active=False)
+
+    assert services.global_settings.get("capture_source_type") == "camera"
+    assert "capture_source_type" in outcome.changed_keys
+    assert outcome.builder_replaced is True
+    assert services.logger.user_events[0][1]["extra"] == {
+        "keys": "capture_source_type",
+        "reason": "ponkan_unavailable",
+    }
+
+
+def test_app_services_preserves_hidden_ponkan_settings_on_fallback() -> None:
+    settings = {
+        "capture_source_type": "capture",
+        "capture_provider": "ponkan",
+        "capture_device_profile": "n3dsxl",
+        "ponkan_backend": "d3xx-native",
+        "ponkan_raw_slots": 3,
+        "ponkan_output_queue_size": 4,
+        "ponkan_drop_policy": "block",
+        "ponkan_poll_interval": 0.01,
+        "ponkan_read_timeout": 0.5,
+        "ponkan_collect_timing": True,
+        "n3dsxl_hd_aspect_box_enabled": False,
+        "serial_device": "COM1",
+    }
+    services = make_services(
+        settings,
+        device_discovery=FakeDiscovery(serial=("COM1",), capture=()),
+        ponkan_capture_available=False,
+    )
+
+    services.apply_settings(is_run_active=False)
+
+    assert services.global_settings.get("capture_source_type") == "camera"
+    assert services.global_settings.get("capture_provider") == "ponkan"
+    assert services.global_settings.get("capture_device_profile") == "n3dsxl"
+    assert services.global_settings.get("ponkan_backend") == "d3xx-native"
+    assert services.global_settings.get("ponkan_raw_slots") == 3
+    assert services.global_settings.get("ponkan_output_queue_size") == 4
+    assert services.global_settings.get("ponkan_drop_policy") == "block"
+    assert services.global_settings.get("ponkan_poll_interval") == 0.01
+    assert services.global_settings.get("ponkan_read_timeout") == 0.5
+    assert services.global_settings.get("ponkan_collect_timing") is True
+    assert services.global_settings.get("n3dsxl_hd_aspect_box_enabled") is False

--- a/tests/gui/test_capture_availability.py
+++ b/tests/gui/test_capture_availability.py
@@ -1,0 +1,16 @@
+import sys
+
+from nyxpy.gui import capture_availability
+
+
+def test_availability_check_does_not_import_ponkan(monkeypatch):
+    sys.modules.pop("ponkan", None)
+
+    def fake_find_spec(name: str):
+        assert name == "ponkan"
+        return object()
+
+    monkeypatch.setattr(capture_availability, "find_spec", fake_find_spec)
+
+    assert capture_availability.is_ponkan_capture_available()
+    assert "ponkan" not in sys.modules

--- a/tests/gui/test_device_settings_tab.py
+++ b/tests/gui/test_device_settings_tab.py
@@ -1,3 +1,4 @@
+import pytest
 from PySide6.QtWidgets import QLabel
 
 from nyxpy.framework.core.hardware.capture_source import CaptureRect
@@ -74,6 +75,14 @@ class EmptyDiscovery:
         return ()
 
 
+@pytest.fixture(autouse=True)
+def _default_ponkan_available(monkeypatch):
+    monkeypatch.setattr(
+        "nyxpy.gui.dialogs.settings.device_tab.is_ponkan_capture_available",
+        lambda: True,
+    )
+
+
 def test_device_tab_protocol_options_include_3ds(qtbot):
     tab = DeviceSettingsTab(FakeSettings(), None, device_discovery=FakeDiscovery())
     qtbot.addWidget(tab)
@@ -91,7 +100,7 @@ def test_device_tab_selects_3ds_default_baudrate(qtbot):
     assert tab.ser_baud.currentText() == "115200"
 
 
-def test_device_settings_tab_shows_capture_source_type(qtbot):
+def test_device_settings_tab_shows_simple_capture_option_when_ponkan_available(qtbot):
     tab = DeviceSettingsTab(FakeSettings(), None, device_discovery=FakeDiscovery())
     qtbot.addWidget(tab)
 
@@ -109,6 +118,26 @@ def test_device_settings_tab_shows_capture_source_type(qtbot):
         "ウィンドウ",
         "キャプチャ",
     ]
+
+
+def test_device_settings_tab_hides_capture_option_when_ponkan_unavailable(qtbot):
+    settings = FakeSettings()
+    settings.data["capture_source_type"] = "capture"
+    tab = DeviceSettingsTab(
+        settings,
+        None,
+        device_discovery=FakeDiscovery(),
+        ponkan_capture_available=False,
+    )
+    qtbot.addWidget(tab)
+
+    assert [
+        tab.capture_source_type.itemData(i) for i in range(tab.capture_source_type.count())
+    ] == [
+        "camera",
+        "window",
+    ]
+    assert tab.capture_source_type.currentData() == "camera"
 
 
 def test_device_settings_tab_applies_window_capture_settings(qtbot):
@@ -169,25 +198,36 @@ def test_device_settings_tab_places_letterbox_on_source_row(qtbot):
     assert settings.data["capture_aspect_box_enabled"] is True
 
 
-def test_device_settings_tab_hides_irrelevant_source_fields(qtbot):
+def test_device_settings_tab_shows_only_hd_aspect_for_capture(qtbot):
     tab = DeviceSettingsTab(FakeSettings(), None, device_discovery=FakeDiscovery())
     qtbot.addWidget(tab)
+    advanced_labels = {
+        "Capture Provider:",
+        "Device Profile:",
+        "Ponkan Backend:",
+        "Raw Slots:",
+        "Output Queue Size:",
+        "Drop Policy:",
+        "Poll Interval:",
+        "Read Timeout:",
+        "Collect Timing:",
+    }
 
     assert not tab.cap_device.isHidden()
     assert tab.window_row.isHidden()
-    assert tab.capture_provider.isHidden()
+    assert advanced_labels.isdisjoint(_label_texts(tab.cap_group))
 
     _set_capture_source(tab, "window")
     assert tab.camera_row.isHidden()
     assert not tab.window_row.isHidden()
     assert not tab.window_match_mode.isHidden()
     assert not tab.capture_backend.isHidden()
-    assert tab.capture_provider.isHidden()
+    assert tab.n3dsxl_hd_aspect_box_enabled.isHidden()
 
     _set_capture_source(tab, "camera")
     assert not tab.cap_device.isHidden()
     assert tab.window_row.isHidden()
-    assert tab.capture_provider.isHidden()
+    assert tab.n3dsxl_hd_aspect_box_enabled.isHidden()
 
     _set_capture_source(tab, "capture")
     assert tab.camera_row.isHidden()
@@ -196,30 +236,41 @@ def test_device_settings_tab_hides_irrelevant_source_fields(qtbot):
     assert tab.capture_backend.isHidden()
     assert tab.capture_fps.isHidden()
     assert tab.aspect_box_enabled.isHidden()
-    assert not tab.capture_provider.isHidden()
-    assert not tab.capture_device_profile.isHidden()
-    assert not tab.ponkan_backend.isHidden()
+    assert not tab.n3dsxl_hd_aspect_box_enabled.isHidden()
+    assert not tab.n3dsxl_hd_aspect_box_enabled_label.isHidden()
+    assert advanced_labels.isdisjoint(_label_texts(tab.cap_group))
 
 
-def test_device_settings_tab_applies_ponkan_capture_settings(qtbot):
+def test_device_settings_tab_applies_fixed_ponkan_capture_settings(qtbot):
     settings = FakeSettings()
     tab = DeviceSettingsTab(settings, None, device_discovery=FakeDiscovery())
     qtbot.addWidget(tab)
 
     _set_capture_source(tab, "capture")
-    _set_combo_data(tab.ponkan_backend, "d3xx-native")
-    tab.ponkan_raw_slots.setValue(3)
-    tab.ponkan_output_queue_size.setValue(4)
-    _set_combo_data(tab.ponkan_drop_policy, "block")
-    tab.ponkan_poll_interval.setValue(0.01)
-    tab.ponkan_read_timeout.setValue(0.5)
-    tab.ponkan_collect_timing.setChecked(True)
     tab.n3dsxl_hd_aspect_box_enabled.setChecked(False)
     tab.apply()
 
     assert settings.data["capture_source_type"] == "capture"
     assert settings.data["capture_provider"] == "ponkan"
     assert settings.data["capture_device_profile"] == "n3dsxl"
+    assert settings.data["n3dsxl_hd_aspect_box_enabled"] is False
+
+
+def test_device_settings_tab_does_not_overwrite_hidden_ponkan_settings(qtbot):
+    settings = FakeSettings()
+    settings.data["ponkan_backend"] = "d3xx-native"
+    settings.data["ponkan_raw_slots"] = 3
+    settings.data["ponkan_output_queue_size"] = 4
+    settings.data["ponkan_drop_policy"] = "block"
+    settings.data["ponkan_poll_interval"] = 0.01
+    settings.data["ponkan_read_timeout"] = 0.5
+    settings.data["ponkan_collect_timing"] = True
+    tab = DeviceSettingsTab(settings, None, device_discovery=FakeDiscovery())
+    qtbot.addWidget(tab)
+
+    _set_capture_source(tab, "capture")
+    tab.apply()
+
     assert settings.data["ponkan_backend"] == "d3xx-native"
     assert settings.data["ponkan_raw_slots"] == 3
     assert settings.data["ponkan_output_queue_size"] == 4
@@ -227,7 +278,6 @@ def test_device_settings_tab_applies_ponkan_capture_settings(qtbot):
     assert settings.data["ponkan_poll_interval"] == 0.01
     assert settings.data["ponkan_read_timeout"] == 0.5
     assert settings.data["ponkan_collect_timing"] is True
-    assert settings.data["n3dsxl_hd_aspect_box_enabled"] is False
 
 
 def test_device_settings_tab_preserves_inactive_source_settings_for_capture(qtbot):
@@ -309,9 +359,3 @@ def _set_capture_source(tab: DeviceSettingsTab, source_type: str) -> None:
     index = tab.capture_source_type.findData(source_type)
     assert index >= 0
     tab.capture_source_type.setCurrentIndex(index)
-
-
-def _set_combo_data(combo, value: str) -> None:
-    index = combo.findData(value)
-    assert index >= 0
-    combo.setCurrentIndex(index)

--- a/tests/gui/test_main_window.py
+++ b/tests/gui/test_main_window.py
@@ -189,6 +189,7 @@ class FakeServices:
         self.secrets_settings = FakeSecrets()
         self.device_discovery = FakeDiscovery()
         self.macro_catalog = FakeCatalog()
+        self.ponkan_capture_available = True
         self.builder = FakeBuilder()
         self.apply_calls = []
         self.next_apply_outcome = SettingsApplyOutcome(
@@ -352,23 +353,44 @@ def test_capture_input_menu_nests_candidates_under_input_source(window: MainWind
     assert source_menus == ["カメラ", "ウィンドウ", "キャプチャ"]
 
 
-def test_connection_menu_nests_capture_profiles_under_capture_source(
+def test_connection_menu_hides_capture_when_ponkan_unavailable(
+    qtbot,
+    services: FakeServices,
+) -> None:
+    services.ponkan_capture_available = False
+    w = MainWindow(services=services)
+    qtbot.addWidget(w)
+
+    assert w.capture_source_type_menu is not None
+    source_menus = [
+        action.menu().title()
+        for action in w.capture_source_type_menu.actions()
+        if action.menu() is not None
+    ]
+
+    assert source_menus == ["カメラ", "ウィンドウ"]
+    assert w.capture_source_menu is None
+    w.preview_pane.timer.stop()
+
+
+def test_connection_menu_shows_n3dsxl_action_under_capture_when_ponkan_available(
     window: MainWindow,
 ) -> None:
     assert window.capture_source_menu is not None
-    capture_provider_menus = [
-        action.menu().title() for action in window.capture_source_menu.actions() if action.menu()
+
+    assert [action.text() for action in window.capture_source_menu.actions()] == [
+        "N3DSXL (ponkan-python)"
     ]
-
-    assert capture_provider_menus == ["ponkan"]
-    assert window.capture_provider_menu is not None
-    assert [action.text() for action in window.capture_provider_menu.actions()] == ["n3dsxl"]
+    assert all(action.menu() is None for action in window.capture_source_menu.actions())
+    assert window.capture_provider_menu is None
 
 
-def test_connection_menu_applies_capture_profile_source_setting(window: MainWindow) -> None:
-    assert window.capture_provider_menu is not None
+def test_connection_menu_applies_fixed_ponkan_profile(window: MainWindow) -> None:
+    assert window.capture_source_menu is not None
     action = next(
-        action for action in window.capture_provider_menu.actions() if action.text() == "n3dsxl"
+        action
+        for action in window.capture_source_menu.actions()
+        if action.text() == "N3DSXL (ponkan-python)"
     )
 
     action.trigger()
@@ -379,39 +401,36 @@ def test_connection_menu_applies_capture_profile_source_setting(window: MainWind
     assert window.services.apply_calls[-1] is False
 
 
-def test_connection_menu_has_ponkan_backend_under_capture_settings(
+def test_connection_menu_removes_ponkan_backend_submenu(
     window: MainWindow,
 ) -> None:
-    assert window.capture_settings_menu is not None
-    assert window.ponkan_backend_menu is not None
+    assert window.capture_input_menu is not None
+    child_menus = [
+        action.menu().title()
+        for action in window.capture_input_menu.actions()
+        if action.menu() is not None
+    ]
 
-    backend_actions = window.ponkan_backend_menu.actions()
-    assert [action.text() for action in backend_actions] == ["auto", "d3xx", "d3xx-native"]
-    assert backend_actions[0].isChecked()
-
-    backend_actions[2].trigger()
-
-    assert window.global_settings.get("ponkan_backend") == "d3xx-native"
-    assert window.global_settings.get("capture_source_type") == "camera"
+    assert child_menus == ["入力ソース", "FPS"]
+    assert window.capture_settings_menu is None
+    assert window.ponkan_backend_menu is None
 
 
 def test_connection_menu_disables_capture_fps_for_capture_source(window: MainWindow) -> None:
     window.global_settings.set("capture_source_type", "capture")
     window._refresh_connection_menu()
 
-    assert window.capture_settings_menu is not None
     assert window.capture_fps_menu is not None
-    assert window.capture_settings_menu.isEnabled()
     assert not window.capture_fps_menu.isEnabled()
 
 
 def test_connection_menu_does_not_list_physical_ponkan_devices(window: MainWindow) -> None:
-    assert window.capture_provider_menu is not None
+    assert window.capture_source_menu is not None
 
-    actions = window.capture_provider_menu.actions()
+    actions = window.capture_source_menu.actions()
 
     assert len(actions) == 1
-    assert actions[0].text() == "n3dsxl"
+    assert actions[0].text() == "N3DSXL (ponkan-python)"
 
 
 def test_connection_menu_does_not_import_ponkan_when_populating_capture_actions(
@@ -580,9 +599,11 @@ def test_connection_menu_preserves_inactive_source_settings(window: MainWindow) 
     window.global_settings.set("capture_window_title", "Viewer")
     window.global_settings.set("capture_window_identifier", "hwnd-1")
     window.global_settings.set("ponkan_backend", "d3xx")
-    assert window.capture_provider_menu is not None
+    assert window.capture_source_menu is not None
     action = next(
-        action for action in window.capture_provider_menu.actions() if action.text() == "n3dsxl"
+        action
+        for action in window.capture_source_menu.actions()
+        if action.text() == "N3DSXL (ponkan-python)"
     )
 
     action.trigger()


### PR DESCRIPTION
## Summary

ponkan-python 未導入環境では capture source の GUI 導線を隠し、導入済み環境でも通常設定画面に出す項目を N3DSXL capture 選択と HD Aspect Box に絞ります。

## Related

- spec/agent/complete/local_019/CAPTURE_SOURCE_GUI_DEPENDENCY_AND_SIMPLIFICATION.md
- 指示元: ユーザ依頼 local_019

## Changes

- `ponkan` package availability を import なしで判定する GUI helper を追加
- Settings dialog と接続メニューで ponkan-python unavailable 時に capture 選択肢を非表示
- 接続メニューを `キャプチャ > N3DSXL (ponkan-python)` に簡素化し、`Ponkan Backend` submenu を通常表示から削除
- capture apply 時に hidden ponkan advanced settings を上書きしないよう変更
- active source が capture かつ ponkan-python unavailable の場合は camera へ fallback し、hidden ponkan settings を保持
- local_019 仕様書を complete 配下に追加し、local_018 から参照

## Commit Log

```text
aaeb23e feat(gui): キャプチャ入力の依存表示を整理
```

## Testing

```text
uv run --no-sync ruff format --check .
uv run --no-sync ruff check .
uv run --no-sync ty check src/nyxpy --output-format concise --no-progress
uv run --no-sync pytest
```

## Checklist

- [x] lint / format チェック通過
- [x] 既存テスト通過
- [x] コミット prefix (feat/fix 等) が変更の動機と一致している
- [x] 新規・変更コードに対するテスト追加（該当する場合）
- [x] 型チェック通過