### PR TITLE
ci: setup-uv の cache glob を修正

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -29,7 +29,9 @@ jobs:
         uses: astral-sh/setup-uv@v5
         with:
           enable-cache: true
-          cache-dependency-glob: "pyproject.toml,uv.lock"
+          cache-dependency-glob: |
+            pyproject.toml
+            uv.lock
 
       - name: docs 依存関係のインストール
         run: uv sync --locked --only-group docs --no-install-project

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -43,7 +43,9 @@ jobs:
         uses: astral-sh/setup-uv@v5
         with:
           enable-cache: true
-          cache-dependency-glob: "pyproject.toml,uv.lock"
+          cache-dependency-glob: |
+            pyproject.toml
+            uv.lock
 
       - name: package build
         run: uv build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,9 @@ jobs:
         uses: astral-sh/setup-uv@v5
         with:
           enable-cache: true
-          cache-dependency-glob: "pyproject.toml,uv.lock"
+          cache-dependency-glob: |
+            pyproject.toml
+            uv.lock
 
       - name: 依存関係のインストール
         run: uv sync --locked --all-extras --dev


### PR DESCRIPTION
## Summary

`astral-sh/setup-uv` の `cache-dependency-glob` 指定を複数行 glob に直し、`pyproject.toml` と `uv.lock` が個別に cache key の依存ファイルとして拾われるようにします。

## Related

- 指示元: `cache-dependency-glob` warning の修正依頼

## Changes

- `publish.yml` の `cache-dependency-glob` を `pyproject.toml` / `uv.lock` の複数行指定に変更。
- `test.yml` と `docs.yml` にも同じ誤指定があったため、同じ形で修正。

## Commit Log

```
2037a43 ci: setup-uv の cache glob を修正
```

## Testing

```
rg -n 'cache-dependency-glob: "pyproject.toml,uv.lock"|cache-dependency-glob' .github\workflows
# old quoted comma-separated glob: no matches
# remaining cache-dependency-glob entries: publish/test/docs each use multiline glob

git diff --check
# PASS

uv run python -c "from pathlib import Path; import yaml; [yaml.safe_load(Path(p).read_text(encoding='utf-8')) for p in ['.github/workflows/publish.yml','.github/workflows/test.yml','.github/workflows/docs.yml']]; print('yaml ok')"
# PASS: yaml ok
```

## Checklist

- [x] lint / format チェック通過
- [x] 既存テスト通過（workflow 設定変更のためローカルでは YAML parse / diff check。GitHub Actions の build/test/docs で確認）
- [x] コミット prefix (feat/fix 等) が変更の動機と一致している
- [x] 新規・変更コードに対するテスト追加（workflow 設定変更のため該当なし）
- [x] 型チェック通過（Python 型変更なし）

## Review Notes

- 今回の修正対象は GitHub Actions の cache key 入力だけです。package build や publish 手順の動作は変えていません。
- `setup-uv` の cache warning が消えるかは、PR 上の Actions run の annotation で確認します。