### PR TITLE
chore(release): nyxpy-fw 0.2.0を準備

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nyxpy-fw"
-version = "0.1.0"
+version = "0.2.0"
 description = "Game automation framework with macro APIs, CLI, and GUI"
 authors = [
     {name = "niart120",email = "38847256+niart120@users.noreply.github.com"}

--- a/spec/agent/complete/local_015/PYPI_PUBLICATION_RUNBOOK.md
+++ b/spec/agent/complete/local_015/PYPI_PUBLICATION_RUNBOOK.md
@@ -188,8 +188,8 @@ TestPyPI は依存ライブラリが揃っていないため、NyX の wheel だ
 ```console
 python -m venv .venv-testpypi
 .venv-testpypi\Scripts\python -m pip install --upgrade pip
-.venv-testpypi\Scripts\python -m pip download --no-deps --index-url https://test.pypi.org/simple/ --dest .tmp-testpypi nyxpy-fw==0.1.0
-.venv-testpypi\Scripts\python -m pip install .tmp-testpypi\nyxpy_fw-0.1.0-py3-none-any.whl
+.venv-testpypi\Scripts\python -m pip download --no-deps --index-url https://test.pypi.org/simple/ --dest .tmp-testpypi nyxpy-fw==0.2.0
+.venv-testpypi\Scripts\python -m pip install .tmp-testpypi\nyxpy_fw-0.2.0-py3-none-any.whl
 .venv-testpypi\Scripts\python -c "import nyxpy; print(nyxpy.__name__)"
 .venv-testpypi\Scripts\nyxpy --help
 ```
@@ -206,15 +206,15 @@ POSIX shell では `.venv-testpypi\Scripts\python` を `.venv-testpypi/bin/pytho
 2. annotated tag を作成する。
 
 ```console
-git tag -a v0.1.0 -m "v0.1.0"
+git tag -a v0.2.0 -m "v0.2.0"
 git push origin master
-git push origin v0.1.0
+git push origin v0.2.0
 ```
 
 3. GitHub の **Actions** を開く。
 4. **Publish Python Package** workflow を選ぶ。
 5. **Run workflow** を押す。
-6. ref に `v0.1.0` tag を選ぶ。
+6. ref に `v0.2.0` tag を選ぶ。
 7. `target` に `pypi` を選ぶ。
 8. workflow を実行する。
 9. GitHub environment `pypi` の approval が求められた場合は、内容を確認して承認する。

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.12, <3.14"
 resolution-markers = [
     "sys_platform == 'darwin'",
@@ -711,7 +711,7 @@ wheels = [
 
 [[package]]
 name = "nyxpy-fw"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "chardet" },


### PR DESCRIPTION
## Summary

`nyxpy-fw` の release candidate を `0.2.0` に更新します。未リリース差分に `feat(capture)` / `feat(gui)` が含まれるため、release type は minor と判断しています。

## Related

- 指示元: `$pypi-release`
- release tag: `v0.2.0`（未作成）
- PyPI 事前確認: `https://pypi.org/pypi/nyxpy-fw/0.2.0/json` は `404`

## Changes

- `pyproject.toml` の project version を `0.2.0` に更新。
- `uv.lock` の editable package metadata を `0.2.0` に同期。
- PyPI 公開手順書の TestPyPI / production publish 例を `0.2.0` に更新。

## Commit Log

```
01beae8 chore(release): nyxpy-fw 0.2.0を準備
```

## Testing

```
uv sync --dev                                      PASS
uv lock --check                                   PASS
uv run ruff format --check .                      PASS
uv run ruff check .                               PASS
uv run ty check src/nyxpy --output-format concise --no-progress  PASS
uv run pytest                                     PASS (667 passed, 10 skipped)
uv run vulture src tests examples macros --min-confidence 80     PASS
uv sync --dev --group docs                        PASS
uv run --no-sync mkdocs build --strict            PASS
uv build                                          PASS
uvx twine check --strict dist\nyxpy_fw-0.2.0-py3-none-any.whl dist\nyxpy_fw-0.2.0.tar.gz  PASS
git diff --check                                  PASS
```

Artifact checks:

- wheel metadata: `Name: nyxpy-fw`, `Version: 0.2.0`, `Requires-Python: <3.14,>=3.12`
- wheel contains `nyxpy/__main__.py`, `nyxpy/py.typed`, `nyxpy/framework/`
- wheel entry points include `nyxpy`, `nyx-cli`, `nyx-gui`
- sdist top-level excludes `.pypirc`, `.nyxpy`, `dist`, `site`, `macros`, `resources`

## Checklist

- [x] lint / format チェック通過
- [x] 既存テスト通過
- [x] コミット prefix (feat/fix 等) が変更の動機と一致している
- [x] 新規・変更コードに対するテスト追加（release metadata 更新のため該当なし）
- [x] 型チェック通過

## Review Notes

- `BREAKING CHANGE` または `!` 付き commit は未リリース差分にありません。
- TestPyPI は未実行です。production tag push と `target=pypi` workflow 実行は、この PR merge 後に明示確認を得てから行います。
- GUI / 実機 smoke は未実行です。