### PR TITLE
docs(swbt): 連携仕様を実装単位へ整理

### DIFF
--- a/spec/agent/wip/local_021/SWBT_CONTROLLER_BACKEND.md
+++ b/spec/agent/wip/local_021/SWBT_CONTROLLER_BACKEND.md
@@ -1,316 +1,159 @@
-# swbt controller backend 実装計画
-
-> **対象モジュール**: `src/nyxpy/framework/core/io/`, `src/nyxpy/framework/core/runtime/`, `src/nyxpy/framework/core/settings/`, `src/nyxpy/cli/`, `src/nyxpy/gui/`
-> **目的**: `swbt-python` を NyX の `ControllerOutputPort` backend として追加し、既存 `Command` API から Bluetooth HID 経由の Switch 入力を扱えるようにする。
-> **関連ドキュメント**: `docs/architecture/swbt-integration/`
-> **破壊的変更**: あり。serial 専用 factory を `SerialControllerOutputPortFactory` へ改名し、互換 alias は残さない。
-
-## 0. 文書配置
-
-この文書は未着手の実装計画であるため、`spec/agent/wip/local_021/` に置く。完了時は実装結果と検証結果を反映したうえで `spec/agent/complete/local_021/` へ移す。
-
-`docs/architecture/swbt-integration/` は設計判断の保管場所とする。この文書は、その設計を Project NyX の現在のコードへ実装するための作業順序、対象ファイル、テスト、完了条件を管理する。
-
-この改修全体を `local_021` だけで完結させない。`local_021` は親計画として扱い、実装はマイルストーンごとの作業仕様へ分ける。マイルストーン番号はこの文書内の進行単位であり、実際の `local_0xx` 番号は着手時点の空き番号を使う。
+# swbt controller backend 実装計画 仕様書
 
 ## 1. 概要
 
 ### 1.1 目的
 
-`swbt-python` を `SerialProtocolInterface` へ入れず、`ControllerOutputPort` の具象実装として追加する。マクロ、`DefaultCommand`、`ExecutionContext`、`MacroRuntime` は backend の種類を知らず、既存の `cmd.press()` / `cmd.hold()` / `cmd.release()` / `cmd.capture()` をそのまま使う。
+`swbt-python` を Project NyX の `ControllerOutputPort` backend として導入する。マクロ API は `Command` と `ControllerOutputPort` に閉じ、Bluetooth HID の接続、pairing、reconnect、入力変換、IMU 変換は `nyxpy.framework.core.hardware.swbt` package に集約する。
 
 ### 1.2 用語定義
 
 | 用語 | 定義 |
 |------|------|
-| controller backend | NyX の controller 出力実装。`serial` または `swbt` |
-| `ControllerOutputPort` | Runtime が controller 入力送信に使う抽象 port |
-| `SerialControllerOutputPortFactory` | 既存 serial controller port を生成する factory。現行 `ControllerOutputPortFactory` を改名する |
-| `SwbtControllerOutputPortFactory` | `SwbtGamepadService` を所有し、runtime 用の `SwbtControllerOutputPort` を生成する factory |
-| `SwbtGamepadService` | `swbt-python` の `SwitchGamepad` lifecycle と非同期処理を NyX の同期実行へ接続する service |
-| `NyxSwbtInputMapper` | NyX の button / hat / stick 値を `swbt-python` の `InputState` へ変換する mapper |
-| manual input | GUI から直接 controller state を送る操作 |
+| swbt backend | `swbt-python` を使って Nintendo Switch へ Bluetooth HID controller 入力を送る backend |
+| controller backend | NyX の controller 出力方式。`serial` または `swbt` |
+| `ControllerOutputPort` | Runtime が controller 入力を送る抽象 port |
+| `SwbtControllerSession` | `swbt-python` の async controller lifecycle を同期 port から使う backend 内部部品 |
+| `SwbtControllerModel` | Pro Controller / Joy-Con L / Joy-Con R の class、capabilities、既定 key store 名を束ねる定義 |
+| `NyxSwbtInputMapper` | NyX の `Button`、`Hat`、`LStick`、`RStick`、`IMUFrame` を swbt の `InputState` へ変換する mapper |
+| GUI manual input | GUI の既存 `VirtualControllerModel -> ControllerOutputPort` 経路から送る入力 |
 
 ### 1.3 背景・問題
 
-現行の `ControllerOutputPortFactory` は名前上は汎用だが、実体は serial device と `SerialProtocolInterface` に依存する serial 専用 factory である。`swbt-python` は serial bytes 生成部品ではなく、Bluetooth HID の接続、pairing、reconnect、周期 report loop、入力状態を所有するため、serial protocol として追加すると責務が崩れる。
+現行 controller 出力は serial backend を前提にしており、`ControllerOutputPortFactory` も serial device と protocol に依存している。`swbt-python` は serial protocol ではなく、専用 USB Bluetooth adapter、pairing key、reconnect、周期 report loop を持つ controller 実装である。serial protocol の分岐として追加すると、adapter discovery、session lifetime、GUI manual input、runtime 実行の責務が混ざる。
 
-CLI も現状では `--serial` / `--capture` を前提に serial protocol を先に生成する構成である。`--controller swbt` では `--serial` を不要にし、serial protocol 生成を通らない構成へ変える必要がある。
+`docs/architecture/swbt-integration/testing-rollout.md` は、設定 model、adapter discovery、session、port、runtime、GUI、実機検証の順に導入する方針を定めている。本仕様はその導入順序を Project NyX の `spec/agent/wip/local_022` から `local_026` へ分割する親計画である。
 
 ### 1.4 期待効果
 
 | 指標 | 現状 | 目標 |
 |------|------|------|
-| マクロ API | serial backend 前提 | serial / swbt で同じ `Command` API を使う |
-| backend 選択箇所 | CLI / builder が serial 前提 | 構成起点で一度だけ `ControllerOutputPort` factory を選ぶ |
-| swbt 依存範囲 | 未導入 | `hardware/swbt_*` と `io/swbt_adapter.py` 周辺へ閉じる |
-| 通常 install | swbt 依存なし | swbt 依存なしで serial backend が動く |
-| 実機なしテスト | serial dummy 中心 | swbt mapper / port / service / runtime injection を実機なしで検証する |
+| swbt 実装配置 | 未導入 | `src/nyxpy/framework/core/hardware/swbt/` に集約する |
+| swbt 依存 | 通常 install に存在しない | optional dependency `swbt-python>=0.2.0,<0.3.0` として導入する |
+| backend 選択 | serial 前提 | runtime builder 構成時に `serial` / `swbt` の factory を選ぶ |
+| IMU | command surface なし | `Command.imu(...)` と `ControllerOutputPort.imu(...)` を追加し、非対応 backend は `NotImplementedError` |
+| GUI manual input | serial port を差し込む | 既存 `VirtualControllerModel` に swbt port を差し込む |
+| 実機確認 | 未整備 | Pro Controller / Joy-Con L / Joy-Con R の pairing、reconnect、入力、neutral を確認する |
 
 ### 1.5 着手条件
 
-- `docs/architecture/swbt-integration/` の設計レビュー反映済み commit が存在すること。
-- `swbt-python>=0.1.1,<0.2.0` の公開 API を前提にすること。
-- 既存の `serial_device` / `serial_baud` / `serial_protocol` は読み込み元として維持し、新 schema へ正規化すること。
-- alias / 互換 import / `DeprecationWarning` を追加しないこと。
+- `docs/architecture/swbt-integration/` の設計文書を正とする。
+- `swbt-python` は PyPI の最新公開版 `0.2.0` を対象にし、NyX 側の依存範囲は `>=0.2.0,<0.3.0` とする。
+- 既存 serial backend は残すが、旧 factory 名や旧 import path の互換 shim は追加しない。
+- `manual.py`、`SwbtManualInputSession`、`swbt_*.py` module は作らない。
+- GUI から `swbt-python` を直接 import しない。
 
 ## 2. 対象ファイル
 
 | ファイル | 変更種別 | 変更内容 |
 |----------|----------|----------|
-| `pyproject.toml` | 変更 | `swbt` optional dependency と必要な pytest marker を追加する |
-| `src/nyxpy/framework/core/io/adapters.py` | 変更 | `ControllerOutputPortFactory` を `SerialControllerOutputPortFactory` へ改名し、呼び出し元を更新する |
-| `src/nyxpy/framework/core/io/swbt_adapter.py` | 新規 | `SwbtControllerOutputPort`、mapper、dummy service を実装する |
-| `src/nyxpy/framework/core/hardware/swbt_service.py` | 新規 | `SwbtGamepadService` と config、例外変換を実装する |
-| `src/nyxpy/framework/core/io/device_factories.py` | 変更 | serial / swbt factory 選択と lifetime 管理を追加する |
-| `src/nyxpy/framework/core/runtime/builder.py` | 変更 | controller config から `PortFactory[ControllerOutputPort]` を構成できるようにする |
-| `src/nyxpy/framework/core/settings/global_settings.py` | 変更 | `controller.*` schema と既存 serial 設定の正規化を追加する |
-| `src/nyxpy/cli/run_cli.py` | 変更 | `--controller` と swbt 用 option を追加し、swbt backend では `--serial` を不要にする |
-| `src/nyxpy/gui/app_services.py` | 変更 | GUI と runtime が同じ swbt service を共有する builder lifetime へ更新する |
-| `src/nyxpy/gui/models/virtual_controller_model.py` | 変更 | manual input と runtime の同時操作を避ける制御を追加する |
-| `tests/unit/` | 変更 | mapper、port、service、settings、CLI option の単体テストを追加する |
-| `tests/integration/` | 変更 | swbt dummy service を使った runtime injection test を追加する |
-| `tests/hardware/` | 変更 | `@pytest.mark.swbt` の実機確認テストを追加する |
+| `spec/agent/wip/local_022/SWBT_CONTROLLER_FOUNDATION.md` | 変更 | dependency、controller model、settings、IMU command、adapter discovery の仕様 |
+| `spec/agent/wip/local_023/SWBT_CORE_ADAPTER_SERVICE.md` | 変更 | session、mapper、port、factory、dummy session の仕様 |
+| `spec/agent/wip/local_024/SWBT_RUNTIME_CLI_INTEGRATION.md` | 変更 | runtime builder、`nyxpy run`、`nyxpy swbt` CLI の仕様 |
+| `spec/agent/wip/local_025/SWBT_GUI_SHARED_SERVICE.md` | 変更 | GUI backend 選択、adapter refresh、pair/reconnect/disconnect、manual input 排他の仕様 |
+| `spec/agent/wip/local_026/SWBT_REALDEVICE_DOCS_CLOSEOUT.md` | 変更 | 実機検証、docs、完了判定の仕様 |
+| `docs/architecture/swbt-integration/testing-rollout.md` | 変更 | 実装後に確定値、検証結果、残課題を反映する |
 
 ## 3. 設計方針
 
 ### アーキテクチャ上の位置づけ
 
-swbt は `ControllerOutputPort` の具象 backend として扱う。`SerialProtocolInterface`、`ProtocolFactory`、serial device discovery には入れない。`Command`、`MacroRuntime`、`ExecutionContext` は swbt を import しない。
+swbt backend は `ControllerOutputPort` の具象 backend である。`SerialProtocolInterface`、serial device discovery、GUI model、macro API へ swbt 固有処理を混ぜない。
+
+```text
+macro Command
+  -> runtime ExecutionContext
+  -> io ControllerOutputPort
+       -> hardware.swbt.SwbtControllerOutputPort
+            -> SwbtControllerSession
+                 -> swbt-python
+```
 
 ### 公開 API 方針
 
-既存マクロ向けの `Command` API は変更しない。設定と CLI には `controller.backend` / `--controller` を追加する。serial 専用 factory 名は `SerialControllerOutputPortFactory` へ改め、旧名 alias は残さない。
+マクロ向けには `Command.imu(...)` だけを追加する。既存 `press` / `hold` / `release` は backend 非依存のまま維持する。CLI には `nyxpy swbt adapters`、`nyxpy swbt pair`、`nyxpy swbt reconnect` と、`nyxpy run --controller swbt` を追加する。
 
 ### 後方互換性
 
-破壊的変更あり。`ControllerOutputPortFactory` の旧名 import は失効させる。Project NyX のフレームワーク本体はアルファ版であり、互換 shim を増やさず呼び出し元とテストを同じ変更で正名へ更新する。
-
-既存 workspace 設定の読み込みは壊さない。`serial_device` / `serial_baud` / `serial_protocol` は serial backend の入力として読み、内部では `SerialControllerConfig` へ正規化する。
+Project NyX のフレームワーク本体はアルファ版であり、旧 factory 名の alias や `DeprecationWarning` は追加しない。既存 workspace の `serial_device`、`serial_baud`、`serial_protocol` は読み込み元として扱い、新 `controller.serial.*` へ正規化する。
 
 ### レイヤー構成
 
-`swbt-python` import は `hardware/swbt_service.py` と `io/swbt_adapter.py` 周辺に閉じ込める。GUI / CLI は config を作り、runtime builder に渡す。framework core から GUI へは依存しない。
+`src/nyxpy/framework/core/hardware/swbt/` に swbt 専用実装を置く。`io/ports.py` には backend 共通 contract だけを置く。`gui` は framework の application service 経由で adapter 列挙と接続操作を呼び、`swbt-python` の型を widget 層へ漏らさない。
 
 ### 性能要件
 
 | 指標 | 目標値 |
 |------|--------|
-| swbt report period | 既定 `8000us` |
-| 短押し duration | 既存 `Command.press(..., dur=...)` の duration を維持する |
-| runtime 開始時の reconnect | 既存接続が共有されている場合は reconnect しない |
-| serial backend | swbt extra 未導入環境で import error を起こさない |
+| adapter refresh | Bluetooth controller open、pairing、report loop を開始しない |
+| report period | 既定 `8000us` |
+| macro runtime pairing | 暗黙 pairing をしない。保存済み key で reconnect だけを行う |
+| swbt 未導入環境 | serial backend の import と通常テストが壊れない |
 
 ### 並行性・スレッド安全性
 
-`SwbtGamepadService` が async event loop thread を所有する。同期 port は service の同期メソッドを呼び、service 内で event loop thread へ処理を渡す。service の lifecycle 変更は lock で保護する。
-
-GUI manual input と macro runtime は同じ service を共有するが、同時操作は対象外とする。GUI は macro 実行中の manual input を無効化し、runtime port 作成時に service を neutral へ揃える。
+`SwbtControllerSession` が event loop thread と connection lock を所有する。GUI lifetime port と macro runtime port は同じ session を使い回せるが、同時入力は許可しない。macro start 前に GUI lifetime port を `release()` / `close()` してから runtime port を作る。
 
 ## 4. 実装仕様
 
-### 公開インターフェース
+### 子仕様分割
 
-```python
-@dataclass(frozen=True)
-class SerialControllerConfig:
-    device: str | None = None
-    protocol: str = "CH552"
-    baudrate: int = 9600
+| 子仕様 | 対応範囲 | 依存 | 完了条件 |
+|--------|----------|------|----------|
+| `local_022` | swbt extra、controller model、settings、IMU command、adapter discovery | `local_021` | `hardware/swbt/config.py` と discovery API の仕様が確定し、IMU の共通 contract が定義されている |
+| `local_023` | `SwbtControllerSession`、mapper、port、factory、dummy session | `local_022` | 実機なしで button、D-pad、stick、IMU、session lifecycle を検証できる |
+| `local_024` | runtime builder、`nyxpy run`、`nyxpy swbt adapters/pair/reconnect` | `local_022`, `local_023` | swbt backend で serial protocol 生成を通らず、CLI から明示 pair/reconnect できる |
+| `local_025` | GUI backend 選択、adapter refresh、pair/reconnect/disconnect、manual input 排他 | `local_024` | 既存 `VirtualControllerModel` に swbt port を差し込み、macro 実行中の manual input を止める |
+| `local_026` | 実機検証、docs、完了記録 | `local_022` から `local_025` | Pro Controller / Joy-Con L / Joy-Con R の実機結果と docs 反映が残る |
 
+### 完了条件 checklist への対応
 
-@dataclass(frozen=True)
-class SwbtControllerConfig:
-    adapter: str = "usb:0"
-    key_store_path: Path | None = Path(".nyxpy/swbt/switch-bond.json")
-    connect_timeout_sec: float = 30.0
-    allow_pairing: bool = False
-    report_period_us: int = 8000
-    device_name: str = "Pro Controller"
-    diagnostics_path: Path | None = None
-    connect_on_open: bool = True
-    invert_stick_y: bool = False
+| `testing-rollout.md` の条件 | 担当仕様 |
+|-----------------------------|----------|
+| `hardware/swbt` package に収める、`swbt_*.py` を増やさない | `local_022`, `local_023` |
+| `SwbtControllerType` / `SwbtControllerModel` / capabilities / config | `local_022` |
+| `Command.imu(...)`、非対応 backend の `NotImplementedError` | `local_022`, `local_023` |
+| `list_adapters()` を GUI / CLI から使う | `local_022`, `local_024`, `local_025` |
+| adapter refresh が pairing / reconnect / report loop を開始しない | `local_022`, `local_025` |
+| macro run で pairing が暗黙実行されない | `local_023`, `local_024` |
+| GUI manual input が `VirtualControllerModel -> ControllerOutputPort` 経路を使う | `local_025` |
+| GUI manual input と macro runtime が同じ adapter を同時に開かない | `local_025` |
+| GUI に diagnostics editor、controller color editor、IMU editor を置かない | `local_025` |
+| Joy-Con type ごとの unsupported input が明確に失敗する | `local_022`, `local_023`, `local_026` |
+| close 時に neutral を試みる | `local_023`, `local_025`, `local_026` |
 
+### 未確定事項の扱い
 
-ControllerConfig = SerialControllerConfig | SwbtControllerConfig
-
-
-class SwbtGamepadService:
-    def start(self, *, allow_pairing: bool, timeout_sec: float) -> None: ...
-    def apply(self, state: InputState) -> None: ...
-    def neutral(self) -> None: ...
-    def status(self) -> GamepadStatus: ...
-    def close(self) -> None: ...
-
-
-class SwbtControllerOutputPort(ControllerOutputPort):
-    def press(self, buttons: Iterable[ButtonLike]) -> None: ...
-    def hold(self, buttons: Iterable[ButtonLike]) -> None: ...
-    def release(self, buttons: Iterable[ButtonLike] | None = None) -> None: ...
-    def close(self) -> None: ...
-
-
-class SwbtControllerOutputPortFactory:
-    def create(
-        self,
-        *,
-        allow_dummy: bool = False,
-        timeout_sec: float | None = None,
-    ) -> ControllerOutputPort: ...
-
-    def close(self) -> None: ...
-```
-
-### 設定パラメータ
-
-| パラメータ | 型 | デフォルト | 説明 |
-|------------|-----|-----------|------|
-| `controller.backend` | `str` | `"serial"` | `serial` または `swbt` |
-| `controller.serial.device` | `str | None` | `None` | serial device 名 |
-| `controller.serial.protocol` | `str` | `"CH552"` | serial protocol 名 |
-| `controller.serial.baudrate` | `int` | `9600` | serial baudrate |
-| `controller.swbt.adapter` | `str` | `"usb:0"` | Bumble が開く Bluetooth adapter |
-| `controller.swbt.key_store_path` | `str | None` | `".nyxpy/swbt/switch-bond.json"` | bond 情報の保存先 |
-| `controller.swbt.connect_timeout_sec` | `float` | `30.0` | 接続 timeout 秒 |
-| `controller.swbt.allow_pairing` | `bool` | `False` | 初回 pairing を許可するか |
-| `controller.swbt.report_period_us` | `int` | `8000` | HID report 周期 |
-| `controller.swbt.device_name` | `str` | `"Pro Controller"` | Switch 側へ見せる device 名 |
-| `controller.swbt.diagnostics_path` | `str | None` | `None` | diagnostics trace の保存先 |
-| `controller.swbt.connect_on_open` | `bool` | `True` | port 作成時に接続するか |
-| `controller.swbt.invert_stick_y` | `bool` | `False` | stick Y 軸を反転するか |
-
-### CLI 仕様
-
-`--controller` を serial protocol 生成より前に解決する。
-
-```console
-nyxpy run sample_macro --controller serial --serial COM3 --capture Camera1
-nyxpy run sample_macro --controller swbt --bt-adapter usb:0 --capture Camera1
-nyxpy run sample_macro --controller swbt --bt-adapter usb:0 --bt-pair --capture Camera1
-```
-
-`--serial` は serial backend のときだけ必須である。swbt backend では不要であり、未指定でも parse error にしない。swbt backend では `ProtocolFactory.resolve_baudrate()` と `create_protocol()` を呼ばない。
-
-### service lifetime
-
-`SwbtControllerOutputPortFactory` が `SwbtGamepadService` を所有する。service key は少なくとも `adapter`、`key_store_path`、`report_period_us`、`device_name`、`diagnostics_path`、`connect_on_open` を含む。`allow_pairing` と `connect_timeout_sec` は接続試行ごとの値として扱い、接続済み service の key には含めない。
-
-`SwbtControllerOutputPort.close()` は neutral を送る。transport の完全 close は factory の `close()` が行う。
-
-### エラーハンドリング
-
-| 例外クラス | 発生条件 |
-|------------|----------|
-| `ConfigurationError` | backend 名不正、swbt extra 未導入、adapter open 失敗、connect timeout |
-| `DeviceError` | close 後の apply、送信失敗、service lifecycle 不整合 |
-| `UnsupportedSwbtInputError` | 3DS button、touch、keyboard、sleep control など swbt backend 非対応入力 |
-| `NotImplementedError` | `keyboard()`、`type_key()`、`touch_down()`、`disable_sleep()` など API として存在するが swbt では実装しない操作 |
-
-### シングルトン管理
-
-新規グローバル singleton は追加しない。CLI と GUI の composition root が factory lifetime を所有し、factory が service lifetime を所有する。
+stick Y 軸既定値、短押しの最小 duration、public flush 要否は実機検証で確定する。仕様作成時点では `report_period_us=8000` と NyX 現行 `LStick.x/y` / `RStick.x/y` を前提にし、実機結果で `local_023` または follow-up 仕様へ戻す。
 
 ## 5. テスト方針
 
 | テスト種別 | テスト名 | 検証内容 |
 |------------|----------|----------|
-| ユニット | `test_nyx_swbt_input_mapper_*` | button / hat / stick / `invert_stick_y` の変換 |
-| ユニット | `test_swbt_controller_output_port_*` | `press` / `hold` / `release` / `close` の状態遷移 |
-| ユニット | `test_swbt_controller_output_port_rejects_unsupported_inputs` | 3DS / touch / keyboard / sleep control が silent failure にならない |
-| ユニット | `test_swbt_gamepad_service_*` | fake `SwitchGamepad` による open / connect / apply / neutral / close と例外変換 |
-| ユニット | `test_controller_settings_normalization_*` | 既存 serial 設定と `controller.*` schema の正規化 |
-| ユニット | `test_run_cli_controller_options_*` | swbt backend では `--serial` 不要、serial backend では必須 |
-| 結合 | `test_runtime_builder_uses_swbt_factory_without_protocol_factory` | swbt backend で serial protocol 生成を通らない |
-| 結合 | `test_runtime_macro_press_a_with_dummy_swbt_service` | `Command.press(Button.A)` が dummy service へ反映される |
-| ハードウェア | `test_swbt_pair_and_reconnect` | `@pytest.mark.realdevice` / `@pytest.mark.swbt` で pairing と reconnect を確認する |
-| ハードウェア | `test_swbt_button_and_stick_reflection` | 実機で button、D-pad、stick、neutral を確認する |
+| 静的 | `test_swbt_files_are_inside_hardware_package` | `swbt_*.py`、`hardware/swbt/manual.py`、`SwbtManualInputSession` がない |
+| ユニット | `test_swbt_controller_models_and_capabilities` | controller type、capabilities、key store 既定値 |
+| ユニット | `test_controller_output_port_imu_default_unsupported` | serial / dummy serial で `imu()` が `NotImplementedError` |
+| ユニット | `test_swbt_mapper_rejects_joycon_unsupported_inputs` | Joy-Con L/R の存在しない stick / button を拒否する |
+| 結合 | `test_runtime_swbt_does_not_create_serial_protocol` | swbt runtime が serial protocol を生成しない |
+| GUI | `test_virtual_controller_uses_controller_output_port_for_swbt` | GUI model が swbt 具象型や `swbt-python` を import しない |
+| ハードウェア | `test_swbt_pro_controller_realdevice` | Pro Controller の pair/reconnect/input/neutral |
+| ハードウェア | `test_swbt_joycon_l_r_realdevice` | Joy-Con L / Joy-Con R の pair/reconnect/input/neutral |
 
-実装中の通常検証は次を使う。
+通常 gate は実機を除外する。
 
 ```console
 uv run ruff format .
 uv run ruff check .
 uv run ty check src/nyxpy --output-format concise --no-progress
-uv run pytest tests/unit/ tests/integration/ -m "not realdevice and not swbt"
-```
-
-実機検証は環境があるときだけ次を使う。
-
-```console
-uv run pytest tests/hardware/ -m swbt --bt-adapter usb:0 --bt-key-store .nyxpy/swbt/test-switch.json
+uv run pytest tests -m "not realdevice and not swbt"
 ```
 
 ## 6. 実装チェックリスト
 
-- [ ] `local_022`: `ControllerOutputPortFactory` を `SerialControllerOutputPortFactory` へ改名し、旧名 alias を残さず呼び出し元とテストを更新する。
-- [ ] `local_022`: `SerialControllerConfig` / `SwbtControllerConfig` / `ControllerConfig` を追加する。
-- [ ] `local_022`: `controller.*` settings schema と既存 serial 設定からの正規化を追加する。
-- [ ] `local_022`: 既存 serial backend の CLI、runtime、unit test を通す。
-- [ ] `local_023`: `pyproject.toml` に `swbt` optional dependency を追加する。
-- [ ] `local_023`: `NyxSwbtInputMapper` を実装し、現行 NyX button 名を `swbt-python` の button 名へ変換する。
-- [ ] `local_023`: `SwbtControllerOutputPort` を実装し、port close は neutral のみにする。
-- [ ] `local_023`: `SwbtGamepadService` を実装し、fake `SwitchGamepad` 注入で単体テスト可能にする。
-- [ ] `local_023`: `SwbtControllerOutputPortFactory` を実装し、service key と factory close を管理する。
-- [ ] `local_023`: mapper / port / service / factory の単体テストを追加して通す。
-- [ ] `local_024`: `MacroRuntimeBuilder` の controller factory 構成を config ベースへ更新する。
-- [ ] `local_024`: CLI に `--controller` と `--bt-*` option を追加する。
-- [ ] `local_024`: swbt backend で serial protocol 生成が呼ばれないことをテストする。
-- [ ] `local_024`: dummy swbt service を使った runtime 結合テストを追加して通す。
-- [ ] `local_025`: GUI に backend 選択、adapter refresh、pair once、reconnect、disconnect を追加する。
-- [ ] `local_025`: GUI で macro 実行中の manual input を無効化する。
-- [ ] `local_025`: GUI と runtime が同じ `SwbtGamepadService` を共有することを確認する。
-- [ ] `local_026`: 実機環境で pairing / reconnect / button / stick / neutral を確認する。
-- [ ] `local_026`: stick Y 軸の既定値を実機結果で確定し、必要なら `invert_stick_y` 既定値を更新する。
-- [ ] `local_026`: swbt public flush の要否を短押し実機テストで判断する。
-- [ ] `local_026`: 利用者 docs と完了記録を更新する。
-- [ ] 各マイルストーン: `uv run ruff format .` を実行する。
-- [ ] 各マイルストーン: `uv run ruff check .` を実行する。
-- [ ] 各マイルストーン: `uv run ty check src/nyxpy --output-format concise --no-progress` を実行する。
-- [ ] 各マイルストーン: 該当範囲の `uv run pytest` を実行する。
-- [ ] 全子仕様の必須セクション、依存関係、対象ファイル、完了条件に矛盾がないことを監査する。
-
-## 7. 子仕様分割
-
-| 子仕様 | 対応範囲 | 依存 | 完了条件 |
-|--------|----------|------|----------|
-| `local_021/SWBT_CONTROLLER_BACKEND.md` | 親計画、設計判断の取り込み、実装分割の確定 | なし | この文書と子仕様がレビュー可能な状態で commit されている |
-| `local_022/SWBT_CONTROLLER_FOUNDATION.md` | serial factory 改名、controller config、settings 正規化 | `local_021` | 既存 serial backend の挙動が変わらず、swbt import が増えていない |
-| `local_023/SWBT_CORE_ADAPTER_SERVICE.md` | swbt optional dependency、mapper、port、service、factory、dummy / fake | `local_022` | 実機なしで button / hat / stick、port state、service lifecycle を検証できる |
-| `local_024/SWBT_RUNTIME_CLI_INTEGRATION.md` | runtime builder、CLI option、dummy runtime integration | `local_022`, `local_023` | `--controller swbt` で serial protocol 生成を通らず、`--serial` が不要になる |
-| `local_025/SWBT_GUI_SHARED_SERVICE.md` | GUI backend 選択、shared service、manual input 制御 | `local_022`, `local_023`, `local_024` | GUI と runtime が接続を共有し、macro 実行中の manual input が無効化される |
-| `local_026/SWBT_REALDEVICE_DOCS_CLOSEOUT.md` | 実機検証、Y 軸既定、短押し flush 要否、利用者 docs、完了記録 | `local_022` から `local_025` | pairing / reconnect / button / D-pad / stick / neutral を実機で確認して記録する |
-
-依存が強いものは同じ子仕様へまとめる。`SwbtControllerOutputPort`、`SwbtGamepadService`、`SwbtControllerOutputPortFactory` は lifecycle と state contract が密接なため `local_023` に集約する。実機検証、利用者 docs、親計画の closeout は結果の証跡を同じ文書で扱うため `local_026` に集約する。
-
-子仕様は別々に commit できる粒度にする。GUI と実機検証は環境依存と確認観点が違うため、runtime / CLI 実装に混ぜない。
-
-`local_021` に実装コードを含めない。`local_021` は子仕様の親計画と矛盾監査の起点に限定する。
-
-## 8. 未確定事項
-
-| 項目 | 現時点の扱い | 確定方法 |
-|------|--------------|----------|
-| stick Y 軸の既定 | `invert_stick_y=false` で開始 | 実機で上方向、下方向を確認する |
-| swbt public flush の要否 | NyX port は周期 report 反映を前提に実装 | 短押し duration の実機確認で不足があれば `swbt-python` 側へ public flush 追加を検討する |
-| GUI diagnostics の既定保存先 | 固定 path または無効 | 初期 GUI 実装時に artifact lifetime と衝突しない値を選ぶ |
-| 実機テストの自動判定 | 初期は人手確認を含む | trace と画面側の確認方法が固まったら自動判定へ拡張する |
-
-## 9. 全体完了条件
-
-- 既存 serial backend の CLI、runtime、テストが壊れていない。
-- swbt extra 未導入環境で serial backend が import error なしに動く。
-- swbt extra 導入環境で `--controller swbt` を選べる。
-- swbt backend では `--serial` が不要で、serial protocol 生成が呼ばれない。
-- 既存マクロが `Command` API を変更せず swbt backend で実行できる。
-- `Command` / `MacroRuntime` / `ExecutionContext` が swbt を import していない。
-- GUI と runtime が同じ `SwbtGamepadService` 接続を共有し、macro 実行中の manual input が無効化される。
-- close、cancel、failure 時に neutral が試みられる。
-- swbt 非対応操作が silent failure にならない。
-- 実機で pairing、reconnect、button、D-pad、stick、neutral の挙動が確認されている。
-
-## 10. local_021 の完了条件
-
-- 親計画として必要な対象ファイル、設計方針、テスト方針、マイルストーン分割が記述されている。
-- `docs/architecture/swbt-integration/` の設計判断と矛盾していない。
-- `local_021` は実装コードを含めず、子仕様の親計画と矛盾監査の起点に限定する判断が明記されている。
-- プレースホルダや未処理を示す仮テキストが残っていない。
+- [ ] `local_022` で swbt extra、controller model、settings、IMU、adapter discovery の仕様を実装可能な粒度にする。
+- [ ] `local_023` で session、mapper、port、factory、dummy session の責務を二重化なしで定義する。
+- [ ] `local_024` で `nyxpy run` と `nyxpy swbt` subcommand の入力、出力、エラーを定義する。
+- [ ] `local_025` で GUI manual input の既存経路、接続操作、macro runtime との排他を定義する。
+- [ ] `local_026` で実機検証、docs 反映、complete 移動条件を定義する。
+- [ ] すべての子仕様が `docs/architecture/swbt-integration/testing-rollout.md` の完了条件へ対応していることを確認する。
+- [ ] 実装後、未解決事項を `spec/dev-journal.md` または新規 wip 仕様へ分離してから `complete` へ移す。

--- a/spec/agent/wip/local_022/SWBT_CONTROLLER_FOUNDATION.md
+++ b/spec/agent/wip/local_022/SWBT_CONTROLLER_FOUNDATION.md
@@ -1,260 +1,270 @@
-# swbt controller backend 基盤仕様書
-
-> **対象モジュール**: `src/nyxpy/framework/core/io/`, `src/nyxpy/framework/core/runtime/`, `src/nyxpy/framework/core/settings/`, `src/nyxpy/cli/`
-> **目的**: swbt controller backend 追加前に、controller 出力 factory 名、controller 設定型、settings 正規化の基盤を整える。
-> **関連ドキュメント**: `spec/agent/wip/local_021/SWBT_CONTROLLER_BACKEND.md`, `docs/architecture/swbt-integration/runtime-composition.md`, `docs/architecture/swbt-integration/configuration-cli-gui.md`, `docs/architecture/swbt-integration/testing-rollout.md`
-> **破壊的変更**: あり。`ControllerOutputPortFactory` を `SerialControllerOutputPortFactory` へ改名し、旧名 alias、互換 import、`DeprecationWarning` は追加しない。
+# swbt controller foundation 仕様書
 
 ## 1. 概要
 
 ### 1.1 目的
 
-M1 では、既存 serial controller 出力の責務を明示するために factory 名を `SerialControllerOutputPortFactory` へ改める。あわせて `SerialControllerConfig`、`SwbtControllerConfig`、`ControllerConfig` を導入し、既存 `serial_device` / `serial_baud` / `serial_protocol` と新しい `controller.*` 設定を同じ設定型へ正規化する。
+swbt backend の実装前に、optional dependency、controller model、settings 正規化、IMU command、adapter discovery を定義する。ここでは Bluetooth 接続や入力送信は実装せず、後続の session / port / runtime / GUI が依存する型と contract を確定する。
 
 ### 1.2 用語定義
 
 | 用語 | 定義 |
 |------|------|
-| `ControllerOutputPort` | Runtime が controller 入力送信に使う抽象 port |
-| `SerialControllerOutputPort` | `SerialCommInterface` と `SerialProtocolInterface` を `ControllerOutputPort` へ接続する既存実装 |
-| `SerialControllerOutputPortFactory` | serial device discovery、serial device cache、protocol を所有し、`SerialControllerOutputPort` を生成する factory |
-| `ControllerConfig` | controller backend ごとの設定型。M1 では serial 実行に使い、swbt 設定型は後続実装へ渡す基盤として定義する |
-| settings 正規化 | 旧 flat key と新 `controller.*` key を読み、runtime builder が扱う設定型へ変換する処理 |
-| `MacroRuntimeBuilder` | Registry と各種 port factory から `ExecutionContext` を組み立てる composition root |
+| `SwbtControllerType` | 永続化・CLI 入力で使う controller 種別。`pro-controller`、`joy-con-l`、`joy-con-r` |
+| `SwbtControllerModel` | swbt controller class、capabilities、表示名、既定 key store 名を持つ immutable definition |
+| `SwbtInputCapabilities` | controller 種別ごとの button、left stick、right stick、IMU 対応可否 |
+| `SwbtControllerConfig` | settings / CLI / GUI から正規化済みの swbt backend 設定 |
+| `ControllerConfig` | `SerialControllerConfig | SwbtControllerConfig` |
+| `IMUFrame` | NyX 側の IMU 入力 model。swbt の `IMUFrame` とは mapper で変換する |
+| `SwbtAdapterDiscoveryService` | `swbt.list_adapters()` を NyX の DTO とエラーへ変換する service |
 
 ### 1.3 背景・問題
 
-現行 `ControllerOutputPortFactory` は汎用名だが、実装は serial device と `SerialProtocolInterface` に依存している。swbt backend を同名 factory の分岐として足すと、serial protocol 生成、Bluetooth HID 接続、GUI manual input の lifetime が一つの責務に混ざる。
+swbt backend は controller type ごとに対応 input が違う。Pro Controller と Joy-Con L/R を文字列のまま扱うと、GUI choices、CLI choices、settings validation、mapper の unsupported 判定が重複する。
 
-settings も現状は `serial_device`、`serial_baud`、`serial_protocol` が正であり、controller backend を表す型がない。後続の M2 以降で swbt を追加する前に、serial 専用 factory と controller 設定の境界を固定する。
+IMU は swbt backend で扱えるが、既存 serial backend では扱えない。silent no-op にすると IMU 前提のマクロが失敗に気づけないため、`Command` と `ControllerOutputPort` の共通 surface として追加し、非対応 backend は `NotImplementedError` にする。
 
 ### 1.4 期待効果
 
 | 指標 | 現状 | 目標 |
 |------|------|------|
-| factory 名 | `ControllerOutputPortFactory` が serial 専用責務を隠している | `SerialControllerOutputPortFactory` が serial 専用責務を明示する |
-| 旧名 API | 旧名 import が有効 | 旧名 import は失効し、呼び出し元とテストは正名へ更新済み |
-| 設定入力 | `serial_device` / `serial_baud` / `serial_protocol` を個別参照 | `SerialControllerConfig` へ正規化して参照する |
-| swbt 依存 | 未導入 | M1 では `swbt-python` import と optional dependency を追加しない |
-| serial 挙動 | CLI で `--serial` と `--capture` が必須 | M1 完了後も同じ挙動を維持する |
+| dependency | swbt 未導入 | `swbt-python>=0.2.0,<0.3.0` を `swbt` extra に追加 |
+| controller type | 未定義 | `SwbtControllerModel` へ正規化し、config に raw 文字列を残さない |
+| GUI / CLI choices | 個別定義になり得る | `supported_controller_models()` から導出する |
+| adapter refresh | 未定義 | `list_adapters()` の no-open discovery を使う |
+| IMU | command surface なし | `IMUFrame`、`Command.imu(...)`、`ControllerOutputPort.imu(...)` を追加 |
 
 ### 1.5 着手条件
 
-- `spec/agent/wip/local_021/SWBT_CONTROLLER_BACKEND.md` が親計画として存在する。
-- `docs/architecture/swbt-integration/` の設計レビュー反映済みである。
-- 現行 serial backend の単体テストと CLI parser テストを更新できる状態である。
-- M1 では `swbt-python` import、`pyproject.toml` の `swbt` optional dependency、`SwbtControllerOutputPort`、`SwbtGamepadService` を追加しない。
+- 親計画 `local_021` が存在する。
+- `docs/architecture/swbt-integration/configuration-cli-gui.md`、`controller-models.md`、`adapter-discovery.md`、`imu-command.md` を参照済みである。
+- この仕様では `SwbtControllerSession`、`SwbtControllerOutputPort`、`SwbtControllerOutputPortFactory` を実装しない。
+- `swbt` import は `hardware/swbt` package 内に閉じ、serial backend の通常 import を壊さない。
 
 ## 2. 対象ファイル
 
 | ファイル | 変更種別 | 変更内容 |
 |----------|----------|----------|
-| `src/nyxpy/framework/core/io/controller_config.py` | 新規 | `SerialControllerConfig`、`SwbtControllerConfig`、`ControllerConfig`、settings 正規化 helper を定義する |
-| `src/nyxpy/framework/core/io/device_factories.py` | 変更 | `ControllerOutputPortFactory` を `SerialControllerOutputPortFactory` へ改名し、エラーメッセージも正名へ更新する |
-| `src/nyxpy/framework/core/io/__init__.py` | 変更 | 旧名 export を削除し、`SerialControllerOutputPortFactory` と controller config 型を export する |
-| `src/nyxpy/framework/core/runtime/builder.py` | 変更 | serial controller config を使って serial port factory を構成する。swbt config は明示エラーにする |
-| `src/nyxpy/framework/core/settings/global_settings.py` | 変更 | `controller.backend`、`controller.serial.*`、`controller.swbt.*` の schema field を追加し、既存 flat key は残す |
-| `src/nyxpy/cli/run_cli.py` | 変更 | factory import と型注釈を正名へ更新し、M1 では現行 serial CLI 動作を維持する |
-| `tests/unit/framework/io/test_device_factories.py` | 変更 | factory 改名、旧名未公開、serial factory 挙動維持を検証する |
-| `tests/unit/framework/runtime/test_runtime_builder.py` | 変更 | settings 正規化後も serial controller factory が使われることを検証する |
-| `tests/unit/framework/settings/test_settings_schema.py` | 変更 | `controller.*` schema、旧 serial key からの正規化、invalid backend を検証する |
-| `tests/unit/cli/test_run_cli_parser.py` | 変更 | M1 時点で `--serial` / `--capture` 必須が変わらないことを検証する |
-| `tests/integration/test_cli_runtime_adapter.py` | 変更 | CLI から builder へ渡る serial 構成が現行挙動を保つことを検証する |
+| `pyproject.toml` | 変更 | `[project.optional-dependencies].swbt` に `swbt-python>=0.2.0,<0.3.0` を追加し、`swbt` pytest marker を追加する |
+| `src/nyxpy/framework/core/constants/imu.py` | 新規 | `IMUFrame` と `Vector3` を定義する |
+| `src/nyxpy/framework/core/constants/__init__.py` | 変更 | `IMUFrame` を公開する |
+| `src/nyxpy/framework/core/io/ports.py` | 変更 | `supports_imu` と既定 unsupported の `imu(...)` を追加する |
+| `src/nyxpy/framework/core/macro/command.py` | 変更 | `Command.imu(...)` と `DefaultCommand.imu(...)` を追加する |
+| `src/nyxpy/framework/core/io/controller_config.py` | 新規 | `ControllerBackend`、`SerialControllerConfig`、`ControllerConfig`、settings 正規化 helper を定義する |
+| `src/nyxpy/framework/core/hardware/swbt/__init__.py` | 新規 | swbt backend の public re-export を定義する |
+| `src/nyxpy/framework/core/hardware/swbt/config.py` | 新規 | `SwbtControllerType`、`SwbtInputCapabilities`、`SwbtControllerModel`、`SwbtControllerConfig`、`supported_controller_models()` を定義する |
+| `src/nyxpy/framework/core/hardware/swbt/discovery.py` | 新規 | `SwbtAdapterDiscoveryService`、`SwbtAdapterView`、`resolve_adapter(...)` を定義する |
+| `src/nyxpy/framework/core/hardware/swbt/errors.py` | 新規 | swbt 例外から NyX 例外への変換 code を定義する |
+| `src/nyxpy/framework/core/settings/global_settings.py` | 変更 | `controller.*` schema を追加し、既存 serial flat key を読み込み元として残す |
+| `tests/unit/framework/hardware/swbt/test_config.py` | 新規 | controller model、capabilities、config validation を検証する |
+| `tests/unit/framework/hardware/swbt/test_discovery.py` | 新規 | adapter discovery と adapter 名解決を fake `list_adapters()` で検証する |
+| `tests/unit/framework/io/test_controller_config.py` | 新規 | settings 正規化と旧 serial key fallback を検証する |
+| `tests/unit/framework/io/test_ports.py` | 変更 | `ControllerOutputPort.imu()` 既定 unsupported を検証する |
+| `tests/unit/framework/macro/test_command.py` | 変更 | `DefaultCommand.imu(...)` が controller port へ委譲することを検証する |
 
 ## 3. 設計方針
 
 ### アーキテクチャ上の位置づけ
 
-M1 は controller 出力 backend 追加の前段である。`SerialControllerOutputPortFactory` は `core/io/device_factories.py` に残し、serial device discovery と serial device cache の所有者であり続ける。`MacroRuntimeBuilder` は引き続き `PortFactory[ControllerOutputPort]` を受け取り、実行中の `Command`、`ExecutionContext`、`MacroRuntime` は backend 種別を知らない。
+M1 は `hardware/swbt` package の土台である。`config.py` と `discovery.py` は `swbt-python` の public API を使ってよいが、GUI、runtime builder、macro command から `swbt-python` を直接 import させない。
 
 ### 公開 API 方針
 
-`ControllerOutputPortFactory` という公開名は廃止し、`SerialControllerOutputPortFactory` だけを公開する。旧名 alias、旧 import path、警告付き互換層は追加しない。`ControllerConfig` は `src/nyxpy/framework/core/io/controller_config.py` に置き、runtime builder、CLI、GUI の composition root から参照できる型にする。
+`Command.imu(...)` はマクロ作者向け API として追加する。serial backend は `ControllerOutputPort` の既定実装により `NotImplementedError` になる。`SwbtControllerConfig` は `controller_type: str` を持たず、settings parser で `SwbtControllerModel` へ解決する。
 
 ### 後方互換性
 
-factory 名の変更は破壊的変更として扱う。Project NyX のフレームワーク本体はアルファ版であるため、旧名を延命せず、呼び出し元とテストを同じ変更で更新する。
-
-既存 workspace 設定の読み込みは壊さない。`serial_device`、`serial_baud`、`serial_protocol` は `controller.serial.*` が未指定のときの fallback として読み、内部では `SerialControllerConfig` へ正規化する。
+`ControllerOutputPortFactory` の改名や runtime 接続は後続仕様で扱う。M1 では既存 serial CLI の動作を変えない。既存 settings の `serial_device`、`serial_baud`、`serial_protocol` は `controller.serial.*` が未指定の場合の fallback とする。
 
 ### レイヤー構成
 
-`controller_config.py` は dataclass と settings mapping からの正規化だけを持つ。`swbt-python` の import、Bluetooth adapter 操作、service lifetime は M2 以降の担当に残す。`global_settings.py` は schema field を定義するだけで、runtime builder の生成責務を持たない。
+`hardware/swbt/config.py` は controller model と validation を持つ。`discovery.py` は adapter 列挙だけを行い、pairing、reconnect、controller open、report loop を開始しない。`errors.py` は `ConfigurationError` / `DeviceError` への変換を提供する。
 
 ### 性能要件
 
 | 指標 | 目標値 |
 |------|--------|
-| serial device discovery 回数 | 現行 `create_device_runtime_builder()` と同じく builder 作成時 1 回 |
-| serial device cache | 現行 factory と同じく device identifier ごとに再利用 |
-| settings 正規化 | builder 作成時に 1 回実行し、macro 実行中に再計算しない |
-| swbt 追加 import | M1 差分では `swbt` package import 数 0 |
+| adapter discovery | controller open なし |
+| `supported_controller_models()` | 定義済み tuple を返し、I/O しない |
+| settings 正規化 | builder / CLI / GUI の構成時に 1 回実行する |
+| swbt extra 未導入時 | serial backend と `Command` import が成功する |
 
 ### 並行性・スレッド安全性
 
-M1 では新しい thread や async event loop を追加しない。serial device cache は現行 `SerialControllerOutputPortFactory` の辞書管理を維持し、既存の runtime builder lifetime で閉じる。`SettingsStore` の `RLock` と `MacroRuntimeBuilder.shutdown()` の責務は変更しない。
+M1 では thread や async event loop を追加しない。adapter discovery は同期 API として定義し、GUI では呼び出し側が worker thread に逃がす。
 
 ## 4. 実装仕様
 
-### 公開インターフェース
+### dependency
 
-```python
-from collections.abc import Mapping
-from dataclasses import dataclass
-from pathlib import Path
-
-from nyxpy.framework.core.settings.schema import SettingValue
-
-
-@dataclass(frozen=True, slots=True)
-class SerialControllerConfig:
-    device: str | None = None
-    protocol: str = "CH552"
-    baudrate: int = 9600
-
-
-@dataclass(frozen=True, slots=True)
-class SwbtControllerConfig:
-    adapter: str = "usb:0"
-    key_store_path: Path | None = Path(".nyxpy/swbt/switch-bond.json")
-    connect_timeout_sec: float = 30.0
-    allow_pairing: bool = False
-    report_period_us: int = 8000
-    device_name: str = "Pro Controller"
-    diagnostics_path: Path | None = None
-    connect_on_open: bool = True
-    invert_stick_y: bool = False
-
-
-type ControllerConfig = SerialControllerConfig | SwbtControllerConfig
-
-
-def controller_config_from_settings(
-    settings: Mapping[str, SettingValue],
-    *,
-    serial_device_override: str | None = None,
-    serial_protocol_override: str | None = None,
-    serial_baudrate_override: int | None = None,
-) -> ControllerConfig:
-    """settings snapshot と CLI override から controller config を作る。"""
-    ...
-
-
-class SerialControllerOutputPortFactory:
-    def create(
-        self,
-        *,
-        name: str | None,
-        baudrate: int | None,
-        allow_dummy: bool,
-        timeout_sec: float,
-    ) -> ControllerOutputPort:
-        ...
-
-    def close(self) -> None:
-        ...
+```toml
+[project.optional-dependencies]
+swbt = [
+    "swbt-python>=0.2.0,<0.3.0",
+]
 ```
 
-`controller_config_from_settings()` は `controller.backend` が未指定なら `"serial"` とみなす。serial の各値は新 schema を優先し、未指定なら既存 flat key を読む。protocol fallback は `settings.get("serial_protocol", "CH552")` であり、`settings.get("protocol")` は使わない。
+### controller model
 
-M1 の `create_device_runtime_builder()` は `SwbtControllerConfig` を受け取った場合、`ConfigurationError` を送出する。swbt backend を選択可能にする実装は M4 に残す。
+```python
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
 
-### 設定パラメータ
+
+class SwbtControllerType(str, Enum):
+    PRO_CONTROLLER = "pro-controller"
+    JOY_CON_L = "joy-con-l"
+    JOY_CON_R = "joy-con-r"
+
+
+@dataclass(frozen=True, slots=True)
+class SwbtInputCapabilities:
+    buttons: frozenset[object]
+    left_stick: bool
+    right_stick: bool
+    imu: bool
+
+
+@dataclass(frozen=True, slots=True)
+class SwbtControllerModel:
+    controller_type: SwbtControllerType
+    display_name: str
+    controller_cls: type[object]
+    default_key_store_name: str
+    capabilities: SwbtInputCapabilities
+
+    def default_key_store_path(self, base_dir: Path) -> Path: ...
+```
+
+`controller_cls` と capabilities の button set は `swbt` import が必要である。`hardware/swbt/config.py` は swbt backend 選択時だけ使う前提なので `swbt` を import してよい。`swbt` 未導入で `supported_controller_models()` を呼んだ場合は `ConfigurationError(code="NYX_SWBT_DEPENDENCY_MISSING")` へ変換する。
+
+### controller config
+
+```python
+@dataclass(frozen=True, slots=True)
+class SwbtControllerConfig:
+    model: SwbtControllerModel
+    adapter: str = "usb:0"
+    key_store_path: Path | None = Path(".nyxpy/swbt/pro-controller-bond.json")
+    connect_timeout_sec: float = 30.0
+    operation_timeout_sec: float = 5.0
+    report_period_us: int | None = 8000
+    diagnostics_path: Path | None = None
+    reset_on_port_create: bool = True
+```
+
+設定値は次である。
 
 | パラメータ | 型 | デフォルト | 説明 |
 |------------|-----|-----------|------|
-| `controller.backend` | `str` | `"serial"` | controller backend 名。M1 では `serial` のみ実行可能 |
-| `controller.serial.device` | `str | None` | `None` | serial device identifier。未指定なら `serial_device` を読む |
-| `controller.serial.protocol` | `str` | `"CH552"` | serial protocol 名。未指定なら `serial_protocol` を読む |
-| `controller.serial.baudrate` | `int` | `9600` | serial baudrate。未指定なら `serial_baud` を読む |
-| `controller.swbt.adapter` | `str` | `"usb:0"` | M2 以降で使う Bluetooth adapter 名 |
-| `controller.swbt.key_store_path` | `str | None` | `".nyxpy/swbt/switch-bond.json"` | M3 以降で使う bond 情報保存先 |
-| `controller.swbt.connect_timeout_sec` | `float` | `30.0` | M3 以降で使う接続 timeout 秒 |
-| `controller.swbt.allow_pairing` | `bool` | `False` | M4 以降で使う pairing 許可 |
-| `controller.swbt.report_period_us` | `int` | `8000` | M3 以降で使う HID report 周期 |
-| `controller.swbt.device_name` | `str` | `"Pro Controller"` | M3 以降で Switch 側に見せる device 名 |
-| `controller.swbt.diagnostics_path` | `str | None` | `None` | M3 以降で diagnostics trace の保存先に使う |
-| `controller.swbt.connect_on_open` | `bool` | `True` | M3 以降で port 作成時接続の制御に使う |
-| `controller.swbt.invert_stick_y` | `bool` | `False` | M2 以降で stick Y 軸変換に使う |
+| `controller.backend` | `str` | `"serial"` | `serial` または `swbt` |
+| `controller.serial.device` | `str | None` | `None` | serial device |
+| `controller.serial.protocol` | `str` | `"CH552"` | serial protocol |
+| `controller.serial.baudrate` | `int` | `9600` | serial baudrate |
+| `controller.swbt.controller_type` | `str` | `"pro-controller"` | swbt controller type |
+| `controller.swbt.adapter` | `str` | `"usb:0"` | adapter 名。未指定時は discovery 結果で解決可能 |
+| `controller.swbt.key_store_path` | `str | None` | controller type 別既定 | pairing key JSON |
+| `controller.swbt.connect_timeout_sec` | `float` | `30.0` | pair/reconnect timeout |
+| `controller.swbt.operation_timeout_sec` | `float` | `5.0` | apply/status/close の同期 timeout |
+| `controller.swbt.report_period_us` | `int | None` | `8000` | swbt report loop 周期 |
+| `controller.swbt.reset_on_port_create` | `bool` | `True` | port 作成時に neutral を送るか |
 
-既存 `serial_device`、`serial_baud`、`serial_protocol` は schema に残す。保存時に旧 key を削除する migration は M1 では行わない。
+### IMU API
+
+```python
+Vector3 = tuple[int, int, int]
+
+
+@dataclass(frozen=True, slots=True)
+class IMUFrame:
+    accelerometer: Vector3 = (0, 0, 0)
+    gyroscope: Vector3 = (0, 0, 0)
+
+    @classmethod
+    def neutral(cls) -> "IMUFrame": ...
+    @classmethod
+    def raw(cls, *, accel: Vector3 | None = None, gyro: Vector3 | None = None) -> "IMUFrame": ...
+    @classmethod
+    def accel(cls, *, x: int = 0, y: int = 0, z: int = 0) -> "IMUFrame": ...
+    @classmethod
+    def gyro(cls, *, x: int = 0, y: int = 0, z: int = 0) -> "IMUFrame": ...
+```
+
+`Command.imu(frame)` は 1 frame を 3 frame 分に複製する。`Command.imu(frame1, frame2, frame3)` は 3 frame を順に使う。0、2、4 個以上は swbt mapper で `NYX_IMU_FRAME_COUNT_INVALID` にする。
+
+### adapter discovery
+
+```python
+@dataclass(frozen=True, slots=True)
+class SwbtAdapterView:
+    name: str
+    aliases: tuple[str, ...]
+    display_name: str
+    vendor_id: int | None
+    product_id: int | None
+    manufacturer: str | None
+    product: str | None
+    serial_number: str | None
+    is_bluetooth_hci: bool
+
+
+class SwbtAdapterDiscoveryService:
+    def list_adapters(self) -> tuple[SwbtAdapterView, ...]: ...
+```
+
+`list_adapters()` は adapter 候補を返すだけで、controller open、pairing、reconnect、report loop を開始しない。adapter 未指定時、候補が 1 件ならその `name` を採用できる。0 件または複数件では明示選択を要求する。
 
 ### エラーハンドリング
 
-| 例外クラス | 発生条件 |
-|------------|----------|
-| `ConfigurationError` | `controller.backend` が `serial` / `swbt` 以外である |
-| `ConfigurationError` | M1 の runtime builder に `SwbtControllerConfig` が渡された |
-| `ConfigurationError` | `controller.swbt.report_period_us <= 0` または `controller.swbt.connect_timeout_sec <= 0` |
-| `ConfigurationError` | serial device selection、serial open に失敗し、dummy fallback も許可されていない |
-| `ExceptionGroup` | `SerialControllerOutputPortFactory.close()` で cached serial device の close が失敗した |
+| 条件 | NyX 例外 |
+|------|----------|
+| swbt import 不可 | `ConfigurationError(code="NYX_SWBT_DEPENDENCY_MISSING")` |
+| 不正 controller type | `ConfigurationError(code="NYX_SWBT_CONTROLLER_TYPE_UNSUPPORTED")` |
+| adapter discovery 失敗 | `ConfigurationError(code="NYX_SWBT_ADAPTER_DISCOVERY_FAILED")` |
+| adapter 未選択 | `ConfigurationError(code="NYX_SWBT_ADAPTER_NOT_SELECTED")` |
+| adapter 候補不一致 | `ConfigurationError(code="NYX_SWBT_ADAPTER_NOT_FOUND")` |
+| adapter 候補曖昧 | `ConfigurationError(code="NYX_SWBT_ADAPTER_AMBIGUOUS")` |
+| IMU frame 数不正 | `DeviceError(code="NYX_IMU_FRAME_COUNT_INVALID")` |
 
 ### シングルトン管理
 
-新規グローバル singleton は追加しない。`SerialControllerOutputPortFactory` は `create_device_runtime_builder()` の lifetime に属し、`MacroRuntimeBuilder.shutdown()` から `close()` される。settings 正規化 helper は状態を持たない純粋関数として実装する。
+新規グローバル singleton は追加しない。controller model registry は immutable な module 定義として扱い、session や adapter resource を保持しない。
 
 ## 5. テスト方針
 
 | テスト種別 | テスト名 | 検証内容 |
 |------------|----------|----------|
-| ユニット | `test_serial_controller_output_port_factory_reuses_serial_device` | 改名後も serial device cache と port 生成が現行どおり動く |
-| ユニット | `test_controller_output_port_factory_old_name_is_not_exported` | `nyxpy.framework.core.io` と `device_factories` から旧名を import できない |
-| ユニット | `test_controller_config_defaults_to_serial` | `controller.backend` 未指定で `SerialControllerConfig` が返る |
-| ユニット | `test_controller_config_prefers_controller_serial_fields` | `controller.serial.*` が旧 flat key より優先される |
-| ユニット | `test_controller_config_falls_back_to_legacy_serial_protocol` | `serial_protocol` を fallback として読み、`protocol` という誤った key を読まない |
-| ユニット | `test_controller_config_rejects_invalid_backend` | 不正 backend が `ConfigurationError` になる |
-| ユニット | `test_controller_config_rejects_invalid_swbt_numbers` | `report_period_us` と `connect_timeout_sec` の不正値を拒否する |
-| ユニット | `test_create_device_runtime_builder_uses_serial_controller_config` | settings 正規化後も serial factory が `name` と `baudrate` を受け取る |
-| ユニット | `test_create_device_runtime_builder_rejects_swbt_until_backend_exists` | M1 では `SwbtControllerConfig` を runtime に接続しない |
-| ユニット | `test_cli_parser_still_requires_serial_and_capture` | M1 では CLI の `--serial` / `--capture` 必須が変わらない |
-| 静的 | `test_foundation_does_not_import_swbt_package` | M1 対象 module の import 文に `swbt` package が増えていない |
-| 結合 | `test_cli_create_runtime_builder_preserves_serial_arguments` | CLI から builder へ渡る serial device、protocol、baudrate が現行どおりである |
+| ユニット | `test_swbt_optional_dependency_declared` | `pyproject.toml` の `swbt-python>=0.2.0,<0.3.0` |
+| ユニット | `test_supported_controller_models_returns_three_models` | Pro Controller / Joy-Con L / Joy-Con R が登録される |
+| ユニット | `test_parse_controller_type_rejects_unknown_value` | 不正値が `NYX_SWBT_CONTROLLER_TYPE_UNSUPPORTED` |
+| ユニット | `test_swbt_config_resolves_default_key_store_per_controller_type` | controller type ごとに key store path が分かれる |
+| ユニット | `test_controller_config_falls_back_to_legacy_serial_keys` | 旧 serial flat key が読み込み元になる |
+| ユニット | `test_controller_config_does_not_keep_controller_type_string` | `SwbtControllerConfig` に raw 文字列が残らない |
+| ユニット | `test_controller_output_port_imu_default_unsupported` | 既定 `imu()` が `NotImplementedError` |
+| ユニット | `test_default_command_imu_delegates_to_controller` | `DefaultCommand.imu()` が port へ委譲する |
+| ユニット | `test_adapter_discovery_returns_view_without_opening_controller` | fake `list_adapters()` のみが呼ばれる |
+| ユニット | `test_resolve_adapter_uses_aliases_and_rejects_ambiguous` | alias 解決と曖昧候補の拒否 |
 
-通常検証は次を実行する。
+検証コマンド:
 
 ```console
 uv run ruff format .
 uv run ruff check .
 uv run ty check src/nyxpy --output-format concise --no-progress
-uv run pytest tests/unit/framework/io/test_device_factories.py tests/unit/framework/runtime/test_runtime_builder.py tests/unit/framework/settings/test_settings_schema.py tests/unit/cli/test_run_cli_parser.py tests/integration/test_cli_runtime_adapter.py
+uv run pytest tests/unit/framework/hardware/swbt/test_config.py tests/unit/framework/hardware/swbt/test_discovery.py tests/unit/framework/io/test_controller_config.py tests/unit/framework/io/test_ports.py tests/unit/framework/macro/test_command.py
 ```
 
 ## 6. 実装チェックリスト
 
-- [ ] `src/nyxpy/framework/core/io/controller_config.py` を追加し、controller config 型と正規化 helper を実装する
-- [ ] `ControllerOutputPortFactory` を `SerialControllerOutputPortFactory` へ改名する
-- [ ] 旧名 alias、互換 import、`DeprecationWarning` が追加されていないことを確認する
-- [ ] `src/nyxpy/framework/core/io/__init__.py` の export を正名へ更新する
-- [ ] `MacroRuntimeBuilder` と `create_device_runtime_builder()` の型注釈と factory 生成を正名へ更新する
-- [ ] `GLOBAL_SETTINGS_SCHEMA` に `controller.*` field を追加し、既存 serial field を残す
-- [ ] `run_cli.py` の import と型注釈を正名へ更新し、M1 では `--serial` / `--capture` 必須を維持する
-- [ ] factory 改名と settings 正規化のユニットテストを追加または更新する
-- [ ] CLI と runtime builder の既存 serial 挙動を検証する
-- [ ] M1 対象 module に `swbt-python` import が増えていないことを検証する
-- [ ] `uv run ruff format .` を実行する
-- [ ] `uv run ruff check .` を実行する
-- [ ] `uv run ty check src/nyxpy --output-format concise --no-progress` を実行する
-- [ ] 対象テストを `uv run pytest` で実行する
-
-## 7. 親計画との依存関係と引き渡し
-
-### 7.1 親計画との依存関係
-
-この仕様は `local_021` の M1 に対応する。M1 は M2 以降の swbt mapper、port、service、runtime/CLI 接続の前提であり、serial factory が正名へ整理されていない状態では後続の `SwbtControllerOutputPortFactory` を同列に置けない。
-
-M1 は `local_021` の次の決定を固定する。
-
-- `ControllerOutputPortFactory` の旧名は残さない。
-- `serial_device`、`serial_baud`、`serial_protocol` は読み込み元として残し、新 schema へ正規化する。
-- `SerialProtocolInterface` と `ProtocolFactory` に swbt を入れない。
-- M1 では swbt 実行経路をまだ有効化しない。
-
-### 7.2 完了後に次へ渡す成果
-
-M1 完了後、M2 へ次を渡す。
-
-- `SerialControllerOutputPortFactory` へ改名済みの serial factory。
-- `SerialControllerConfig`、`SwbtControllerConfig`、`ControllerConfig` の確定した import path。
-- 旧 serial key と `controller.*` key を解決する settings 正規化 helper。
-- swbt import がない状態で通る serial backend の単体テストと CLI parser テスト。
-- `SwbtControllerConfig` を受け取ったときの明示エラー。M4 でこのエラー箇所を swbt factory 接続へ置き換える。
+- [ ] `pyproject.toml` に `swbt` optional dependency と pytest marker を追加する。
+- [ ] `IMUFrame` を追加し、constants package から公開する。
+- [ ] `ControllerOutputPort.supports_imu` と `imu(...)` の既定 unsupported を追加する。
+- [ ] `Command.imu(...)` と `DefaultCommand.imu(...)` を追加する。
+- [ ] `ControllerBackend`、`SerialControllerConfig`、`ControllerConfig`、settings 正規化 helper を追加する。
+- [ ] `hardware/swbt/config.py` に controller model と capabilities を追加する。
+- [ ] `hardware/swbt/discovery.py` に adapter DTO、discovery service、adapter 解決を追加する。
+- [ ] `hardware/swbt/errors.py` に swbt 例外 mapping を追加する。
+- [ ] GUI / CLI choices が `supported_controller_models()` から導出できることをテストする。
+- [ ] adapter refresh が pairing、reconnect、report loop を開始しないことをテストする。
+- [ ] swbt 未導入環境で serial backend の import が壊れないことをテストする。

--- a/spec/agent/wip/local_023/SWBT_CORE_ADAPTER_SERVICE.md
+++ b/spec/agent/wip/local_023/SWBT_CORE_ADAPTER_SERVICE.md
@@ -1,433 +1,228 @@
-# swbt core adapter/service 仕様書
+# swbt session / mapper / port / factory 仕様書
 
 ## 1. 概要
 
 ### 1.1 目的
 
-`swbt-python` を NyX の `ControllerOutputPort` 実装として扱うための core 部品を追加する。対象は入力変換、port 状態管理、`SwitchGamepad` の同期 service、service を共有する factory であり、CLI、GUI、runtime builder への接続は後続仕様へ渡す。
+`swbt-python` の async controller API を NyX の同期 `ControllerOutputPort` として扱う core 部品を追加する。対象は `SwbtControllerSession`、`NyxSwbtInputMapper`、`SwbtControllerOutputPort`、`SwbtControllerOutputPortFactory`、`DummySwbtControllerSession` である。
 
 ### 1.2 用語定義
 
 | 用語 | 定義 |
 |------|------|
-| `swbt-python` | Switch 向け Bluetooth HID controller を扱う外部ライブラリ。Python package 名は `swbt-python`、import 名は `swbt` |
-| `NyxSwbtInputMapper` | NyX の `Button`、`Hat`、`LStick`、`RStick` を swbt の `Button`、`Stick`、`InputState` へ変換する mapper |
-| `SwbtControllerOutputPort` | `ControllerOutputPort` を実装し、NyX の controller 入力状態を `SwbtGamepadService` へ渡す port |
-| `SwbtGamepadService` | `SwitchGamepad`、event loop thread、diagnostics writer、接続 lifecycle を所有する同期 service |
-| `SwbtControllerOutputPortFactory` | 同じ service key の `SwbtGamepadService` を共有し、`create()` ごとに新しい port を返す factory |
-| service key | GUI manual input と macro runtime が同じ接続を共有してよいかを判定する不変設定の組 |
-| dummy service | 実機なしテストと dummy 実行で使う記録用 service。Bluetooth transport は開かない |
-| fake `SwitchGamepad` | `SwbtGamepadService` の単体テストで注入する非同期 fake。`open`、`connect`、`apply`、`close` の呼び出し順を検証する |
+| `SwbtControllerSession` | swbt controller instance、event loop thread、pair/reconnect、apply、neutral、close を所有する backend 内部部品 |
+| `DummySwbtControllerSession` | 実機なしテストで `InputState` を記録する session double |
+| `NyxSwbtState` | port が持つ現在入力状態。button、left stick、right stick、IMU frames を含む |
+| `NyxSwbtInputMapper` | `NyxSwbtState` と NyX 入力を swbt `InputState` へ変換する mapper |
+| `SwbtControllerOutputPort` | `ControllerOutputPort` を実装し、完全な `InputState` を session へ渡す port |
+| `SwbtControllerOutputPortFactory` | config ごとの session cache を持ち、runtime / GUI lifetime port を生成する factory |
+| session key | controller model、adapter、key store、report period、diagnostics path、operation timeout を含む cache key |
 
 ### 1.3 背景・問題
 
-既存の serial controller 出力は `SerialProtocolInterface` が入力状態を bytes へ変換し、`SerialCommInterface` が送信する構造である。`swbt-python` は bytes 生成器ではなく、Bluetooth adapter、pairing 情報、接続状態、周期 report loop を持つ長寿命の controller 実装であるため、serial protocol として扱うと責務が混ざる。
+serial backend は同期 `send()` で入力を送れる。一方、swbt backend は async resource と report loop を持つため、`ControllerOutputPort` から直接 `swbt-python` の coroutine を呼べない。session が event loop thread と lifecycle を所有し、port は入力状態と mapper に集中する必要がある。
 
-この仕様では `swbt-python` への依存を `swbt` extra 選択時だけ有効にし、通常 install の serial backend に import error を持ち込まない。実機に依存する pairing と入力反映確認は扱わず、dummy service と fake `SwitchGamepad` で core 部品の状態遷移と例外変換を検証する。
+GUI manual input と macro runtime は同じ adapter を同時に開けない。factory は同じ session key の session を cache し、GUI と runtime が同じ接続を再利用できるようにする。ただし同じ port object は共有しない。
 
 ### 1.4 期待効果
 
 | 指標 | 現状 | 目標 |
 |------|------|------|
-| swbt 依存範囲 | 未導入 | `io/swbt_adapter.py`、`hardware/swbt_service.py`、lazy import 箇所へ限定 |
-| 通常 install | serial backend のみ | `swbt` extra 未導入でも既存 import と serial backend が動作する |
-| mapper 検証 | 未導入 | button、D-pad、stick、非対応入力を実機なしで単体検証できる |
-| port close | 未導入 | `port.close()` は neutral だけを送る |
-| transport close | 未導入 | factory または service owner の `close()` だけが完全 close を行う |
-| service 共有 | 未導入 | 同じ service key では runtime 用 port と GUI manual input 用 port が同じ接続を使える |
+| swbt 接続 lifecycle | 未導入 | session が open/pair/reconnect/start/apply/neutral/close を所有する |
+| 入力変換 | 未導入 | mapper が button、D-pad、stick、IMU を完全 state へ変換する |
+| unsupported input | 未導入 | Joy-Con capability、touch、keyboard、sleep control を明確に失敗させる |
+| macro runtime pairing | 未導入 | `create()` は reconnect のみ行い、暗黙 pairing しない |
+| close | 未導入 | port close と session/factory close の両方で neutral を試みる |
 
 ### 1.5 着手条件
 
-- 親計画 `spec/agent/wip/local_021/SWBT_CONTROLLER_BACKEND.md` の M2+M3 に対応する作業として着手する。
-- M1 で `SerialControllerOutputPortFactory` 改名と controller config の配置方針が確定している。
-- `SwbtControllerConfig` の設定項目は親計画の値に従い、この仕様では CLI option や settings schema を追加しない。
-- `swbt-python>=0.1.1,<0.2.0` の public API を対象にする。
-- 旧名 alias、互換 import、`DeprecationWarning` は追加しない。
+- `local_022` で `SwbtControllerConfig`、`SwbtControllerModel`、`IMUFrame`、adapter discovery、error mapping が実装済みである。
+- `swbt-python>=0.2.0,<0.3.0` の root module public API だけを使う。
+- `hardware/swbt/manual.py`、`SwbtManualInputSession`、`swbt_*.py` module は追加しない。
+- CLI、GUI、runtime builder の接続は `local_024` と `local_025` に残す。
 
 ## 2. 対象ファイル
 
 | ファイル | 変更種別 | 変更内容 |
 |----------|----------|----------|
-| `pyproject.toml` | 変更 | `[project.optional-dependencies].swbt` に `swbt-python>=0.1.1,<0.2.0` を追加する |
-| `src/nyxpy/framework/core/io/swbt_adapter.py` | 新規 | `NyxSwbtState`、`NyxSwbtInputMapper`、`SwbtControllerOutputPort`、swbt input API loader、非対応入力例外を実装する |
-| `src/nyxpy/framework/core/hardware/swbt_service.py` | 新規 | `SwbtGamepadService`、`SwbtServiceKey`、dummy service、fake 注入用 protocol、例外変換を実装する |
-| `src/nyxpy/framework/core/io/device_factories.py` | 変更 | `SwbtControllerOutputPortFactory` を追加し、service key、service 共有、factory close を管理する。swbt 実装 module は必要時に lazy import する |
-| `tests/unit/framework/io/test_swbt_adapter.py` | 新規 | mapper と port の状態遷移、非対応入力、optional dependency 境界を検証する |
-| `tests/unit/framework/hardware/test_swbt_service.py` | 新規 | fake `SwitchGamepad` で service の start、connect、apply、neutral、close、例外変換を検証する |
-| `tests/unit/framework/io/test_swbt_factory.py` | 新規 | service key、service 再利用、`port.close()` と factory close の分離、dummy fallback、GUI 向け接続操作を検証する |
+| `src/nyxpy/framework/core/hardware/swbt/session.py` | 新規 | `SwbtControllerSession`、`DummySwbtControllerSession`、event loop bridge、connection lifecycle を実装する |
+| `src/nyxpy/framework/core/hardware/swbt/mapper.py` | 新規 | `NyxSwbtState`、`NyxSwbtInputMapper`、button / D-pad / stick / IMU mapping を実装する |
+| `src/nyxpy/framework/core/hardware/swbt/controller.py` | 新規 | `SwbtControllerOutputPort` を実装する |
+| `src/nyxpy/framework/core/hardware/swbt/factory.py` | 新規 | `SwbtControllerOutputPortFactory`、session cache、pair/reconnect/disconnect/status を実装する |
+| `src/nyxpy/framework/core/hardware/swbt/errors.py` | 変更 | session / mapper / port のエラー code を追加する |
+| `src/nyxpy/framework/core/hardware/swbt/__init__.py` | 変更 | core 部品を re-export する |
+| `tests/unit/framework/hardware/swbt/test_session.py` | 新規 | fake swbt controller で session lifecycle を検証する |
+| `tests/unit/framework/hardware/swbt/test_mapper.py` | 新規 | button、D-pad、stick、IMU、capability validation を検証する |
+| `tests/unit/framework/hardware/swbt/test_controller.py` | 新規 | port の press/hold/release/imu/close を検証する |
+| `tests/unit/framework/hardware/swbt/test_factory.py` | 新規 | session key、cache、dummy fallback、pair/reconnect/disconnect/status を検証する |
 
 ## 3. 設計方針
 
-swbt backend は `ControllerOutputPort` の具象実装である。`SerialProtocolInterface`、`ProtocolFactory`、serial device discovery には入れない。`Command`、`MacroRuntime`、`ExecutionContext` は swbt を import しない。
+### アーキテクチャ上の位置づけ
 
-`swbt-python` は optional dependency とする。`nyxpy.framework.core.io.device_factories`、`nyxpy.framework.core.io.adapters`、`nyxpy.framework.core.io.ports` の通常 import では `swbt` を読み込まない。`SwbtControllerOutputPortFactory.create()` が swbt backend を作る時点で `io/swbt_adapter.py` と `hardware/swbt_service.py` を lazy import する。
+`hardware/swbt` は swbt backend の具象実装を所有する。`SwbtControllerOutputPort` は `ControllerOutputPort` を実装するが、GUI 専用 adapter ではない。`SwbtControllerSession` は serial backend における `SerialComm` と `SerialProtocolInterface` の組み合わせに近い内部部品である。
 
-`SwbtControllerOutputPort` は port ごとに NyX 側の入力状態を持つ。`create()` ごとに新しい port を返し、状態は neutral から始める。GUI と runtime は同じ `SwbtGamepadService` を共有できるが、同じ port object は共有しない。
+### 公開 API 方針
 
-`port.close()` は idempotent とし、内部状態を neutral に戻して `service.neutral()` を呼ぶだけにする。Bluetooth transport、diagnostics writer、event loop thread の完全終了は `SwbtControllerOutputPortFactory.close()` が `SwbtGamepadService.close()` を呼ぶことで行う。
+外部へ見せる surface は `ControllerOutputPort` と factory の high-level lifecycle method に限定する。swbt の `InputState`、`Button`、`Stick`、`IMUFrame` は mapper 内に閉じる。`SwbtControllerSession` は framework 内部 API として扱う。
 
-service key は service lifetime に影響する設定だけで作る。少なくとも `adapter`、`key_store_path`、`report_period_us`、`device_name`、`diagnostics_path`、`connect_on_open` を含める。`allow_pairing` と `connect_timeout_sec` は接続試行ごとの値なので service key に含めない。
+### 後方互換性
 
-非対応入力は silent failure にしない。`ThreeDSButton`、`TouchState`、`keyboard()`、`type_key()`、`touch_down()`、`touch_up()`、`disable_sleep()` は swbt backend で扱えない入力として明示的に失敗させる。
+新規 backend 追加であり、serial backend の既存動作を変えない。`ControllerOutputPort` に追加済みの `imu()` は serial backend で既定 unsupported のままでよい。
 
-新規グローバル singleton は追加しない。CLI と GUI の composition root が factory lifetime を所有し、factory が service lifetime を所有する。
+### レイヤー構成
+
+`controller.py` は port contract、`mapper.py` は入力変換、`session.py` は async lifecycle、`factory.py` は session cache と pair/reconnect 操作を担当する。factory 以外が GUI state や runtime builder を知らない。
+
+### 性能要件
+
+| 指標 | 目標値 |
+|------|--------|
+| `press` / `release` | port 内で完全 `InputState` を作り 1 回 `session.apply()` |
+| session start | `open()` 後に reconnect のみ行う |
+| dummy session | Bluetooth transport を開かない |
+| close | port close は neutral、factory close は session close |
+
+### 並行性・スレッド安全性
+
+session は event loop thread と `RLock` を持ち、connection operation と input apply を直列化する。`Future.result()` を待つ間に不要な lock を保持し続けない。port は自身の `NyxSwbtState` を `RLock` で守る。
 
 ## 4. 実装仕様
 
-### 4.1 optional dependency 境界
-
-`pyproject.toml` の既存 `[project.optional-dependencies]` には次の extra key を追加する。
-
-```toml
-[project.optional-dependencies]
-swbt = [
-    "swbt-python>=0.1.1,<0.2.0",
-]
-```
-
-`swbt` import は loader 関数へ閉じ込める。extra 未導入で swbt backend を作ろうとした場合は `ConfigurationError` を送出する。
+### session
 
 ```python
-from dataclasses import dataclass
-from typing import Any
-
-
-@dataclass(frozen=True)
-class SwbtInputApi:
-    button: Any
-    stick: Any
-    input_state: Any
-
-
-def load_swbt_input_api() -> SwbtInputApi:
-    try:
-        from swbt import Button, InputState, Stick
-    except ModuleNotFoundError as exc:
-        raise ConfigurationError(
-            "swbt extra is not installed",
-            code="NYX_SWBT_EXTRA_MISSING",
-            component="SwbtControllerOutputPortFactory",
-            cause=exc,
-        ) from exc
-    return SwbtInputApi(button=Button, stick=Stick, input_state=InputState)
+class SwbtControllerSession:
+    def open(self) -> None: ...
+    def start(self, *, timeout_sec: float) -> None: ...
+    def pair(self, *, timeout_sec: float) -> object: ...
+    def reconnect(self, *, timeout_sec: float) -> object: ...
+    def apply(self, state: object) -> None: ...
+    def neutral(self) -> None: ...
+    def status(self) -> object: ...
+    def close(self) -> None: ...
 ```
 
-unit test は fake `SwbtInputApi` を注入し、`swbt-python` 未導入環境でも mapper と port の検証を実行できるようにする。
+`open()` は transport と report loop の準備だけを行い、pairing / reconnect を開始しない。`start()` は macro / GUI lifetime port 用であり、保存済み key store に基づく reconnect だけを行う。key store がない場合に pairing へ fallback しない。
 
-### 4.2 入力状態と mapper
+### mapper
 
-`NyxSwbtState` は swbt の完全入力状態を作るための中間状態である。型は production では `swbt.Button`、`swbt.Stick`、`swbt.InputState` を使うが、test では fake API を注入するため `Any` を許容する。
-
-```python
-from dataclasses import dataclass, field
-from typing import Any
-
-
-@dataclass
-class NyxSwbtState:
-    buttons: set[Any] = field(default_factory=set)
-    left_stick: Any | None = None
-    right_stick: Any | None = None
-```
-
-`NyxSwbtInputMapper` は次の public method を持つ。
-
-```python
-class UnsupportedSwbtInputError(ValueError):
-    """swbt backend で表現できない NyX 入力を受け取った場合の例外。"""
-
-
-class NyxSwbtInputMapper:
-    def __init__(self, *, input_api: SwbtInputApi | None = None, invert_stick_y: bool = False) -> None: ...
-    def new_state(self) -> NyxSwbtState: ...
-    def add_to_state(self, state: NyxSwbtState, keys: tuple[KeyType, ...]) -> None: ...
-    def remove_from_state(self, state: NyxSwbtState, keys: tuple[KeyType, ...]) -> None: ...
-    def to_input_state(self, state: NyxSwbtState) -> object: ...
-```
-
-button は明示 dict で変換する。NyX 側の `CAP`、`LS`、`RS` は swbt 側の `CAPTURE`、`LEFT_STICK`、`RIGHT_STICK` へ対応させる。
+現行 NyX constants を正として扱う。button mapping は次である。
 
 | NyX | swbt |
 |-----|------|
-| `Button.A` | `Button.A` |
-| `Button.B` | `Button.B` |
-| `Button.X` | `Button.X` |
-| `Button.Y` | `Button.Y` |
-| `Button.L` | `Button.L` |
-| `Button.R` | `Button.R` |
-| `Button.ZL` | `Button.ZL` |
-| `Button.ZR` | `Button.ZR` |
-| `Button.PLUS` | `Button.PLUS` |
-| `Button.MINUS` | `Button.MINUS` |
-| `Button.HOME` | `Button.HOME` |
+| `Button.A` / `B` / `X` / `Y` | 同名 button |
+| `Button.L` / `R` / `ZL` / `ZR` | 同名 button |
+| `Button.PLUS` / `MINUS` / `HOME` | 同名 button |
 | `Button.CAP` | `Button.CAPTURE` |
 | `Button.LS` | `Button.LEFT_STICK` |
 | `Button.RS` | `Button.RIGHT_STICK` |
 
-`Hat` は D-pad button set へ変換する。`press(Hat.CENTER)` と `release(Hat.*)` は D-pad 全解除として扱う。斜め方向は 2 button 同時押しで表す。新しい `Hat` を押した場合は既存 D-pad button を全解除してから新しい方向を入れる。
+`Hat` は D-pad button set に変換する。`Hat.CENTER` は D-pad 全解除である。`LStick` / `RStick` は現行の `x` / `y` `0..255` を swbt `Stick` の範囲へ変換する。Joy-Con L は right stick、Joy-Con R は left stick を拒否する。
 
-stick は NyX の `0..255` を swbt の `0..4095` へ変換する。
+IMU は `IMUFrame` 1 個または 3 個だけを受ける。1 個は 3 frame に複製し、3 個は順に使う。0、2、4 個以上は `DeviceError(code="NYX_IMU_FRAME_COUNT_INVALID")` とする。
 
-```python
-def stick_8bit_to_12bit(value: int) -> int:
-    if not 0 <= value <= 255:
-        raise ValueError(f"stick value out of range: {value}")
-    return round(value * 4095 / 255)
-```
-
-`invert_stick_y=false` を初期値とする。Y 軸既定値の最終確定は実機検証の担当範囲へ渡す。
-
-### 4.3 `SwbtControllerOutputPort`
-
-`SwbtControllerOutputPort` は `ControllerOutputPort` を実装する。`tap()` は使わない。NyX の `Command.press()` は `press()`、待機、`release()` の分離を前提にしており、swbt の即時 action API と意味が一致しないためである。
+### port
 
 ```python
-from threading import RLock
-
-
 class SwbtControllerOutputPort(ControllerOutputPort):
-    def __init__(
-        self,
-        *,
-        service: SwbtGamepadServiceProtocol,
-        mapper: NyxSwbtInputMapper,
-        reset_on_open: bool = True,
-    ) -> None: ...
-
+    @property
+    def supports_imu(self) -> bool: ...
     @property
     def supports_touch(self) -> bool: ...
-
     def press(self, keys: tuple[KeyType, ...]) -> None: ...
     def hold(self, keys: tuple[KeyType, ...]) -> None: ...
     def release(self, keys: tuple[KeyType, ...] = ()) -> None: ...
+    def imu(self, *frames: IMUFrame) -> None: ...
     def keyboard(self, text: str) -> None: ...
     def type_key(self, key: KeyCode | SpecialKeyCode) -> None: ...
     def close(self) -> None: ...
 ```
 
-操作の意味は次の通りである。
+`press()` は state に追加し、`hold()` は state を破棄して keys だけにし、`release(keys)` は state から除去する。`release()` と `close()` は button、stick、IMU を neutral に戻し、`session.neutral()` を呼ぶ。close 後の入力操作は `DeviceError(code="NYX_SWBT_PORT_CLOSED")` とする。
 
-| 操作 | 処理 |
-|------|------|
-| `__init__(reset_on_open=True)` | port state を neutral で作り、`service.neutral()` を呼ぶ |
-| `press(keys)` | 現在状態へ keys を追加し、完全状態を `service.apply()` へ渡す |
-| `hold(keys)` | 現在状態を破棄し、keys のみを追加して `service.apply()` へ渡す |
-| `release(keys)` | keys を現在状態から除去し、完全状態を `service.apply()` へ渡す |
-| `release()` | 現在状態を neutral に戻し、`service.neutral()` を呼ぶ |
-| `close()` | idempotent。現在状態を neutral に戻し、`service.neutral()` を呼ぶ。transport は閉じない |
+touch、keyboard、sleep control は `NotImplementedError` とする。silent no-op にしない。
 
-close 後の `press()`、`hold()`、`release()` は `DeviceError(code="NYX_SWBT_PORT_CLOSED")` とする。`close()` の二回目は例外にしない。
-
-### 4.4 `SwbtGamepadService`
-
-service は `SwitchGamepad` と event loop thread を所有する。同期 port から呼ばれる method は `asyncio.run_coroutine_threadsafe()` で event loop thread へ処理を渡し、例外を NyX の `ConfigurationError` または `DeviceError` へ変換する。
+### factory
 
 ```python
-from collections.abc import Callable
-from dataclasses import dataclass
-from pathlib import Path
-from typing import Protocol
-
-
-@dataclass(frozen=True)
-class SwbtServiceKey:
-    adapter: str
-    key_store_path: Path | None
-    report_period_us: int
-    device_name: str
-    diagnostics_path: Path | None
-    connect_on_open: bool
-
-
-class SwbtGamepadProtocol(Protocol):
-    async def open(self) -> None: ...
-    async def connect(self, *, timeout: float, allow_pairing: bool) -> None: ...
-    async def apply(self, state: object) -> None: ...
-    async def close(self, *, neutral: bool = True) -> None: ...
-
-
-class SwbtGamepadServiceProtocol(Protocol):
-    def start(self, *, allow_pairing: bool, timeout_sec: float) -> None: ...
-    def connect(self, *, allow_pairing: bool, timeout_sec: float) -> None: ...
-    def apply(self, state: object) -> None: ...
-    def neutral(self) -> None: ...
-    def status(self) -> object: ...
-    def close(self) -> None: ...
-
-
-class SwbtGamepadService:
-    def __init__(
-        self,
-        *,
-        key: SwbtServiceKey,
-        gamepad_factory: Callable[..., SwbtGamepadProtocol] | None = None,
-        input_api: SwbtInputApi | None = None,
-        operation_timeout_sec: float = 5.0,
-    ) -> None: ...
-```
-
-`start()` の順序は次にする。
-
-`status()` の production return は `swbt.GamepadStatus` である。上記 signature では `swbt` 未導入環境の import 境界を保つため `object` としている。実装では `TYPE_CHECKING` 配下で `GamepadStatus` を参照し、docstring とテストで返却 object の意味を固定する。GUI は `GamepadStatus` を直接 import せず、GUI service layer で表示用 DTO へ変換する。
-
-| 順序 | 処理 |
-|------|------|
-| 1 | event loop thread を起動する |
-| 2 | `diagnostics_path` があれば JSON Lines writer を開く |
-| 3 | `SwitchGamepad` を作る |
-| 4 | `open()` を実行する |
-| 5 | `connect_on_open=true` なら `connect(timeout=timeout_sec, allow_pairing=allow_pairing)` を実行する |
-| 6 | 失敗時は可能な範囲で `close(neutral=True)` と writer close を試み、NyX 例外へ変換する |
-
-`neutral()` は `InputState.neutral()` を作って `apply()` と同じ送信経路へ流す。`close()` は idempotent とし、`SwitchGamepad.close(neutral=True)`、writer close、event loop stop、thread join の順で終了する。
-
-service の lifecycle は `RLock` で保護する。`close` 開始後の `apply()` は `DeviceError(code="NYX_SWBT_SERVICE_CLOSING")`、close 後の `apply()` は `DeviceError(code="NYX_SWBT_SERVICE_CLOSED")` とする。`Future.result()` を待つ間に lifecycle lock を保持し続けない。
-
-### 4.5 dummy service と fake `SwitchGamepad`
-
-dummy service は production code に置き、実機なし runtime と単体テストで使えるようにする。Bluetooth transport は開かず、受け取った state を記録する。
-
-```python
-class DummySwbtGamepadService:
-    def __init__(self, *, neutral_state_factory: Callable[[], object]) -> None: ...
-    def start(self, *, allow_pairing: bool, timeout_sec: float) -> None: ...
-    def connect(self, *, allow_pairing: bool, timeout_sec: float) -> None: ...
-    def apply(self, state: object) -> None: ...
-    def neutral(self) -> None: ...
-    def status(self) -> object: ...
-    def close(self) -> None: ...
-```
-
-fake `SwitchGamepad` は tests 配下に置く。`SwbtGamepadService` へ `gamepad_factory` で注入し、`open`、`connect`、`apply`、`close(neutral=True)` の呼び出し順と引数を検証する。
-
-### 4.6 `SwbtControllerOutputPortFactory`
-
-factory は `device_factories.py` に置き、既存 serial factory と同じ port factory 層で扱う。実装本体の import は `create()` または service 作成時まで遅延する。
-
-```python
-from collections.abc import Callable
-
-
 class SwbtControllerOutputPortFactory:
-    def __init__(
-        self,
-        *,
-        config: SwbtControllerConfig,
-        service_factory: Callable[[SwbtServiceKey], SwbtGamepadServiceProtocol] | None = None,
-        mapper_factory: Callable[..., NyxSwbtInputMapper] | None = None,
-    ) -> None: ...
-
-    @property
-    def service_key(self) -> SwbtServiceKey: ...
-
-    def create(
-        self,
-        *,
-        allow_dummy: bool,
-        timeout_sec: float,
-    ) -> ControllerOutputPort: ...
-
-    def pair_once(self, *, timeout_sec: float | None = None) -> object: ...
-    def reconnect(self, *, timeout_sec: float | None = None) -> object: ...
-    def disconnect(self) -> None: ...
-    def status(self) -> object | None: ...
+    def create(self, *, config: SwbtControllerConfig, allow_dummy: bool, timeout_sec: float) -> ControllerOutputPort: ...
+    def pair(self, config: SwbtControllerConfig, *, timeout_sec: float | None = None) -> object: ...
+    def reconnect(self, config: SwbtControllerConfig, *, timeout_sec: float | None = None) -> object: ...
+    def disconnect(self, config: SwbtControllerConfig) -> None: ...
+    def status(self, config: SwbtControllerConfig) -> object | None: ...
     def close(self) -> None: ...
 ```
 
-`create()` は同じ `service_key` の service を再利用し、新しい `SwbtControllerOutputPort` を返す。service が未開始なら `service.start(allow_pairing=config.allow_pairing, timeout_sec=timeout_sec)` を呼ぶ。`allow_dummy=True` で service start が失敗した場合は dummy service へ fallback する。`allow_dummy=False` では `ConfigurationError` を送出する。
+`create()` は session key から session を取得し、未接続なら `session.start()` で reconnect する。`allow_dummy=True` の場合だけ、transport 失敗時に `DummySwbtControllerSession` を返せる。`pair()` と `reconnect()` は GUI / CLI の明示操作であり、macro run からは呼ばない。
 
-`pair_once()` は `allow_pairing=True` で接続を試み、`reconnect()` は `allow_pairing=False` で接続を試みる。どちらも service が未作成なら同じ service key で作成し、成功時は `status()` の結果を返す。`disconnect()` は service を close して factory 内の service 参照を破棄する。これにより GUI は backend を切り替えずに、同じ factory から pair once、reconnect、disconnect を呼べる。
+session key に含める値:
 
-factory の `close()` は所有する service を一度だけ close する。すでに作成済みの port に対しては、runtime 側の通常 close が neutral を送る前提であり、factory close は transport の最終解放を担当する。
+```text
+model.controller_type
+adapter
+key_store_path
+report_period_us
+diagnostics_path
+operation_timeout_sec
+```
 
-### 4.7 例外変換
+接続試行ごとの `connect_timeout_sec` と `allow_dummy` は session key に含めない。
+
+### エラーハンドリング
 
 | 条件 | NyX 例外 |
 |------|----------|
-| `swbt` import 不可 | `ConfigurationError(code="NYX_SWBT_EXTRA_MISSING")` |
-| adapter open 失敗 | `ConfigurationError(code="NYX_SWBT_TRANSPORT_OPEN_FAILED")` |
-| connect timeout | `ConfigurationError(code="NYX_SWBT_CONNECTION_TIMED_OUT")` |
-| connect 失敗 | `ConfigurationError(code="NYX_SWBT_CONNECTION_FAILED")` |
-| key store 不正 | `ConfigurationError(code="NYX_SWBT_KEY_STORE_INVALID")` |
-| service close 中の apply | `DeviceError(code="NYX_SWBT_SERVICE_CLOSING")` |
-| service close 後の apply | `DeviceError(code="NYX_SWBT_SERVICE_CLOSED")` |
-| port close 後の入力操作 | `DeviceError(code="NYX_SWBT_PORT_CLOSED")` |
-| swbt 非対応入力 | `UnsupportedSwbtInputError` |
-| swbt 入力値不正 | `DeviceError(code="NYX_SWBT_INPUT_INVALID")` |
+| transport open 失敗 | `ConfigurationError(code="NYX_SWBT_TRANSPORT_OPEN_FAILED")` |
+| connection timeout | `ConfigurationError(code="NYX_SWBT_CONNECTION_TIMED_OUT")` |
+| connection failed | `ConfigurationError(code="NYX_SWBT_CONNECTION_FAILED")` |
+| invalid key store | `ConfigurationError(code="NYX_SWBT_KEY_STORE_INVALID")` |
+| unsupported input | `DeviceError(code="NYX_SWBT_INPUT_UNSUPPORTED")` |
+| invalid input | `DeviceError(code="NYX_SWBT_INPUT_INVALID")` |
+| close 後の port 操作 | `DeviceError(code="NYX_SWBT_PORT_CLOSED")` |
+| close 後の session apply | `DeviceError(code="NYX_SWBT_NOT_CONNECTED")` |
 
-`swbt-python` の例外 object は macro 側へ直接漏らさない。`details` には `adapter`、`key_store_path`、`allow_pairing`、`connect_timeout_sec`、元例外型を入れる。
+### シングルトン管理
+
+新規グローバル singleton は追加しない。factory instance が session cache を所有し、runtime builder または GUI app service が factory lifetime を所有する。
 
 ## 5. テスト方針
 
 | テスト種別 | テスト名 | 検証内容 |
 |------------|----------|----------|
-| ユニット | `test_swbt_optional_dependency_is_lazy_for_default_imports` | `swbt` 未導入でも `ports`、`adapters`、`device_factories` の import が成功する |
-| ユニット | `test_mapper_maps_switch_buttons_with_explicit_names` | `CAP`、`LS`、`RS` を含む button map が fake swbt button へ変換される |
-| ユニット | `test_mapper_replaces_dpad_buttons_when_hat_changes` | `Hat.UP` 後に `Hat.RIGHT` を押すと D-pad が RIGHT だけになる |
-| ユニット | `test_mapper_clears_dpad_for_hat_center_and_release` | `Hat.CENTER` と `release(Hat.*)` が D-pad 全解除になる |
-| ユニット | `test_mapper_converts_sticks_from_8bit_to_12bit` | `0`、`128`、`255` の stick 値が `0..4095` へ変換される |
-| ユニット | `test_mapper_inverts_stick_y_when_enabled` | `invert_stick_y=True` で Y 値が反転する |
-| ユニット | `test_mapper_rejects_unsupported_nyx_inputs` | `ThreeDSButton` と `TouchState` が `UnsupportedSwbtInputError` になる |
-| ユニット | `test_port_press_hold_release_apply_complete_state` | `press`、`hold`、`release` が dummy service へ完全状態を渡す |
-| ユニット | `test_port_close_sends_neutral_without_closing_service` | `port.close()` が neutral だけを送信し、service close を呼ばない |
-| ユニット | `test_port_rejects_operations_after_close` | close 後の入力操作が `DeviceError(code="NYX_SWBT_PORT_CLOSED")` になる |
-| ユニット | `test_service_start_opens_and_connects_fake_gamepad` | fake `SwitchGamepad` で open と connect の順序を検証する |
-| ユニット | `test_service_apply_runs_on_event_loop_thread` | `apply()` が service 所有 event loop thread 上で実行される |
-| ユニット | `test_service_close_uses_trailing_neutral` | `close()` が `close(neutral=True)` を呼び、thread と writer を閉じる |
-| ユニット | `test_service_maps_swbt_exceptions_to_framework_errors` | transport、timeout、key store、closed 系の例外変換を検証する |
-| ユニット | `test_factory_reuses_service_for_same_key_and_new_ports` | 同じ service key で service を共有し、port は毎回新規になる |
-| ユニット | `test_factory_key_excludes_attempt_options` | `allow_pairing` と `connect_timeout_sec` の違いだけでは service key が変わらない |
-| ユニット | `test_factory_key_includes_lifetime_options` | `adapter`、`key_store_path`、`report_period_us`、`device_name`、`diagnostics_path`、`connect_on_open` の違いで key が変わる |
-| ユニット | `test_factory_falls_back_to_dummy_when_allowed` | `allow_dummy=True` の service start 失敗で dummy service を返す |
-| ユニット | `test_factory_pair_reconnect_disconnect_for_gui_actions` | GUI から呼ぶ pair once、reconnect、disconnect が service へ正しい接続条件を渡す |
+| ユニット | `test_session_open_does_not_pair_or_reconnect` | `open()` が接続操作を開始しない |
+| ユニット | `test_session_start_reconnects_without_pairing` | `start()` が reconnect のみ行う |
+| ユニット | `test_session_close_trails_neutral_and_stops_loop` | close 時に neutral と loop stop を行う |
+| ユニット | `test_mapper_maps_buttons_with_current_nyx_names` | `CAP` / `LS` / `RS` を swbt 名へ変換する |
+| ユニット | `test_mapper_replaces_dpad_direction` | D-pad 方向切替が古い方向を解除する |
+| ユニット | `test_mapper_converts_stick_xy_and_rejects_joycon_missing_stick` | stick 変換と Joy-Con capability |
+| ユニット | `test_mapper_normalizes_imu_one_or_three_frames` | IMU frame 数の規則 |
+| ユニット | `test_port_press_hold_release_apply_complete_state` | port 操作が完全 state を apply する |
+| ユニット | `test_port_close_sends_neutral_without_session_close` | port close は transport を閉じない |
+| ユニット | `test_factory_reuses_session_for_same_key` | 同じ key で session を共有し port は新規 |
+| ユニット | `test_factory_pair_reconnect_are_explicit_operations` | pair/reconnect が明示操作として session へ渡る |
+| ユニット | `test_factory_does_not_create_manual_session_type` | `SwbtManualInputSession` が存在しない |
 
-この仕様の通常検証は次で行う。
+検証コマンド:
 
 ```console
 uv run ruff format .
 uv run ruff check .
 uv run ty check src/nyxpy --output-format concise --no-progress
-uv run pytest tests/unit/framework/io/test_swbt_adapter.py tests/unit/framework/hardware/test_swbt_service.py tests/unit/framework/io/test_swbt_factory.py
+uv run pytest tests/unit/framework/hardware/swbt/test_session.py tests/unit/framework/hardware/swbt/test_mapper.py tests/unit/framework/hardware/swbt/test_controller.py tests/unit/framework/hardware/swbt/test_factory.py
 ```
-
-実機検証はこの仕様の完了条件に含めない。pairing、reconnect、実機上の button、D-pad、stick 反映は M6 の担当範囲で確認する。
 
 ## 6. 実装チェックリスト
 
-- [ ] `pyproject.toml` に `swbt` optional dependency を追加する。
-- [ ] `SwbtInputApi` と `load_swbt_input_api()` を追加し、`swbt` import を lazy にする。
+- [ ] `SwbtControllerSession` を実装し、open と pair/reconnect を分離する。
+- [ ] session の event loop thread、operation timeout、close idempotency を実装する。
+- [ ] `DummySwbtControllerSession` を実装し、Bluetooth transport を開かず state を記録する。
 - [ ] `NyxSwbtState` と `NyxSwbtInputMapper` を実装する。
-- [ ] button、D-pad、stick、Y 軸反転、非対応入力の mapper 単体テストを追加する。
-- [ ] `SwbtControllerOutputPort` を実装する。
-- [ ] `press`、`hold`、`release`、`close`、close 後操作の port 単体テストを追加する。
-- [ ] `SwbtServiceKey` と `SwbtGamepadService` を実装する。
-- [ ] event loop thread、diagnostics writer、start/connect/apply/neutral/close の service 単体テストを追加する。
-- [ ] `swbt-python` 例外から NyX 例外への変換を実装する。
-- [ ] `DummySwbtGamepadService` と fake `SwitchGamepad` 注入経路を実装する。
-- [ ] `SwbtControllerOutputPortFactory` を実装し、service key と factory close を管理する。
-- [ ] GUI 向けの pair once / reconnect / disconnect / status 操作を `SwbtControllerOutputPortFactory` に追加する。
-- [ ] `allow_dummy=True` の dummy fallback と `allow_dummy=False` の失敗をテストする。
-- [ ] `swbt` extra 未導入でも通常 import が壊れないことをテストする。
-- [ ] `uv run ruff format .` を実行する。
-- [ ] `uv run ruff check .` を実行する。
-- [ ] `uv run ty check src/nyxpy --output-format concise --no-progress` を実行する。
-- [ ] M2+M3 対象の unit test を実行する。
-
-## 7. 親計画との依存関係と引き渡し
-
-この仕様は `local_021` の M2+M3 をまとめる。M1 の成果である controller config と serial factory 改名が前提であり、M2+M3 では settings schema、CLI option、GUI 操作を実装しない。
-
-後続の M4 へ渡す成果は次である。
-
-| 成果 | 後続での使い方 |
-|------|----------------|
-| `SwbtControllerOutputPortFactory` | runtime builder が `controller.backend="swbt"` のときに選択する |
-| `SwbtServiceKey` | GUI と runtime が同じ service を共有してよいかを判定する |
-| `DummySwbtGamepadService` | runtime integration test で実機なしに `Command.press()` の反映を確認する |
-| pair once / reconnect / disconnect / status 操作 | GUI の接続操作から共有 service を制御する |
-| optional dependency 境界 | `--controller swbt` 選択時だけ `swbt` extra を要求し、serial backend の import を壊さない |
-| 例外 code と details | CLI と GUI が接続失敗、extra 未導入、key store 不正を利用者へ表示する |
-
-M5 へ渡す前提は、port object は共有せず service だけを共有することである。GUI manual input と macro runtime の同時入力制御は M5 で行い、この仕様では service 側が destructive な lifecycle 競合を起こさないところまでを保証する。
-
-M6 へ渡す未確定事項は、stick Y 軸の既定値と短押し時の public flush 要否である。M2+M3 では `invert_stick_y=false` と周期 report loop 前提で実装し、private method には依存しない。
+- [ ] button、D-pad、stick、IMU、Joy-Con capability の mapper test を追加する。
+- [ ] `SwbtControllerOutputPort` を実装し、非対応入力を silent no-op にしない。
+- [ ] port close と release all で IMU を含め neutral に戻す。
+- [ ] `SwbtControllerOutputPortFactory` を実装し、session key と session cache を管理する。
+- [ ] `create()` が暗黙 pairing せず reconnect のみ行うことを確認する。
+- [ ] `pair()` / `reconnect()` / `disconnect()` / `status()` を明示 lifecycle 操作として実装する。
+- [ ] `hardware/swbt/manual.py`、`SwbtManualInputSession`、`swbt_*.py` module がないことを静的に確認する。

--- a/spec/agent/wip/local_024/SWBT_RUNTIME_CLI_INTEGRATION.md
+++ b/spec/agent/wip/local_024/SWBT_RUNTIME_CLI_INTEGRATION.md
@@ -1,123 +1,94 @@
 # swbt runtime / CLI 連携仕様書
 
-> **対象モジュール**: `src/nyxpy/framework/core/runtime/`, `src/nyxpy/cli/`
-> **目的**: `controller.backend` と `--controller` で選ばれた controller backend を runtime builder に接続し、`swbt` backend では serial protocol 生成を通らずに `ControllerOutputPort` を注入する。
-> **関連ドキュメント**: `spec/agent/wip/local_021/SWBT_CONTROLLER_BACKEND.md`, `docs/architecture/swbt-integration/runtime-composition.md`, `docs/architecture/swbt-integration/configuration-cli-gui.md`, `docs/architecture/swbt-integration/testing-rollout.md`
-> **破壊的変更**: あり。`create_runtime_builder()` と `create_device_runtime_builder()` の controller 引数を config ベースへ寄せ、旧 `ControllerOutputPortFactory` 名の互換 alias は使わない。
-
 ## 1. 概要
 
 ### 1.1 目的
 
-Runtime と CLI の構成起点で `serial` / `swbt` backend を一度だけ選択し、`MacroRuntimeBuilder` へ `PortFactory[ControllerOutputPort]` として注入する。`swbt` backend では `--serial` を不要にし、`ProtocolFactory.resolve_baudrate()` と `ProtocolFactory.create_protocol()` を呼ばない経路をテストで固定する。
+Runtime builder の構成起点で `serial` / `swbt` controller backend を選択し、`swbt` backend では serial protocol 生成を通らずに `SwbtControllerOutputPortFactory` を注入する。CLI には `nyxpy run --controller swbt` と `nyxpy swbt adapters/pair/reconnect` を追加する。
 
 ### 1.2 用語定義
 
 | 用語 | 定義 |
 |------|------|
-| MacroRuntimeBuilder | Registry と各種 port factory から `ExecutionContext` と `MacroRuntime` 実行単位を組み立てる composition root |
-| ControllerConfig | `SerialControllerConfig` または `SwbtControllerConfig` の union。local_022 で追加される controller backend 設定 |
-| SerialControllerConfig | serial backend の device、protocol、baudrate を保持する設定値 object |
-| SwbtControllerConfig | swbt backend の adapter、key store、pairing 許可、timeout、diagnostics などを保持する設定値 object |
-| SerialControllerOutputPortFactory | serial device と `SerialProtocolInterface` から `ControllerOutputPort` を生成する factory。local_022 の改名後名 |
-| SwbtControllerOutputPortFactory | `SwbtGamepadService` を所有し、swbt 用 `ControllerOutputPort` を生成する factory。local_023 で追加される |
-| CLI override | `nyxpy run` の option によって settings snapshot より優先される実行時設定 |
-| dummy swbt service | 実 Bluetooth 接続を行わず、`ControllerOutputPort` から送られた state を記録するテスト用 service |
+| `ControllerConfig` | `SerialControllerConfig | SwbtControllerConfig` |
+| `make_controller_port_factory` | `ControllerConfig` から runtime 用 `PortFactory[ControllerOutputPort]` を作る構成関数 |
+| `nyxpy swbt adapters` | adapter 候補を列挙する CLI。pairing / reconnect は開始しない |
+| `nyxpy swbt pair` | controller type、adapter、key store を指定して明示 pairing する CLI |
+| `nyxpy swbt reconnect` | 保存済み key store で明示 reconnect する CLI |
+| runtime reconnect | macro run 開始時に保存済み pairing key で接続する処理。pairing はしない |
+| CLI override | settings より優先する CLI 指定値 |
 
 ### 1.3 背景・問題
 
-現行 `src/nyxpy/cli/run_cli.py` は `cli_main()` で `ProtocolFactory.resolve_baudrate()` と `create_protocol()` を先に呼び、その後 `create_runtime_builder()` に protocol を渡す。現行 `create_device_runtime_builder()` も `SerialProtocolInterface` と `ControllerOutputPortFactory.create(name=..., baudrate=...)` を必須前提にしている。
+現行 `nyxpy run` は serial protocol を先に作ってから runtime builder を構成する。これでは `--controller swbt` を選んでも serial device / protocol 生成を避けられない。swbt backend は `SerialProtocolInterface` ではなく `ControllerOutputPort` backend なので、controller backend の解決を protocol 生成より前へ移す必要がある。
 
-この順序では `--controller swbt` を選んでも serial protocol 生成を避けられない。swbt は `SerialProtocolInterface` ではなく `ControllerOutputPort` backend なので、backend 選択を protocol 生成より前へ移し、runtime builder には backend 選択済みの controller factory を渡す必要がある。
+Pairing は利用者の明示操作である。macro run が key store 不足を見て暗黙 pairing すると、実行時に Switch 側状態を要求し、再現性の低い副作用になる。
 
 ### 1.4 期待効果
 
 | 指標 | 現状 | 目標 |
 |------|------|------|
-| swbt CLI 実行時の serial protocol 生成 | `cli_main()` が常に `resolve_baudrate()` と `create_protocol()` を呼ぶ | `--controller swbt` では両方とも呼ばない |
-| `--serial` の必須性 | parser が常に `required=True` とする | `serial` backend の実行時 validation だけで必須とし、`swbt` backend では不要 |
-| runtime builder の controller 構成 | serial 名、baudrate、protocol を直接受ける | `ControllerConfig` から `PortFactory[ControllerOutputPort]` を構成する |
-| 実機なし swbt runtime test | 未整備 | dummy swbt service で `Command.press()` から state 反映まで検証する |
-| `Command` / `MacroRuntime` の swbt 依存 | swbt 未導入 | 引き続き swbt を import しない |
+| swbt run | 未導入 | `nyxpy run sample --controller swbt ...` で runtime port を注入できる |
+| serial protocol 生成 | CLI が常に実行 | swbt backend では 0 回 |
+| adapter CLI | 未導入 | `nyxpy swbt adapters [--json]` で no-open discovery |
+| pair/reconnect CLI | 未導入 | `nyxpy swbt pair` と `nyxpy swbt reconnect` で明示 lifecycle |
+| CLI choices | 手書きになり得る | `supported_controller_models()` から導出 |
 
 ### 1.5 着手条件
 
-- local_022 で `SerialControllerConfig`、`SwbtControllerConfig`、`ControllerConfig`、settings 正規化、`SerialControllerOutputPortFactory` 改名が実装済みであること。
-- local_023 で `SwbtControllerOutputPortFactory`、`SwbtControllerOutputPort`、`DummySwbtGamepadService` 相当のテスト用 service が実装済みであること。
-- `docs/architecture/swbt-integration/` の判断どおり、旧 factory 名の alias、互換 import、`DeprecationWarning` を追加しないこと。
-- 既存 serial backend の CLI / runtime テストが、local_022 と local_023 の変更後も実行可能であること。
+- `local_022` の config、IMU、adapter discovery が完了している。
+- `local_023` の session、mapper、port、factory が完了している。
+- `swbt-python` 未導入環境では、`--controller swbt` または `nyxpy swbt ...` 実行時にだけ dependency missing を表示する。
+- CLI に clipboard / command copy / GUI 連携用 preview は追加しない。
 
 ## 2. 対象ファイル
 
 | ファイル | 変更種別 | 変更内容 |
 |----------|----------|----------|
-| `src/nyxpy/framework/core/runtime/builder.py` | 変更 | `create_device_runtime_builder()` を `ControllerConfig` ベースの controller factory 選択へ更新し、`make_controller_port_factory()` を追加する |
-| `src/nyxpy/cli/run_cli.py` | 変更 | `--controller` と `--bt-*` option を追加し、backend 解決後に runtime builder を作成する |
-| `src/nyxpy/__main__.py` | 変更 | `add_run_arguments()` 由来の `nyxpy run` parser で新 option を利用できることを維持する |
-| `tests/unit/cli/test_run_cli_parser.py` | 変更 | CLI parser と `cli_main()` の backend 別挙動を検証する |
-| `tests/unit/cli/test_main.py` | 変更 | `create_runtime_builder()` の新 signature と serial baudrate 解決を検証する |
-| `tests/integration/test_cli_runtime_adapter.py` | 変更 | CLI adapter が secrets / settings / controller config を runtime builder へ正しく渡すことを検証する |
-| `tests/unit/framework/runtime/test_runtime_builder.py` | 変更 | `create_device_runtime_builder()` が `ControllerConfig` から serial / swbt factory を選ぶことを検証する |
-| `tests/integration/test_swbt_runtime_cli_integration.py` | 新規 | dummy swbt service を使い、CLI 相当設定から runtime 実行までを検証する |
+| `src/nyxpy/framework/core/runtime/builder.py` | 変更 | `ControllerConfig` ベースの factory 選択と `make_controller_port_factory()` を追加する |
+| `src/nyxpy/framework/core/io/device_factories.py` | 変更 | 既存 serial factory を `SerialControllerOutputPortFactory` として扱い、旧名 alias を残さない |
+| `src/nyxpy/cli/run_cli.py` | 変更 | `--controller`、`--swbt-adapter`、`--swbt-controller-type`、`--swbt-key-store`、`--swbt-timeout` を追加する |
+| `src/nyxpy/cli/swbt_cli.py` | 新規 | `adapters`、`pair`、`reconnect` subcommand の処理を実装する |
+| `src/nyxpy/__main__.py` | 変更 | `swbt` subparser を追加し、`swbt_cli.py` へ委譲する |
+| `tests/unit/framework/runtime/test_runtime_builder.py` | 変更 | backend 別 factory 選択を検証する |
+| `tests/unit/cli/test_run_cli_parser.py` | 変更 | `nyxpy run` の swbt option と serial validation を検証する |
+| `tests/unit/cli/test_swbt_cli.py` | 新規 | `adapters`、`pair`、`reconnect` CLI を fake service で検証する |
+| `tests/integration/test_swbt_runtime_cli_integration.py` | 新規 | dummy session で `Command.press()` / `Command.imu()` が runtime から届くことを検証する |
 
 ## 3. 設計方針
 
 ### アーキテクチャ上の位置づけ
 
-`MacroRuntimeBuilder` 本体は現行どおり `PortFactory[ControllerOutputPort]` を受ける。backend 選択は `MacroRuntimeBuilder.build()` 内では行わず、`create_device_runtime_builder()` の構成処理で完了させる。
-
-`run_cli.py` は CLI option と settings snapshot を統合して `ControllerConfig` を作る。`serial` の場合だけ `ProtocolFactory.resolve_baudrate()` と `ProtocolFactory.create_protocol()` を呼び、`swbt` の場合は `SwbtControllerOutputPortFactory` へ必要な設定を渡す。
+backend 選択は runtime builder を作る構成処理で完了させる。`MacroRuntimeBuilder.build()`、`ExecutionContext`、`Command` は backend 種別を判定しない。
 
 ### 公開 API 方針
 
-`nyxpy run` には次の option を追加する。
-
-| option | 用途 | backend |
-|--------|------|---------|
-| `--controller serial|swbt` | controller backend の実行時選択 | 共通 |
-| `--bt-adapter TEXT` | swbt adapter 名 | swbt |
-| `--bt-pair` | pairing を一度許可する | swbt |
-| `--bt-key-store PATH` | swbt bond 情報の保存先 | swbt |
-| `--bt-timeout FLOAT` | swbt 接続 timeout 秒 | swbt |
-| `--bt-diagnostics PATH` | swbt diagnostics trace 出力先 | swbt |
-
-`--controller` の parser default は `None` とし、未指定時は settings 正規化に委ねる。settings にも backend がなければ local_022 の既定値として `serial` になる。これにより、設定ファイルで `controller.backend = "swbt"` を選んだ workspace を CLI の暗黙 default が上書きしない。
+`nyxpy run` の `--controller` は `serial|swbt` を受ける。未指定時は settings の `controller.backend` に従う。`nyxpy swbt` は developer / operator 向け CLI であり、GUI 連携用の clipboard 出力は持たない。
 
 ### 後方互換性
 
-破壊的変更あり。`create_runtime_builder()` と `create_device_runtime_builder()` の controller 引数は `ControllerConfig` を中心に再設計する。Project NyX のフレームワーク本体はアルファ版として扱うため、旧 signature の shim は追加しない。呼び出し元とテストを同じ変更で正 API へ更新する。
-
-CLI の利用者向け挙動では、既存の serial 実行形を維持する。
-
-```console
-nyxpy run sample_macro --serial COM3 --capture Camera1
-nyxpy run sample_macro --controller serial --serial COM3 --capture Camera1
-```
-
-`--serial` は parser では必須にしない。`serial` backend の構成時に未指定なら `ConfigurationError` とし、`swbt` backend では未指定でも実行可能にする。`swbt` backend で明示された `--serial`、`--protocol`、`--baud` は serial factory へ渡さず、protocol 生成も行わない。
+`nyxpy run sample --serial COM3 --capture Camera1` は維持する。`--serial` は parser 必須ではなく backend validation で必須にする。swbt backend では `--serial`、`--protocol`、`--baud` を controller factory へ渡さない。
 
 ### レイヤー構成
 
-`swbt-python` の import は local_023 の `hardware` / `io` 層に閉じる。`run_cli.py` は `SwbtControllerConfig` と `SwbtControllerOutputPortFactory` までを扱い、`swbt.SwitchGamepad` を直接 import しない。
-
-`Command`、`MacroRuntime`、`ExecutionContext` は swbt を知らない。CLI の backend 分岐は composition root の責務であり、マクロ API や runtime 実行中の分岐には持ち込まない。
+`run_cli.py` と `swbt_cli.py` は `hardware/swbt` の service / factory を使うが、`swbt-python` の controller class を直接 import しない。`__main__.py` は subparser と委譲だけを担当する。
 
 ### 性能要件
 
 | 指標 | 目標値 |
 |------|--------|
-| serial backend の device discovery | 現行どおり builder 作成時に一度実行する |
-| swbt backend の serial discovery | controller 用には実行しない。capture discovery は既存 frame source 用に維持する |
-| swbt backend の protocol factory 呼び出し | 0 回 |
-| dummy swbt runtime integration | 実機なしで 1 秒以内に完了する短い smoke test とする |
+| `--controller swbt` の serial protocol 生成 | 0 回 |
+| `nyxpy swbt adapters` | adapter open なし |
+| dummy runtime integration | 実機なしで短時間に完了 |
+| runtime shutdown | factory close callback が 1 回実行される |
 
 ### 並行性・スレッド安全性
 
-本仕様の runtime / CLI 実装は、`SwbtGamepadService` の event loop thread や lock を直接実装しない。local_023 の factory と service が thread safety を担う。`create_device_runtime_builder()` は factory の lifetime を `shutdown_callbacks` に登録し、CLI の `finally` で `runtime_builder.shutdown()` を呼ぶ現行構造を維持する。
+CLI は同期処理として session / factory を呼ぶ。event loop thread は `SwbtControllerSession` が所有する。CLI 終了時は `finally` で runtime builder または factory を close する。
 
 ## 4. 実装仕様
 
-### 公開インターフェース
+### runtime factory 選択
 
 ```python
 def make_controller_port_factory(
@@ -126,208 +97,94 @@ def make_controller_port_factory(
     serial_factory: SerialControllerOutputPortFactory | None,
     swbt_factory: SwbtControllerOutputPortFactory | None,
     allow_dummy: Callable[[RuntimeBuildRequest], bool],
-    timeout_sec: float,
-) -> PortFactory[ControllerOutputPort]:
-    """ControllerConfig から runtime 用 controller port factory を作る。"""
-
-
-def create_device_runtime_builder(
-    *,
-    project_root: Path,
-    registry: MacroRegistry,
-    notification_handler,
-    logger: LoggerPort,
-    controller_config: ControllerConfig | None = None,
-    device_discovery: DeviceDiscoveryService | None = None,
-    serial_controller_factory: SerialControllerOutputPortFactory | None = None,
-    swbt_controller_factory: SwbtControllerOutputPortFactory | None = None,
-    frame_source_factory: FrameSourcePortFactory | None = None,
-    capture_name: str | None = None,
-    detection_timeout_sec: float = 2.0,
-    settings: SettingsSnapshot | None = None,
-    lifetime_allow_dummy: bool | None = None,
-) -> MacroRuntimeBuilder:
-    """Device discovery と controller config を Runtime builder へ接続する。"""
-
-
-def create_runtime_builder(
-    logger: LoggerPort,
-    *,
-    project_root: pathlib.Path | None = None,
-    controller_config: ControllerConfig | None = None,
-    capture_name: str | None = None,
-    detection_timeout_sec: float = 2.0,
-    settings_store: SettingsStore | None = None,
-    secrets_store: SecretsStore | None = None,
-    device_discovery: DeviceDiscoveryService | None = None,
-    serial_controller_factory: SerialControllerOutputPortFactory | None = None,
-    swbt_controller_factory: SwbtControllerOutputPortFactory | None = None,
-    frame_source_factory: FrameSourcePortFactory | None = None,
-) -> MacroRuntimeBuilder:
-    """CLI で利用する Runtime builder を作成する。"""
+    detection_timeout_sec: float,
+) -> PortFactory[ControllerOutputPort]: ...
 ```
 
-`create_runtime_builder()` から `protocol` の必須引数を外す。serial backend では `controller_config.protocol` から protocol を作り、`SerialControllerOutputPortFactory` を構成する。swbt backend では protocol を作らず、local_023 の `SwbtControllerOutputPortFactory` を使う。
+`SerialControllerConfig` では serial factory を使う。`SwbtControllerConfig` では swbt factory を使い、`factory.create(config=config, allow_dummy=..., timeout_sec=config.connect_timeout_sec)` を呼ぶ。swbt branch では `ProtocolFactory.resolve_baudrate()` と `ProtocolFactory.create_protocol()` を呼ばない。
 
-### controller factory 選択
+### `nyxpy run` option
 
-`make_controller_port_factory()` は `ControllerConfig` の型で分岐する。分岐後に返す callable は `MacroRuntimeBuilder` へ渡される通常の `PortFactory[ControllerOutputPort]` である。
+| option | 型 | backend | 説明 |
+|--------|----|---------|------|
+| `--controller serial|swbt` | `str | None` | 共通 | controller backend override |
+| `--serial` | `str | None` | serial | serial device override |
+| `--protocol` | `str | None` | serial | protocol override |
+| `--baud` | `int | None` | serial | baudrate override |
+| `--swbt-adapter` | `str | None` | swbt | adapter override |
+| `--swbt-controller-type` | `str | None` | swbt | controller type override |
+| `--swbt-key-store` | `Path | None` | swbt | key store override |
+| `--swbt-timeout` | `float | None` | swbt | connect timeout override |
+| `--swbt-diagnostics` | `Path | None` | swbt | diagnostics trace path |
 
-```python
-match config:
-    case SerialControllerConfig():
-        return lambda request, _definition: serial_factory.create(
-            name=config.device,
-            baudrate=config.baudrate,
-            allow_dummy=allow_dummy(request),
-            timeout_sec=timeout_sec,
-        )
-    case SwbtControllerConfig():
-        return lambda request, _definition: swbt_factory.create(
-            allow_dummy=allow_dummy(request),
-            timeout_sec=config.connect_timeout_sec,
-        )
+`--swbt-controller-type` の choices は `supported_controller_models()` から作る。dependency missing で choices を作れない場合は swbt backend 実行時に `NYX_SWBT_DEPENDENCY_MISSING` として失敗する。
+
+### `nyxpy swbt adapters`
+
+```console
+nyxpy swbt adapters
+nyxpy swbt adapters --json
 ```
 
-`serial_factory` が `None` のまま `SerialControllerConfig` を受けた場合、`create_device_runtime_builder()` は `ProtocolFactory.create_protocol(config.protocol)` を使って `SerialControllerOutputPortFactory` を作る。`swbt_factory` が `None` のまま `SwbtControllerConfig` を受けた場合、local_023 の factory constructor へ `SwbtControllerConfig` を渡して作る。
+標準出力には adapter `name`、display name、aliases、VID/PID を出す。`--json` は `SwbtAdapterView` の machine-readable 表現を出す。列挙だけを行い、pairing / reconnect / report loop を開始しない。
 
-### CLI option と settings 統合
+### `nyxpy swbt pair` / `reconnect`
 
-`add_run_arguments()` は `--serial` の `required=True` を外し、`--controller` と `--bt-*` を追加する。CLI option の default は、settings を上書きしない値にする。
+```console
+nyxpy swbt pair --adapter usb:0 --controller-type pro-controller --key-store .nyxpy/swbt/pro-controller-bond.json
+nyxpy swbt reconnect --adapter usb:0 --controller-type pro-controller --key-store .nyxpy/swbt/pro-controller-bond.json
+```
 
-| パラメータ | 型 | デフォルト | 説明 |
-|------------|-----|-----------|------|
-| `args.controller` | `str | None` | `None` | CLI 指定時だけ `controller.backend` を上書きする |
-| `args.serial` | `str | None` | `None` | serial backend の device override。swbt では使わない |
-| `args.protocol` | `str | None` | `None` | serial backend の protocol override。swbt では使わない |
-| `args.baud` | `int | None` | `None` | serial backend の baudrate override。swbt では使わない |
-| `args.capture` | `str` | 必須 | frame source 用 capture 名。controller backend に関係なく必須 |
-| `args.bt_adapter` | `str | None` | `None` | swbt adapter override |
-| `args.bt_pair` | `bool` | `False` | swbt pairing 許可 override。指定時のみ `True` |
-| `args.bt_key_store` | `pathlib.Path | None` | `None` | swbt key store override |
-| `args.bt_timeout` | `float | None` | `None` | swbt 接続 timeout override |
-| `args.bt_diagnostics` | `pathlib.Path | None` | `None` | swbt diagnostics path override |
-
-settings snapshot から local_022 の `controller_config_from_settings()` で基準 config を作り、CLI override を重ねる。`--bt-pair` は flag なので、未指定なら settings の `controller.swbt.allow_pairing` を維持し、指定時だけ `True` にする。
-
-### CLI 実行順序
-
-`cli_main()` は次の順序で処理する。
-
-1. workspace と logging を初期化する。
-2. settings store と secrets store を開く。
-3. settings snapshot から `ControllerConfig` を作る。
-4. CLI option を `ControllerConfig` へ重ねる。
-5. `serial` backend の場合だけ baudrate と protocol を解決する。
-6. `swbt` backend の場合は protocol factory を呼ばずに runtime builder を作る。
-7. `RuntimeBuildRequest(entrypoint="cli")` で macro を実行する。
-8. `finally` で `runtime_builder.shutdown()` と logging close を行う。
-
-この順序により、`--controller swbt` の smoke test で `ProtocolFactory.resolve_baudrate()` と `create_protocol()` を例外化しても実行が成功する。
+`pair` は `SwbtControllerOutputPortFactory.pair(config)` を呼ぶ。`reconnect` は `factory.reconnect(config)` を呼ぶ。どちらも最後に factory を close し、close 時に neutral を試みる。
 
 ### エラーハンドリング
 
-| 例外クラス | 発生条件 |
-|------------|----------|
-| `ConfigurationError` | `--controller` が未対応値、serial backend で device 未指定、swbt factory 作成失敗、swbt extra 未導入 |
-| `ConfigurationError` | `--bt-timeout` が `0` 以下、または local_022 の settings validation に反する値 |
-| `ValueError` | `--baud` が整数として parse できないなど argparse で捕捉される CLI 入力 |
-| `ExceptionGroup` | `runtime_builder.shutdown()` で複数 port / factory close が失敗した場合。現行 cleanup logging に任せる |
-
-serial backend で device 未指定の場合は、parser error ではなく `ConfigurationError` として扱う。これにより parser は `swbt` 実行にも同じ形で使える。
+| 条件 | 動作 |
+|------|------|
+| serial backend で serial device 未指定 | `ConfigurationError` を表示し終了 code 1 |
+| swbt extra 未導入 | `NYX_SWBT_DEPENDENCY_MISSING` を表示 |
+| adapter 未選択 / 不一致 | `NYX_SWBT_ADAPTER_*` を表示 |
+| key store 不正 | `NYX_SWBT_KEY_STORE_INVALID` を表示 |
+| pairing / reconnect timeout | `NYX_SWBT_CONNECTION_TIMED_OUT` を表示 |
+| `runtime_builder.shutdown()` 失敗 | technical log に残し、既存 cleanup 方針に従う |
 
 ### シングルトン管理
 
-新規グローバル singleton は追加しない。CLI 実行ごとに `create_runtime_builder()` が factory を構成し、`cli_main()` の `finally` で `runtime_builder.shutdown()` を呼ぶ。settings store と secrets store は既存の workspace lifetime に従い、swbt service lifetime は local_023 の `SwbtControllerOutputPortFactory` が所有する。
+新規グローバル singleton は追加しない。CLI 実行ごとに factory を生成し、`finally` で close する。runtime builder が factory lifetime を所有する場合は shutdown callback に登録する。
 
 ## 5. テスト方針
 
 | テスト種別 | テスト名 | 検証内容 |
 |------------|----------|----------|
-| ユニット | `test_cli_parser_accepts_swbt_without_serial` | `--controller swbt --capture Camera1` を parse でき、`args.serial is None` になる |
-| ユニット | `test_cli_parser_keeps_serial_options_optional_at_parse_time` | parser 段階では `--serial` なしでも失敗せず、backend validation へ進められる |
-| ユニット | `test_cli_main_serial_resolves_protocol_and_baudrate` | `serial` backend では `ProtocolFactory.resolve_baudrate()` と `create_protocol()` が呼ばれる |
-| ユニット | `test_cli_main_swbt_does_not_resolve_serial_protocol` | `swbt` backend では `resolve_baudrate()` と `create_protocol()` が呼ばれない |
-| ユニット | `test_cli_main_swbt_passes_bt_options_to_controller_config` | `--bt-adapter`、`--bt-pair`、`--bt-key-store`、`--bt-timeout`、`--bt-diagnostics` が `SwbtControllerConfig` に反映される |
-| ユニット | `test_create_runtime_builder_builds_serial_factory_from_config` | `SerialControllerConfig` では serial factory が使われる |
-| ユニット | `test_create_runtime_builder_builds_swbt_factory_from_config` | `SwbtControllerConfig` では swbt factory が使われ、serial factory を要求しない |
-| ユニット | `test_make_controller_port_factory_selects_serial` | `SerialControllerConfig` から serial `PortFactory` が作られる |
-| ユニット | `test_make_controller_port_factory_selects_swbt` | `SwbtControllerConfig` から swbt `PortFactory` が作られる |
-| 結合 | `test_runtime_builder_uses_swbt_factory_without_protocol_factory` | swbt config の runtime build で serial protocol factory が呼ばれない |
-| 結合 | `test_cli_swbt_runtime_runs_press_a_with_dummy_service` | dummy swbt service で `Command.press(Button.A)` の state と neutral が記録される |
-| 結合 | `test_command_runtime_context_do_not_import_swbt` | `Command`、`MacroRuntime`、`ExecutionContext` が swbt module を import しない |
+| ユニット | `test_run_parser_accepts_swbt_without_serial` | `--controller swbt` で `--serial` なし parse が通る |
+| ユニット | `test_run_serial_requires_serial_at_validation` | serial backend だけ serial device を要求する |
+| ユニット | `test_run_swbt_does_not_resolve_serial_protocol` | swbt backend で serial protocol factory が呼ばれない |
+| ユニット | `test_run_swbt_cli_overrides_settings` | adapter、controller type、key store、timeout を config へ反映 |
+| ユニット | `test_make_controller_port_factory_selects_swbt` | swbt config で swbt factory を選ぶ |
+| ユニット | `test_swbt_adapters_cli_prints_json` | fake discovery の JSON 出力 |
+| ユニット | `test_swbt_pair_cli_calls_factory_pair` | pair CLI が明示 pairing だけを呼ぶ |
+| ユニット | `test_swbt_reconnect_cli_calls_factory_reconnect` | reconnect CLI が明示 reconnect だけを呼ぶ |
+| 結合 | `test_swbt_runtime_runs_press_and_imu_with_dummy_session` | dummy session に Button と IMU state が届く |
+| 結合 | `test_command_runtime_context_do_not_import_swbt` | `Command` / `MacroRuntime` / `ExecutionContext` が swbt を import しない |
 
-実装後の通常検証は次を使う。
+検証コマンド:
 
 ```console
 uv run ruff format .
 uv run ruff check .
 uv run ty check src/nyxpy --output-format concise --no-progress
-uv run pytest tests/unit/cli tests/unit/framework/runtime tests/integration/test_cli_runtime_adapter.py tests/integration/test_swbt_runtime_cli_integration.py -m "not realdevice and not swbt"
+uv run pytest tests/unit/cli/test_run_cli_parser.py tests/unit/cli/test_swbt_cli.py tests/unit/framework/runtime/test_runtime_builder.py tests/integration/test_swbt_runtime_cli_integration.py -m "not realdevice and not swbt"
 ```
-
-本仕様では実機検証を実施しない。実機 pairing、reconnect、button / stick 反映は local_021 の M6 へ渡す。
 
 ## 6. 実装チェックリスト
 
-- [ ] `create_device_runtime_builder()` の controller 引数を `ControllerConfig` ベースへ更新する。
-- [ ] `make_controller_port_factory()` を追加し、serial / swbt の factory 選択を runtime builder 構成時に閉じる。
-- [ ] `create_runtime_builder()` から必須 `protocol` 引数を外し、settings snapshot と CLI override から `ControllerConfig` を渡す形へ更新する。
-- [ ] `add_run_arguments()` に `--controller` と `--bt-*` option を追加する。
-- [ ] `--serial` の parser 必須指定を外し、serial backend の validation で必須にする。
-- [ ] `swbt` backend で `ProtocolFactory.resolve_baudrate()` と `create_protocol()` を呼ばない実装にする。
-- [ ] `swbt` backend で `--bt-adapter`、`--bt-pair`、`--bt-key-store`、`--bt-timeout`、`--bt-diagnostics` が `SwbtControllerConfig` に反映されるようにする。
-- [ ] `nyxpy run` と `nyxpy.__main__` 経由の parser が同じ option を使うことを確認する。
-- [ ] 既存 serial backend の CLI unit test を新 signature に更新する。
-- [ ] dummy swbt service を使った runtime integration test を追加する。
-- [ ] `Command`、`MacroRuntime`、`ExecutionContext` が swbt を import しないことを確認する。
-- [ ] `uv run ruff format .` を実行する。
-- [ ] `uv run ruff check .` を実行する。
-- [ ] `uv run ty check src/nyxpy --output-format concise --no-progress` を実行する。
-- [ ] 対象 unit / integration test を実行する。
-
-## 7. 親計画との依存関係
-
-この仕様は `spec/agent/wip/local_021/SWBT_CONTROLLER_BACKEND.md` の M4 に対応する。local_022 の controller config と settings 正規化、local_023 の swbt port / service / factory が完了していることを前提にする。
-
-local_022 から受け取るもの:
-
-| 成果 | 利用箇所 |
-|------|----------|
-| `SerialControllerConfig` | serial backend の device / protocol / baudrate 解決 |
-| `SwbtControllerConfig` | swbt backend の adapter / pairing / timeout / diagnostics 解決 |
-| `controller_config_from_settings()` | settings snapshot からの基準 config 作成 |
-| `SerialControllerOutputPortFactory` | serial runtime port factory |
-
-local_023 から受け取るもの:
-
-| 成果 | 利用箇所 |
-|------|----------|
-| `SwbtControllerOutputPortFactory` | swbt runtime port factory |
-| `DummySwbtGamepadService` または同等の fake | runtime integration test |
-| `SwbtControllerOutputPort` | `ControllerOutputPort` として runtime に注入される具象 port |
-| swbt 例外変換 | CLI で `ConfigurationError` としてユーザ向けに表示する |
-
-## 8. 完了後に次へ渡す成果
-
-local_025 以降の GUI 仕様へ次を渡す。
-
-| 成果 | 受け渡し先での用途 |
-|------|--------------------|
-| `create_device_runtime_builder(controller_config=...)` | GUI backend 選択から runtime builder を再生成する入口 |
-| `create_runtime_builder(..., controller_config=...)` の CLI 実装例 | GUI service layer の構成処理の参考 |
-| swbt factory lifetime の `shutdown_callbacks` 登録 | GUI backend 切り替え時の古い connection close |
-| dummy swbt runtime integration test | GUI なしで runtime injection が成立している証跡 |
-| `--controller swbt` が serial protocol を通らないテスト | GUI 実装でも `ProtocolFactory` へ swbt を入れないための回帰防止 |
-
-実機検証仕様へ次を渡す。
-
-| 成果 | 受け渡し先での用途 |
-|------|--------------------|
-| CLI の `--bt-adapter` / `--bt-key-store` / `--bt-pair` | pairing と reconnect の手動確認コマンド |
-| `--bt-diagnostics` | 実機検証時の trace 保存 |
-| dummy integration の期待 state | 実機入力反映と比較する最小操作列 |
-
-## 9. 未解決事項
-
-本仕様の実装に入る前に追加の意思決定が必要な項目はない。stick Y 軸の既定値、短押し時の flush 要否、GUI diagnostics の既定保存先は local_021 の M6 または GUI 仕様の判断対象であり、runtime / CLI の構成順序には影響しない。
+- [ ] `SerialControllerOutputPortFactory` を正名として扱い、旧名 alias を残さない。
+- [ ] `make_controller_port_factory()` を追加し、backend 分岐を構成処理に閉じる。
+- [ ] `create_device_runtime_builder()` と `create_runtime_builder()` を `ControllerConfig` ベースへ更新する。
+- [ ] swbt backend で serial protocol 生成を呼ばないことをテストする。
+- [ ] `nyxpy run` に swbt option を追加する。
+- [ ] `nyxpy swbt adapters` を追加し、adapter refresh が接続を開始しないことをテストする。
+- [ ] `nyxpy swbt pair` と `nyxpy swbt reconnect` を追加する。
+- [ ] `supported_controller_models()` から CLI choices を作る。
+- [ ] runtime shutdown で swbt factory close が呼ばれることを確認する。
+- [ ] dummy session を使った runtime integration test を追加する。

--- a/spec/agent/wip/local_025/SWBT_GUI_SHARED_SERVICE.md
+++ b/spec/agent/wip/local_025/SWBT_GUI_SHARED_SERVICE.md
@@ -1,259 +1,199 @@
 # swbt GUI / shared service 仕様書
 
-> **対象モジュール**: `src/nyxpy/gui/`, `src/nyxpy/framework/core/runtime/`, `src/nyxpy/framework/core/io/`
-> **目的**: GUI から `serial` / `swbt` controller backend を選択し、GUI manual input と macro runtime が同じ `SwbtGamepadService` 接続を共有する。
-> **親計画**: `spec/agent/wip/local_021/SWBT_CONTROLLER_BACKEND.md`
-> **関連ドキュメント**: `docs/architecture/swbt-integration/runtime-composition.md`, `docs/architecture/swbt-integration/configuration-cli-gui.md`, `docs/architecture/swbt-integration/controller-port-contract.md`, `docs/architecture/swbt-integration/testing-rollout.md`
-> **破壊的変更**: GUI 内部の controller 設定構成を backend 選択式へ変える。既存 serial 設定は `controller.serial.*` へ正規化して読み続ける。
-
 ## 1. 概要
 
 ### 1.1 目的
 
-GUI の controller 出力を serial 固定から backend 選択式へ変更する。swbt backend では、設定画面、接続メニュー、manual input、macro runtime が同じ `SwbtControllerOutputPortFactory` と `SwbtGamepadService` を使い、runtime 開始のたびに Bluetooth 接続を作り直さない。
+GUI から `serial` / `swbt` controller backend を選択し、adapter refresh、controller type 選択、pair、reconnect、disconnect を操作できるようにする。manual input は既存 `VirtualControllerModel -> ControllerOutputPort` 経路を使い、macro runtime と同じ adapter を同時に開かないように制御する。
 
 ### 1.2 用語定義
 
 | 用語 | 定義 |
 |------|------|
-| controller backend | GUI と runtime が使う controller 出力方式。`serial` または `swbt` |
-| `SwbtGamepadService` | `swbt-python` の `SwitchGamepad` lifecycle と非同期処理を NyX の同期 GUI/runtime へ接続する service |
-| `SwbtControllerOutputPortFactory` | `SwbtGamepadService` を所有し、manual input 用 port と runtime 用 port を生成する factory |
-| manual input | GUI の仮想 controller から直接 `ControllerOutputPort` へ送る入力 |
-| runtime input | `MacroRuntime` が `ExecutionContext.controller` 経由で送る入力 |
-| adapter refresh | GUI が `swbt-probe adapters --json` を subprocess として実行し、候補 adapter を表示する操作 |
-| pair once | GUI 操作 1 回に限って `allow_pairing=True` で接続を試みる操作 |
-| reconnect | 保存済み key store を使い、`allow_pairing=False` で接続を試みる操作 |
-| disconnect | GUI が共有 service の transport を明示的に閉じる操作 |
-| diagnostics path | `swbt-python` diagnostics trace の出力先。service lifetime に紐づく |
+| GUI lifetime port | GUI manual input 用に runtime builder から取得する `ControllerOutputPort` |
+| manual input | GUI の仮想 controller から送る button、D-pad、stick、release all |
+| adapter refresh | `SwbtAdapterDiscoveryService.list_adapters()` を呼び、候補を表示する操作 |
+| pair | `SwbtControllerOutputPortFactory.pair(config)` による明示 pairing |
+| reconnect | 保存済み key store による明示 reconnect |
+| disconnect | GUI lifetime port と swbt session を閉じ、controller を `None` に戻す操作 |
+| deferred settings apply | macro 実行中の backend / adapter 変更を実行終了後へ遅延する処理 |
 
 ### 1.3 背景・問題
 
-現行 GUI の `GuiAppServices._replace_runtime_builder()` は `ProtocolFactory.create_protocol()` と `ControllerOutputPortFactory` を常に作成し、serial controller を前提に `create_device_runtime_builder()` へ渡している。`VirtualControllerModel` は macro 実行状態を知らないため、manual input と runtime が同時に controller port を更新できる。
+現行 GUI は serial controller を前提に runtime builder を作り、`VirtualControllerModel` へ controller port を差し込む。swbt backend でもこの経路を使えるが、pairing、reconnect、adapter refresh は入力送信とは別の lifecycle 操作である。GUI 専用の `SwbtManualInputSession` を作ると、既存 model と責務が二重化する。
 
-swbt backend では Bluetooth 接続、pairing、reconnect、diagnostics trace が service lifetime を持つ。GUI と runtime で別 service を作ると、manual input で接続済みでも macro 開始時に再接続が走り、backend 切り替え時の close 責務も曖昧になる。
+swbt の GUI lifetime port と macro runtime port が同時に同じ adapter を使うと、USB transport と入力状態が競合する。macro start 前に manual port を解放し、runtime 終了後に自動 reconnect しない方針を明示する必要がある。
 
 ### 1.4 期待効果
 
 | 指標 | 現状 | 目標 |
 |------|------|------|
-| GUI controller backend | serial 固定 | `serial` / `swbt` を設定と接続メニューから選択できる |
-| macro 開始時の swbt 接続 | backend 未導入 | 既存 service が接続済みなら再接続しない |
-| manual input と runtime の同時更新 | GUI 側に明示制御なし | macro 実行中は manual input を無効化する |
-| adapter 確認 | GUI から確認不可 | `swbt-probe adapters --json` の結果を 5 秒以内に表示する |
-| backend 切り替え時の旧接続 | serial 前提の builder shutdown | runtime builder 再生成時に旧 factory を close し、transport を閉じる |
-| diagnostics trace | GUI 方針未定 | 初期値は無効。path 設定時だけ service に渡す |
+| backend 選択 | serial 固定 | GUI で `serial` / `swbt` を選択できる |
+| adapter refresh | 未導入 | adapter 候補を列挙し、pair/reconnect を開始しない |
+| manual input | serial port 前提 | `VirtualControllerModel` に swbt port を差し込む |
+| macro 実行中 | manual input と runtime の排他なし | manual input、pair、reconnect、disconnect を無効化する |
+| GUI scope | 未定義 | diagnostics editor、controller color editor、IMU editor、CLI copy は置かない |
 
 ### 1.5 着手条件
 
-- `local_022` foundation により `controller.*` settings schema と既存 serial 設定の正規化が実装済みである。
-- `local_023` core により `SwbtGamepadService`、`SwbtControllerOutputPortFactory`、`SwbtControllerConfig`、swbt 例外変換が実装済みである。
-- `local_024` runtime/CLI により backend-aware な runtime builder 構成と factory lifetime が利用できる。
-- swbt backend で `SerialProtocolInterface` と `ProtocolFactory` を使わない構成が既存テストで確認済みである。
-- GUI 着手前に `uv run pytest tests/unit/ tests/integration/ -m "not realdevice and not swbt"` が通る状態である。
+- `local_024` で backend-aware runtime builder と swbt CLI が実装済みである。
+- `local_023` で `SwbtControllerOutputPortFactory` が pair/reconnect/disconnect/status を提供している。
+- GUI は `swbt-python` を直接 import しない。
+- 実機検証は `local_026` に残し、本仕様では fake factory / dummy session で検証する。
 
 ## 2. 対象ファイル
 
 | ファイル | 変更種別 | 変更内容 |
 |----------|----------|----------|
-| `src/nyxpy/gui/app_services.py` | 変更 | controller backend 設定を runtime builder 更新対象に含め、backend-aware factory を保持し、swbt の pair once / reconnect / disconnect / status 操作を提供する |
-| `src/nyxpy/gui/main_window.py` | 変更 | 接続メニューと状態表示を controller backend 対応にし、macro 実行中の manual input 無効化と backend 切り替え後の builder 再生成を制御する |
-| `src/nyxpy/gui/models/virtual_controller_model.py` | 変更 | manual input の有効/無効状態を持ち、無効化時に controller を neutral へ戻す |
-| `src/nyxpy/gui/panes/virtual_controller_pane.py` | 変更 | 仮想 controller widget 群の有効状態を `VirtualControllerModel` と同期する |
-| `src/nyxpy/gui/dialogs/settings/device_tab.py` | 変更 | controller backend 選択、serial 設定、swbt 設定、adapter refresh、diagnostics path 入力を追加する |
-| `src/nyxpy/gui/swbt_probe.py` | 新規 | `swbt-probe adapters --json` の subprocess 実行、JSON parse、GUI 表示用 result 変換を行う |
-| `tests/gui/test_swbt_gui_shared_service.py` | 新規 | GUI service lifetime、manual input guard、settings dialog、adapter refresh の GUI 側仕様を検証する |
-| `tests/gui/test_swbt_probe.py` | 新規 | `swbt_probe.py` の subprocess result parse と error handling を検証する |
+| `src/nyxpy/gui/app_services.py` | 変更 | controller backend 設定を runtime builder 更新対象に含め、swbt discovery / pair / reconnect / disconnect / status を提供する |
+| `src/nyxpy/gui/main_window.py` | 変更 | 接続メニュー、状態表示、macro start 前の manual port release/close、deferred apply を制御する |
+| `src/nyxpy/gui/models/virtual_controller_model.py` | 変更 | manual input enabled 状態と `set_controller(None)` 時の neutral 処理を整理する |
+| `src/nyxpy/gui/panes/virtual_controller_pane.py` | 変更 | manual input disabled 状態を widget 有効状態へ反映する |
+| `src/nyxpy/gui/dialogs/settings/device_tab.py` | 変更 | backend selector、controller type、adapter combo、refresh、key store path、pair/reconnect/disconnect/status を追加する |
+| `tests/gui/test_swbt_gui_shared_service.py` | 新規 | app service、main window、virtual controller の swbt 経路を検証する |
+| `tests/gui/test_settings_tabs.py` | 変更 | swbt settings UI の表示、有効/無効、保存を検証する |
+| `tests/gui/test_virtual_controller_model.py` | 変更 | controller `None`、manual disabled、release all の挙動を検証する |
 
 ## 3. 設計方針
 
 ### アーキテクチャ上の位置づけ
 
-GUI は controller backend の composition root として動作する。`GuiAppServices` が `GlobalSettings` / `SecretsSettings` を読み、`SwbtControllerConfig` または `SerialControllerConfig` へ正規化された結果を runtime builder へ渡す。
-
-`SwbtGamepadService` の lifetime は `SwbtControllerOutputPortFactory` が所有する。GUI は service を直接生成せず、factory または factory が公開する high-level operation へ pair once / reconnect / disconnect を委譲する。
+GUI は `nyxpy.framework.*` を利用する上位層である。`GuiAppServices` が settings を `ControllerConfig` へ正規化し、runtime builder と `SwbtControllerOutputPortFactory` へ委譲する。Widget 層は swbt の `InputState`、`GamepadStatus`、controller class を扱わない。
 
 ### 公開 API 方針
 
-マクロ向け `Command` API は変更しない。GUI 内部 API として、`GuiAppServices` に swbt 操作用メソッドを追加する。これらは GUI から呼ぶための application service API であり、framework core の公開 API にはしない。
-
-`VirtualControllerModel` には `set_manual_input_enabled()` を追加する。manual input 無効時は UI 操作を無視し、既存 controller port がある場合は `release()` または `close()` 相当ではなく `release(())` で neutral を試みる。
+マクロ API は変更しない。GUI 内部 API として `GuiAppServices.refresh_swbt_adapters()`、`pair_swbt()`、`reconnect_swbt()`、`disconnect_swbt()`、`swbt_status()` を追加する。
 
 ### 後方互換性
 
-GUI の既存 serial 利用者は `serial_device` / `serial_baud` / `serial_protocol` を読み続けられる。設定保存時は新 schema へ寄せるが、旧設定名の alias API や互換 import は追加しない。
-
-接続メニューの「シリアルデバイス」と「プロトコル」は controller backend が serial のときだけ有効にする。swbt 選択時に serial 設定を消さず、再度 serial へ戻したときに前回値を使えるようにする。
+既存 serial 設定は読み続ける。GUI 保存時は `controller.*` schema へ寄せるが、旧名 alias API は追加しない。serial backend 選択時だけ serial device / protocol / baudrate UI を有効にする。
 
 ### レイヤー構成
 
-`src/nyxpy/gui/` は `nyxpy.framework.*` を利用する。`src/nyxpy/framework/` は GUI を import しない。`swbt-python` の直接 import は `local_023` core の `hardware/swbt_service.py` と `io/swbt_adapter.py` 周辺に閉じる。
-
-adapter refresh は `swbt-probe` subprocess 呼び出しから始める。GUI helper は `swbt` Python package を import せず、command not found、非ゼロ終了、JSON parse 失敗を GUI 表示用 error に変換する。
+adapter refresh は `SwbtAdapterDiscoveryService.list_adapters()` を呼ぶ。GUI から `swbt-probe` subprocess を呼ばない。pair/reconnect/disconnect は factory の lifecycle method へ委譲する。manual input は `VirtualControllerModel` の既存 method から `ControllerOutputPort` を呼ぶ。
 
 ### 性能要件
 
 | 指標 | 目標値 |
 |------|--------|
-| adapter refresh timeout | 既定 5.0 秒 |
-| GUI 操作の main thread blocking | adapter refresh、pair once、reconnect、disconnect は UI を 100 ms 以上固めない |
-| macro 実行中の manual input | 実行開始から終了まで入力 command を送らない |
-| backend 切り替え時の close | 旧 builder shutdown を 1 回実行し、旧 factory close を取りこぼさない |
-| diagnostics path 変更 | service key 変更として扱い、builder を再生成する |
+| adapter refresh | GUI main thread を 100ms 以上止めない |
+| pair/reconnect/disconnect | worker thread または既存非同期実行基盤で UI を固めない |
+| macro start 前 close | manual port release/close を 1 回行い、失敗時は runtime start を止める |
+| runtime 終了後 | 自動 reconnect しない |
 
 ### 並行性・スレッド安全性
 
-Qt の UI 更新は main thread で行う。`swbt-probe` subprocess、pair once、reconnect、disconnect は worker thread または非同期 task に逃がし、完了後に signal で UI へ戻す。
-
-manual input と runtime input は同じ service を共有するが、同時操作は許可しない。`MainWindow._start_macro()` が成功した時点で `VirtualControllerModel.set_manual_input_enabled(False)` を呼び、`_poll_run_handle()` または start failure の後に有効へ戻す。runtime 用 port は `SwbtControllerOutputPortFactory.create()` の責務として neutral から始める。
+Qt widget 更新は main thread で行う。swbt lifecycle 操作は worker に逃がし、完了後に signal / callback で UI へ戻す。macro 実行中は manual input、pair、reconnect、disconnect、backend 切替を無効化する。内部的に設定反映が入った場合は deferred として扱う。
 
 ## 4. 実装仕様
 
-### 公開インターフェース
+### GUI service API
 
 ```python
-from dataclasses import dataclass
-
-
-@dataclass(frozen=True)
-class SwbtAdapterInfo:
-    identifier: str
-    label: str
-
-
-@dataclass(frozen=True)
-class SwbtAdapterRefreshResult:
-    adapters: tuple[SwbtAdapterInfo, ...]
-    bumble_version: str
-    platform: str
-    python_version: str
-    opens_adapter: bool
-
-
-@dataclass(frozen=True)
-class SwbtControllerStatus:
+@dataclass(frozen=True, slots=True)
+class SwbtControllerStatusView:
     connected: bool
+    controller_type: str
     adapter: str
     message: str
 
 
-@dataclass(frozen=True)
-class SwbtConnectionActionResult:
-    backend: str
-    status: SwbtControllerStatus | None
-    message: str
-
-
 class GuiAppServices:
-    def refresh_swbt_adapters(self, *, timeout_sec: float = 5.0) -> SwbtAdapterRefreshResult: ...
-    def pair_swbt_once(self) -> SwbtConnectionActionResult: ...
-    def reconnect_swbt(self) -> SwbtConnectionActionResult: ...
-    def disconnect_swbt(self) -> SwbtConnectionActionResult: ...
-    def swbt_status(self) -> SwbtControllerStatus | None: ...
-
-
-class VirtualControllerModel(QObject):
-    def set_manual_input_enabled(self, enabled: bool) -> None: ...
-    def manual_input_enabled(self) -> bool: ...
+    def refresh_swbt_adapters(self) -> tuple[SwbtAdapterView, ...]: ...
+    def pair_swbt(self) -> SwbtControllerStatusView: ...
+    def reconnect_swbt(self) -> SwbtControllerStatusView: ...
+    def disconnect_swbt(self) -> None: ...
+    def swbt_status(self) -> SwbtControllerStatusView | None: ...
 ```
 
-`swbt_probe.py` は `swbt-probe adapters --json` の出力を次の payload として扱う。
+`SwbtControllerStatusView` は GUI 表示用 DTO である。`swbt.GamepadStatus` を widget 層へ返さない。
 
-```json
-{
-  "bumble_version": "0.0.230",
-  "candidate_adapters": ["usb:0"],
-  "opens_adapter": false,
-  "platform": "Windows-...",
-  "python_version": "3.12.0",
-  "status": "adapter listing does not open hardware"
-}
+### GUI 項目
+
+| 項目 | 必須 | 内容 |
+|------|------|------|
+| backend selector | yes | `serial` / `swbt` |
+| controller type | yes | Pro Controller / Joy-Con L / Joy-Con R |
+| adapter combo | yes | discovery 結果 |
+| refresh adapters | yes | adapter 列挙のみ |
+| key store path | yes | pairing key JSON |
+| pair button | yes | 明示 pairing |
+| reconnect button | yes | 保存済み key reconnect |
+| disconnect button | yes | GUI lifetime port と session を close |
+| connection status | yes | disconnected / pairing / connected / error |
+
+GUI に置かない項目:
+
+- CLI command preview
+- clipboard copy
+- diagnostics editor
+- diagnostics folder open button
+- controller color editor
+- auto pairing suggestion
+- IMU preset / pose / raw editor
+- IMU recorder / replay
+
+### 操作仕様
+
+| 操作 | 入力条件 | 成功時 | 失敗時 |
+|------|----------|--------|--------|
+| Refresh adapters | macro 未実行中 | combo を更新 | status bar と technical log に表示 |
+| Pair | backend `swbt`、adapter、controller type、key store が有効 | status connected、manual port を注入 | controller `None`、error 表示 |
+| Reconnect | backend `swbt`、key store が存在 | status connected、manual port を注入 | controller `None`、error 表示 |
+| Disconnect | connected | `release()` / `close()` 後、controller `None` | error log、controller `None` |
+| Macro run start | pair/reconnect 中でない | manual port を閉じて runtime start | close 失敗なら実行を止める |
+
+### manual input
+
+`VirtualControllerModel` は controller が `None` のとき no-op にする。接続済み port が error を返した場合は silent no-op にせず technical log と user-visible error を出し、必要に応じて controller を `None` に戻す。
+
+macro start 前の処理:
+
+```text
+virtual_controller.model.set_controller(None)
+previous_manual_port.release()
+previous_manual_port.close()
+runtime start
 ```
 
-`candidate_adapters` の各要素を `SwbtAdapterInfo(identifier=value, label=value)` に変換する。`opens_adapter` が `false` でない場合は、GUI からの adapter refresh としては失敗扱いにする。
+runtime 終了後は自動 reconnect しない。利用者が reconnect を押したときだけ GUI lifetime port を再作成する。
 
-GUI は `swbt-python` の `GamepadStatus` を直接 import しない。`SwbtGamepadService` または factory が返す `GamepadStatus` 相当の object は `GuiAppServices` 内で GUI 表示用の `SwbtControllerStatus` へ変換し、widget 層は `connected`、`adapter`、`message` だけを扱う。
+### settings 反映
 
-### 設定パラメータ
-
-| パラメータ | 型 | デフォルト | 説明 |
-|------------|-----|-----------|------|
-| `controller.backend` | `str` | `"serial"` | GUI と runtime の controller backend。`serial` または `swbt` |
-| `controller.serial.device` | `str | None` | `None` | serial backend の device identifier |
-| `controller.serial.protocol` | `str` | `"CH552"` | serial backend の protocol |
-| `controller.serial.baudrate` | `int` | `9600` | serial backend の baudrate |
-| `controller.swbt.adapter` | `str` | `"usb:0"` | `swbt-probe adapters --json` で表示する candidate adapter |
-| `controller.swbt.key_store_path` | `str | None` | `".nyxpy/swbt/switch-bond.json"` | swbt bond 情報の保存先 |
-| `controller.swbt.connect_timeout_sec` | `float` | `30.0` | pair once / reconnect の timeout 秒 |
-| `controller.swbt.allow_pairing` | `bool` | `False` | 通常 runtime 起動時の pairing 許可。GUI の pair once 操作後も設定値は `False` に戻す |
-| `controller.swbt.diagnostics_path` | `str | None` | `None` | GUI 初期実装では未指定なら diagnostics trace を出さない |
-| `controller.swbt.invert_stick_y` | `bool` | `False` | stick Y 軸反転。実機検証で既定変更が必要なら `local_026` で判断する |
-
-### GUI 操作仕様
-
-| 操作 | 入力条件 | 処理 | 失敗時の表示 |
-|------|----------|------|--------------|
-| backend 選択 | macro 未実行中 | `controller.backend` を保存し、runtime builder を再生成する | builder 再生成失敗を status bar と technical log に出す |
-| adapter refresh | swbt extra が導入済み | `swbt-probe adapters --json` を subprocess 実行し、候補を combo box へ反映する | command not found、非ゼロ終了、JSON 不正を設定画面内に表示する |
-| pair once | backend が `swbt`、macro 未実行中 | 現在 config で `allow_pairing=True` の接続試行を 1 回だけ行う | pairing timeout、adapter open 失敗、key store 不正を表示する |
-| reconnect | backend が `swbt`、macro 未実行中 | 現在 config で `allow_pairing=False` の接続試行を行う | bond 不足、timeout、adapter open 失敗を表示する |
-| disconnect | backend が `swbt`、macro 未実行中 | shared service を close し、manual controller を外す | close error を表示し、builder 状態は再生成対象にする |
-| manual input | macro 未実行中、manual controller 接続済み | `VirtualControllerModel` から current controller port へ送信する | port error を existing technical log へ出す |
-
-### builder / service lifetime
-
-`GuiAppServices` は現在の runtime builder と、そこへ渡した controller factory への参照を保持する。backend 設定、swbt adapter、key store、report period、device name、diagnostics path、`connect_on_open` が変わった場合は builder を再生成し、旧 builder の `shutdown()` で旧 factory を close する。
-
-runtime builder から取得する manual controller と、macro runtime 用に build される controller は別 port でよい。どちらも同じ factory が所有する service を使う。manual controller を close しても transport は閉じず、backend 切り替え、disconnect、アプリ終了で factory close が走ったときだけ transport を閉じる。
-
-### manual input guard
-
-`VirtualControllerModel` は `manual_input_enabled=False` の間、button、D-pad、stick、touch の送信を行わない。無効化時に押下済み状態があれば `release(())` を 1 回試み、GUI 内部状態を neutral へ戻して `stateChanged` を emit する。
-
-`MainWindow` は macro 開始成功後に manual input を無効化する。macro start が失敗した場合は無効化しない。macro 完了、cancel 完了、result 取得失敗、retry dialog の前で manual input を有効へ戻す。
-
-通常の UI 操作では、macro 実行中に backend 選択、pair once、reconnect、disconnect を押せないようにする。テストや内部呼び出しで実行中に設定反映が入った場合は、現行 `GuiAppServices.apply_settings(is_run_active=True)` と同じく deferred として扱い、実行完了後に builder を再生成する。
-
-### diagnostics path の GUI 初期扱い
-
-GUI の初期値は `controller.swbt.diagnostics_path=None` とする。固定 path を自動生成しない。理由は、`SwbtGamepadService` が runtime artifact store に依存せず、diagnostics path が service key に含まれるためである。
-
-ユーザが diagnostics path を設定した場合だけ service config へ渡す。path 変更時は既存 service を再利用せず builder を再生成する。run artifact directory ごとに trace を分ける設計は、この仕様では扱わない。
+controller backend、controller type、adapter、key store、report period、diagnostics path、operation timeout が変わった場合、旧 runtime builder を shutdown し、新しい builder を作る。macro 実行中は変更を deferred とし、実行完了後に反映する。
 
 ### エラーハンドリング
 
-| 例外クラス | 発生条件 |
-|------------|----------|
-| `ConfigurationError` | swbt extra 未導入、backend 名不正、adapter open 失敗、key store 不正、connect timeout |
-| `DeviceError` | 接続済み service の送信失敗、disconnect 中の lifecycle 不整合 |
-| `SwbtAdapterProbeError` | `swbt-probe` が見つからない、非ゼロ終了、JSON parse 失敗、`opens_adapter=true` |
-| `RuntimeError` | GUI が serial backend のまま pair once / reconnect / disconnect を呼んだ場合 |
-
-GUI はこれらを握りつぶさない。status bar には短い利用者向け文言を出し、technical log には例外型、設定値、subprocess exit code を残す。
+| 条件 | 表示 |
+|------|------|
+| swbt extra 未導入 | swbt extra の導入手順を促す |
+| adapter discovery 失敗 | adapter refresh failed |
+| adapter 未選択 | adapter を選択させる |
+| key store 不正 | key store path を確認させる |
+| pair/reconnect timeout | Switch 側の pairing / reconnect 操作を確認させる |
+| unsupported input | 選択 controller type では入力不可と表示 |
+| macro 実行中の操作 | UI disabled。内部呼び出しは deferred または明示エラー |
 
 ### シングルトン管理
 
-新規グローバル singleton は追加しない。`GuiAppServices` が runtime builder lifetime を所有し、runtime builder または controller factory が `SwbtGamepadService` lifetime を所有する。アプリ終了時は `MainWindow.closeEvent()` から `GuiAppServices.close()` を呼び、builder shutdown と logging close を実行する。
+新規グローバル singleton は追加しない。`GuiAppServices` が runtime builder と swbt factory lifetime を所有し、アプリ終了時に close する。
 
 ## 5. テスト方針
 
 | テスト種別 | テスト名 | 検証内容 |
 |------------|----------|----------|
-| ユニット | `test_swbt_probe_parses_adapter_payload` | `candidate_adapters=["usb:0"]` を GUI 表示用 result へ変換する |
-| ユニット | `test_swbt_probe_rejects_adapter_opening_payload` | `opens_adapter=true` を adapter refresh 失敗として扱う |
-| ユニット | `test_swbt_probe_reports_missing_command` | `swbt-probe` が見つからない場合に `SwbtAdapterProbeError` を返す |
-| GUI | `test_device_settings_tab_switches_controller_backend_fields` | backend 選択に応じて serial / swbt 設定欄の有効状態が切り替わる |
-| GUI | `test_device_settings_tab_refreshes_swbt_adapters` | adapter refresh 結果を combo box へ反映し、選択値を settings へ保存する |
-| GUI | `test_virtual_controller_model_disables_manual_input_during_run` | 無効化中に button / stick 操作が controller port へ送られない |
-| GUI | `test_virtual_controller_model_releases_on_disable` | 無効化時に `release(())` を 1 回試み、内部状態を neutral へ戻す |
-| GUI | `test_gui_app_services_rebuilds_builder_on_swbt_service_key_change` | adapter、key store、diagnostics path 変更で旧 builder shutdown と新 builder 作成が走る |
-| GUI | `test_gui_app_services_keeps_swbt_service_for_manual_and_runtime` | manual controller と runtime controller が同じ factory-owned service を使う |
-| GUI | `test_main_window_defers_backend_change_during_run` | macro 実行中の backend 変更を deferred とし、完了後に builder を再生成する |
-| 結合 | `test_main_window_pair_reconnect_disconnect_actions` | fake swbt factory を使い、pair once / reconnect / disconnect が UI 操作から呼ばれる |
-| ハードウェア | `test_swbt_gui_pair_and_reconnect_device` | 実施しない。実機検証は次工程で `@pytest.mark.realdevice` / `@pytest.mark.swbt` として扱う |
-| パフォーマンス | `test_swbt_adapter_refresh_timeout` | fake subprocess で timeout 経路を検証し、実機や Bluetooth adapter は開かない |
+| GUI | `test_device_tab_switches_serial_and_swbt_fields` | backend に応じて設定欄が切り替わる |
+| GUI | `test_device_tab_uses_supported_controller_models_for_choices` | controller type choices が model registry 由来 |
+| GUI | `test_refresh_adapters_does_not_pair_or_reconnect` | fake discovery だけが呼ばれる |
+| GUI | `test_pair_success_sets_manual_controller` | pair 成功後に `VirtualControllerModel.set_controller(port)` |
+| GUI | `test_reconnect_success_sets_manual_controller` | reconnect 成功後に manual port を注入 |
+| GUI | `test_disconnect_releases_and_clears_manual_controller` | disconnect で `release()` / `close()` / `None` |
+| GUI | `test_macro_start_closes_manual_port_before_runtime` | macro start 前に GUI lifetime port を閉じる |
+| GUI | `test_macro_running_disables_swbt_actions` | macro 実行中に manual input と lifecycle 操作を止める |
+| GUI | `test_runtime_finish_does_not_auto_reconnect` | 実行後に自動 reconnect しない |
+| 静的 | `test_gui_does_not_import_swbt_python` | GUI module が `swbt` を direct import しない |
 
-通常検証は次を使う。
+検証コマンド:
 
 ```console
 uv run ruff format .
@@ -264,33 +204,13 @@ uv run pytest tests/gui/ -m "not realdevice and not swbt"
 
 ## 6. 実装チェックリスト
 
-- [ ] `GuiAppServices` が controller backend 設定を builder 更新対象に含める。
-- [ ] `GuiAppServices` が swbt factory/service 操作用の pair once / reconnect / disconnect / status method を提供する。
-- [ ] backend 切り替え、swbt service key 変更、diagnostics path 変更で旧 builder を shutdown する。
-- [ ] `DeviceSettingsTab` に controller backend、serial 設定、swbt 設定、adapter refresh、diagnostics path を追加する。
-- [ ] `swbt_probe.py` で `swbt-probe adapters --json` の subprocess 実行と parse error 変換を実装する。
-- [ ] `MainWindow` の接続メニューと接続状態表示を controller backend 対応にする。
-- [ ] macro 実行中に manual input を無効化し、実行後に有効へ戻す。
-- [ ] `VirtualControllerModel` が無効化時に neutral を試み、無効中の操作を送信しない。
-- [ ] GUI と runtime が同じ `SwbtGamepadService` を共有することを fake service で検証する。
-- [ ] diagnostics path 未指定では trace を出さず、path 変更時は builder を再生成する。
-- [ ] GUI / unit / integration test を追加して通す。
-- [ ] `uv run ruff format .` を実行する。
-- [ ] `uv run ruff check .` を実行する。
-- [ ] `uv run ty check src/nyxpy --output-format concise --no-progress` を実行する。
-
-## 7. 親計画との依存関係
-
-この仕様は `local_021` の M5 に対応する。`local_022` は settings schema と config 正規化、`local_023` は swbt service / port / factory、`local_024` は runtime builder と CLI からの factory lifetime を提供する前提である。
-
-この仕様では CLI option 実装、`SwbtControllerOutputPort` の内部状態遷移、`SwbtGamepadService` の非同期 event loop 実装、実機検証は扱わない。GUI が必要とする pair once / reconnect / disconnect / status 操作は `local_023` の `SwbtControllerOutputPortFactory` が提供する前提である。
-
-## 8. 完了後に次へ渡す成果
-
-- GUI から `serial` / `swbt` controller backend を選択できる。
-- `swbt-probe adapters --json` の結果を GUI へ表示し、`controller.swbt.adapter` へ保存できる。
-- GUI の pair once / reconnect / disconnect 操作が fake swbt factory で検証済みである。
-- manual input と runtime が同じ service を共有し、macro 実行中に manual input が無効化される。
-- diagnostics path の初期値は無効であり、path 変更時に builder を再生成する挙動が記録されている。
-
-次工程の実機検証では、GUI からの pair once、reconnect、disconnect、button、D-pad、stick、neutral、diagnostics trace を確認する。stick Y 軸既定と短押し flush 要否は、この仕様では決めず実機結果に基づいて判断する。
+- [ ] GUI settings に backend selector、controller type、adapter、key store、pair/reconnect/disconnect/status を追加する。
+- [ ] adapter refresh が `SwbtAdapterDiscoveryService` だけを呼ぶようにする。
+- [ ] GUI に diagnostics editor、controller color editor、IMU editor、CLI copy を追加しない。
+- [ ] `GuiAppServices` が swbt factory lifecycle を所有する。
+- [ ] Pair / Reconnect 成功後に GUI lifetime port を `VirtualControllerModel` へ注入する。
+- [ ] Disconnect で manual port と session を閉じ、controller を `None` に戻す。
+- [ ] macro start 前に manual port を `release()` / `close()` する。
+- [ ] macro 実行中は manual input と swbt lifecycle 操作を無効化する。
+- [ ] runtime 終了後に自動 reconnect しない。
+- [ ] GUI module が `swbt-python` を直接 import しないことを確認する。

--- a/spec/agent/wip/local_026/SWBT_REALDEVICE_DOCS_CLOSEOUT.md
+++ b/spec/agent/wip/local_026/SWBT_REALDEVICE_DOCS_CLOSEOUT.md
@@ -4,232 +4,207 @@
 
 ### 1.1 目的
 
-`swbt` controller backend の実機検証、利用者向け docs 反映、実装計画の完了記録を定義する。実装そのものは `local_022` から `local_025` の範囲とし、本仕様は実機で確認すべき挙動、証跡の残し方、完了判定を扱う。
+swbt backend の実機検証、利用者向け docs 反映、完了記録を定義する。Pro Controller、Joy-Con L、Joy-Con R について adapter discovery、pairing、reconnect、button、D-pad、stick、IMU、neutral、short press を確認し、親計画 `local_021` と子仕様を complete へ移せる状態にする。
 
 ### 1.2 用語定義
 
 | 用語 | 定義 |
 |------|------|
-| swbt backend | `swbt-python` を使う Bluetooth HID controller backend |
-| 実機検証 | Switch と専用 USB Bluetooth adapter を使い、pairing、reconnect、入力反映、neutral 復帰を確認する検証 |
-| diagnostics trace | `swbt-python` または NyX の `SwbtGamepadService` が出力する接続、report 送信、切断の JSONL 証跡 |
-| key store | Switch との bond 情報を保存する JSON ファイル |
-| active reconnect | 保存済み key store を使い、pairing を許可せず Switch へ再接続する確認手順 |
-| manual confirmation | Switch 画面を人が見て入力反映を確認し、結果を検証ログへ記録する方式 |
-| closeout | 実装結果、検証結果、残課題を整理し、親計画と子仕様を `spec/agent/complete/` へ移せる状態にする作業 |
+| 実機検証 | Switch、専用 USB Bluetooth adapter、`swbt-python` を使う hardware test |
+| evidence directory | 実機検証の metadata、trace、operator confirmation、summary を保存する directory |
+| diagnostics trace | swbt session の接続、pair/reconnect、report、neutral、disconnect の JSONL 証跡 |
+| operator confirmation | Switch 画面を人が見て入力反映を `pass` / `fail` / `skip` で記録する確認 |
+| short press | `Command.press(..., dur=...)` が swbt report loop に載る最小 duration の確認 |
+| closeout | 実装結果、検証結果、docs、残課題を整理し、wip 仕様を complete へ移せる状態にする作業 |
 
 ### 1.3 背景・問題
 
-`swbt` backend は実機、Bluetooth adapter、Switch 側の待機状態、bond 情報に依存する。単体テストと dummy service だけでは、pairing、reconnect、短押しの取りこぼし、stick Y 軸向き、close 後の入力残留を判定できない。
-
-利用者 docs も現状は serial backend 前提である。`--controller swbt`、`--bt-*` option、GUI の swbt 操作、専用 adapter 要件、トラブルシューティングを公開 docs に反映しなければ、実装後の利用手順が不明確なまま残る。
+単体テストと dummy session では、Bluetooth adapter、pairing key、Switch 側接続状態、Joy-Con capability、stick Y 軸、short press の取りこぼし、close 後の入力残留を確認できない。利用者 docs も serial backend 前提のままでは、swbt extra、専用 adapter、key store、pair/reconnect、GUI 操作、トラブル対応が分からない。
 
 ### 1.4 期待効果
 
 | 指標 | 現状 | 目標 |
 |------|------|------|
-| 実機検証 | serial / capture の `realdevice` test が中心 | `realdevice` と `swbt` marker で swbt 専用検証を分離する |
-| pairing / reconnect 証跡 | NyX 側の標準記録なし | adapter、key store、trace、operator result を 1 つの evidence directory へ保存する |
-| stick Y 軸既定 | `invert_stick_y=false` を初期値とする | Switch のスティック補正画面で既定値を確定する |
-| short press 判定 | 周期 report 前提で未確認 | trace と Switch 画面確認により public flush 要否を判定する |
-| 利用者 docs | serial 前提 | serial と swbt の導入、CLI、GUI、トラブル対応を分けて説明する |
-| 完了記録 | 親計画が wip に残る | `local_021` と子仕様を検証結果付きで complete へ移せる |
+| 実機検証 | 未整備 | `realdevice` と `swbt` marker で通常 gate から分離 |
+| controller 種別 | Pro Controller だけに偏り得る | Pro Controller / Joy-Con L / Joy-Con R を分けて記録 |
+| IMU | 未確認 | `Command.imu(...)` の neutral / gyro frame を trace と必要な観察で確認 |
+| short press | 未確認 | 16ms、33ms、50ms の反映と public flush 要否を判定 |
+| docs | serial 前提 | install、device setup、CLI、GUI、command API、troubleshooting に swbt を反映 |
+| closeout | wip に残る | 検証結果と残課題を反映して complete 移動可能にする |
 
 ### 1.5 着手条件
 
-- `local_022` で controller config、settings 正規化、serial factory 改名が完了している。
-- `local_023` で mapper、port、service、factory の実機なし検証が完了している。
-- `local_024` で runtime / CLI から `--controller swbt` を選べる。
-- `local_025` で GUI が `SwbtGamepadService` を runtime と共有し、macro 実行中の manual input を無効化している。
-- `docs/architecture/swbt-integration/` の設計判断と矛盾しない。
-- 実機検証を実施する環境では `uv sync --extra swbt` が済んでいる。
-- 実機検証を実施する環境では Switch、専用 USB Bluetooth adapter、キャプチャ入力、operator がそろっている。
+- `local_022` から `local_025` の実装と通常 gate が完了している。
+- 実機検証環境で `uv sync --extra swbt` が済んでいる。
+- Switch、専用 USB Bluetooth adapter、キャプチャ入力、operator がそろっている。
+- 実機検証できない場合、`local_026` と親計画は complete へ移さない。
 
 ## 2. 対象ファイル
 
 | ファイル | 変更種別 | 変更内容 |
 |----------|----------|----------|
-| `pyproject.toml` | 変更 | `swbt` pytest marker と、必要なら hardware test 用 option の説明を追加する |
-| `tests/conftest.py` | 新規 | `--bt-adapter`、`--bt-key-store`、`--bt-diagnostics`、`--swbt-evidence-dir`、`--swbt-interactive` を pytest option として追加する |
-| `tests/hardware/test_swbt_controller_backend_realdevice.py` | 新規 | adapter probe、pairing、reconnect、Button、D-pad、stick、neutral、short press を検証する |
-| `docs/user-guide/installation.md` | 変更 | `nyxpy-fw[swbt]` と `uv sync --extra swbt` の導入手順を追加する |
-| `docs/user-guide/device-setup.md` | 変更 | serial backend と swbt backend の機材、adapter、key store、pairing 手順を分けて説明する |
-| `docs/user-guide/cli.md` | 変更 | `--controller swbt`、`--bt-adapter`、`--bt-pair`、`--bt-key-store`、`--bt-diagnostics` を追加する |
-| `docs/user-guide/gui.md` | 変更 | backend 選択、adapter refresh、pair once、reconnect、disconnect、diagnostics trace を説明する |
-| `docs/user-guide/troubleshooting.md` | 変更 | adapter が見えない、pairing timeout、reconnect 失敗、入力残留、短押し取りこぼし、stick Y 軸逆転を追加する |
-| `docs/macro-development/command-api.md` | 変更 | swbt backend で非対応の keyboard、touch、3DS 固有入力、sleep control を明記する |
-| `mkdocs.yml` | 変更 | swbt 専用ページを増やす場合だけ nav を更新する |
-| `docs/architecture/swbt-integration/testing-rollout.md` | 変更 | 実機検証で確定した Y 軸既定、short press 判定、diagnostics 方針を反映する |
-| `spec/agent/wip/local_021/SWBT_CONTROLLER_BACKEND.md` | 変更 | 完了時に M6 / M7 の結果を反映し、complete へ移動する |
-| `spec/agent/wip/local_026/SWBT_REALDEVICE_DOCS_CLOSEOUT.md` | 変更 | 実装後に検証結果と完了記録を反映し、complete へ移動する |
+| `pyproject.toml` | 変更 | `swbt` pytest marker を追加する |
+| `tests/conftest.py` | 変更 | `--swbt-adapter`、`--swbt-controller-type`、`--swbt-key-store`、`--swbt-diagnostics`、`--swbt-evidence-dir`、`--swbt-interactive`、`--swbt-short-press-ms` を追加する |
+| `tests/hardware/test_swbt_controller_backend_realdevice.py` | 新規 | adapter、pair/reconnect、button、D-pad、stick、IMU、neutral、short press を検証する |
+| `docs/user-guide/installation.md` | 変更 | `nyxpy-fw[swbt]` と `uv sync --extra swbt` を追加する |
+| `docs/user-guide/device-setup.md` | 変更 | swbt adapter、key store、pair/reconnect 手順を追加する |
+| `docs/user-guide/cli.md` | 変更 | `nyxpy swbt` と `nyxpy run --controller swbt` を追加する |
+| `docs/user-guide/gui.md` | 変更 | backend selector、adapter refresh、pair、reconnect、disconnect を追加する |
+| `docs/user-guide/troubleshooting.md` | 変更 | adapter 不検出、pair timeout、reconnect 失敗、unsupported input、入力残留、short press を追加する |
+| `docs/macro-development/command-api.md` | 変更 | `Command.imu(...)` と swbt 非対応入力を説明する |
+| `docs/architecture/swbt-integration/testing-rollout.md` | 変更 | 実機で確定した stick Y 軸、short press、flush 要否を反映する |
+| `spec/agent/wip/local_021` から `local_026` | 変更 | 実装結果、検証結果、残課題を反映し、complete 移動可能にする |
 
 ## 3. 設計方針
 
 ### 実機検証の境界
 
-実機検証は `tests/hardware/` に閉じる。通常の `uv run pytest` では実行されないよう、全テストに `@pytest.mark.realdevice` と `@pytest.mark.swbt` を付ける。CI の通常 gate は `-m "not realdevice and not swbt"` を使う。
-
-adapter の存在確認と接続確認は自動判定する。Switch 画面に入力が反映されたかどうかは、初期実装では manual confirmation を許容する。manual confirmation を含む test は `--swbt-interactive` がない場合に skip し、非対話のテスト実行を止めない。
+実機検証は `tests/hardware/` に閉じ、全テストに `@pytest.mark.realdevice` と `@pytest.mark.swbt` を付ける。通常 gate では `-m "not realdevice and not swbt"` で除外する。
 
 ### 証跡保存
 
-実機検証ごとに evidence directory を作る。既定値は `.nyxpy/swbt/hardware-artifacts/<日時>/` とし、`--swbt-evidence-dir` で上書きできる。保存するファイルは次の通りである。
+実機検証ごとに evidence directory を作る。既定値は `.nyxpy/swbt/hardware-artifacts/<日時>/` とする。
 
 | ファイル | 内容 | commit 対象 |
 |----------|------|-------------|
-| `run-metadata.json` | OS、NyX commit、swbt-python version、adapter、key store path、test command | 原則 commit しない |
-| `swbt-trace.jsonl` | 接続、pairing、report 送信、切断の diagnostics trace | 原則 commit しない |
-| `operator-confirmation.jsonl` | manual confirmation の観察結果 | 原則 commit しない |
-| `summary.md` | 検証結果の要約、失敗時の再現条件、docs 反映先 | 必要な要約だけ complete 仕様へ転記する |
+| `run-metadata.json` | OS、NyX commit、swbt-python version、controller type、adapter、key store、test command | 原則 commit しない |
+| `swbt-trace.jsonl` | pair/reconnect/report/neutral/disconnect trace | 原則 commit しない |
+| `operator-confirmation.jsonl` | 画面観察の `pass` / `fail` / `skip` | 原則 commit しない |
+| `summary.md` | 検証結果、失敗条件、docs 反映先 | 必要な要約だけ complete 仕様へ転記 |
 
-raw trace は adapter ID、OS path、実行者固有 path を含み得るため、既定では repository に含めない。PR や完了記録へ載せるのは、接続成否、入力種別、report 有無、判定結果に限定した要約である。
+raw trace には adapter ID、OS path、個人 path が含まれ得る。PR と complete 仕様には判定に必要な要約だけを載せる。
 
-### stick Y 軸の確定
+### controller type 別確認
 
-NyX の `LStick.UP` / `RStick.UP` は現在 `y=0` である。`invert_stick_y=false` を初期値とし、Switch のスティック補正画面で上方向、下方向を確認する。
+Pro Controller、Joy-Con L、Joy-Con R は別 key store を使う。Joy-Con L は right stick、Joy-Con R は left stick を unsupported として明確に失敗させる。unsupported input は実機確認の前に単体テストで固定し、実機では選択 controller type に存在する入力だけを確認する。
 
-判定は左右 stick で分ける。`invert_stick_y=false` で `LStick.UP` と `RStick.UP` が Switch 画面の上方向として観察できる場合、既定値は `false` のまま確定する。上下が逆に観察された場合、`invert_stick_y=true` を既定に変更する実装修正を `local_023` または follow-up 仕様へ戻し、修正後に本仕様の実機検証をやり直す。
+### stick Y 軸と short press
 
-### short press と public flush の判定
+NyX 現行 `LStick.UP` / `RStick.UP` の `x/y` を swbt `Stick` へ変換した結果が Switch 画面で上方向として観察されるか確認する。逆なら `local_023` へ戻して mapper 既定を修正する。
 
-NyX port は `SwbtGamepadService.apply()` に完全な `InputState` を渡し、swbt 側の周期 report で反映される前提で実装する。短押し検証では、duration と trace の両方を確認する。
-
-`report_period_us=8000` の既定値では、16ms、33ms、50ms の Button.A 短押しを検証対象にする。16ms 以上の押下で trace に pressed report と neutral report が記録され、Switch 画面でも反映される場合、NyX 側から swbt public flush を要求しない。16ms 以上で pressed report が trace に出ない、または Switch 画面で安定して取りこぼす場合、`swbt-python` 側に `flush` または `send_current` 相当の public API が必要な候補として記録する。
-
-8ms 以下の押下だけが取りこぼされる場合は public flush 必須とは扱わない。NyX docs に swbt backend の最小推奨 press duration を記載する。
+`report_period_us=8000` では 16ms、33ms、50ms の Button.A short press を確認する。16ms 以上で trace と画面の両方が安定するなら public flush は不要とする。16ms 以上で pressed report が trace に出ない、または画面反映が安定しない場合、`swbt-python` 側の public flush / send_current 相当を残課題として記録する。
 
 ### docs 反映方針
 
-利用者 docs は serial backend を置き換えず、serial と swbt を並列に説明する。swbt backend は通常の PC Bluetooth 機能ではなく、Bumble から直接開く専用 USB Bluetooth adapter を使う前提で書く。
-
-CLI docs では swbt backend でも capture source が必要であることを残す。`--serial` は serial backend 専用であり、`--controller swbt` では不要であると明記する。
-
-GUI docs では runtime と manual input が同じ `SwbtGamepadService` を共有すること、macro 実行中は manual input が無効化されることを書く。これは利用者が disconnect や pair once を押すタイミングを誤らないためである。
+serial backend を置き換えず、serial と swbt を並列に説明する。swbt backend は通常の PC Bluetooth 機能ではなく、Bumble から直接開く専用 USB Bluetooth adapter を使う前提で書く。
 
 ### closeout 方針
 
-`local_026` 完了時点で、親計画 `local_021` と子仕様 `local_022` から `local_026` が実装結果を反映していることを確認する。未解決の設計判断が残る場合は、complete へ移す前に `spec/dev-journal.md` か次の wip 仕様へ分離する。未解決のまま親計画を完了扱いにしない。
+`local_021` から `local_026` は、実装結果、検証コマンド、実機結果、残課題が反映されるまで `wip` に残す。残課題が実装範囲外なら `spec/dev-journal.md` または新規 wip 仕様へ分離してから complete へ移す。
 
 ## 4. 実装仕様
 
 ### pytest option
 
 ```python
-@dataclass(frozen=True)
+@dataclass(frozen=True, slots=True)
 class SwbtRealDeviceOptions:
     adapter: str
+    controller_type: str
     key_store_path: Path
-    diagnostics_path: Path
+    diagnostics_path: Path | None
     evidence_dir: Path
     timeout_sec: float = 30.0
-    allow_pairing: bool = False
     interactive: bool = False
-    report_period_us: int = 8000
-    device_name: str = "Pro Controller"
+    short_press_ms: tuple[int, ...] = (16, 33, 50)
 ```
 
 | option | 型 | 既定値 | 説明 |
 |--------|-----|--------|------|
-| `--bt-adapter` | `str` | `"usb:0"` | Bumble が開く adapter |
-| `--bt-key-store` | `Path` | `.nyxpy/swbt/test-switch.json` | 実機テスト用 key store |
-| `--bt-diagnostics` | `Path | None` | evidence directory 内の `swbt-trace.jsonl` | diagnostics trace 保存先 |
-| `--bt-timeout` | `float` | `30.0` | pairing / reconnect timeout 秒 |
-| `--swbt-evidence-dir` | `Path | None` | `.nyxpy/swbt/hardware-artifacts/<日時>/` | 実機証跡の保存先 |
-| `--swbt-interactive` | `bool` | `False` | manual confirmation を伴う test を実行する |
-| `--swbt-short-press-ms` | `list[int]` | `16,33,50` | short press 判定で使う duration |
+| `--swbt-adapter` | `str` | `"usb:0"` | adapter 名 |
+| `--swbt-controller-type` | `str` | `"pro-controller"` | controller type |
+| `--swbt-key-store` | `Path` | `.nyxpy/swbt/<controller>-test-bond.json` | 実機テスト用 key store |
+| `--swbt-diagnostics` | `Path | None` | evidence directory 内 `swbt-trace.jsonl` | diagnostics trace |
+| `--swbt-timeout` | `float` | `30.0` | pair/reconnect timeout |
+| `--swbt-evidence-dir` | `Path | None` | `.nyxpy/swbt/hardware-artifacts/<日時>/` | 証跡保存先 |
+| `--swbt-interactive` | `bool` | `False` | operator confirmation を実行する |
+| `--swbt-short-press-ms` | `list[int]` | `16,33,50` | short press duration |
 
-### 実機テスト構成
+### 実機テスト
 
 | テスト | 自動判定 | manual confirmation | 検証内容 |
 |--------|----------|---------------------|----------|
-| `test_swbt_adapter_probe_realdevice` | あり | なし | `swbt-probe adapters --json` 相当の adapter 確認で対象 adapter が見える |
-| `test_swbt_pairing_realdevice` | あり | Switch を接続画面に置く操作のみ | `allow_pairing=true` で接続し、key store が作成される |
-| `test_swbt_reconnect_realdevice` | あり | なし | 保存済み key store と `allow_pairing=false` で active reconnect が成功する |
-| `test_swbt_button_dpad_reflection_manual_realdevice` | trace は自動、画面反映は人手 | あり | Button.A、Button.B、PLUS、MINUS、D-pad UP / RIGHT / DOWN / LEFT が反映される |
-| `test_swbt_stick_reflection_manual_realdevice` | trace は自動、画面反映は人手 | あり | left / right stick の上、下、左、右、center が反映される |
-| `test_swbt_neutral_after_close_realdevice` | trace は自動、画面反映は人手 | あり | close、cancel、failure 相当の終了後に neutral が送られ入力が残らない |
-| `test_swbt_short_press_duration_realdevice` | trace は自動、画面反映は人手 | あり | 16ms、33ms、50ms の短押しが report と画面の両方で確認できる |
+| `test_swbt_adapter_discovery_realdevice` | あり | なし | adapter が `list_adapters()` で見える |
+| `test_swbt_pair_realdevice` | あり | Switch を接続画面に置く操作のみ | pairing 成功と key store 作成 |
+| `test_swbt_reconnect_realdevice` | あり | なし | 保存済み key store で reconnect |
+| `test_swbt_button_dpad_manual_realdevice` | trace は自動 | あり | Button、D-pad の反映 |
+| `test_swbt_stick_manual_realdevice` | trace は自動 | あり | left / right stick と Y 軸 |
+| `test_swbt_imu_realdevice` | trace は自動 | 必要に応じてあり | `Command.imu(IMUFrame.neutral())` と gyro frame |
+| `test_swbt_neutral_after_close_realdevice` | trace は自動 | あり | close / cancel / failure 後に neutral |
+| `test_swbt_short_press_duration_realdevice` | trace は自動 | あり | 16ms、33ms、50ms の short press |
 
 ### 実行コマンド
 
-通常 gate では swbt 実機テストを除外する。
+通常 gate:
 
 ```console
 uv run pytest tests -m "not realdevice and not swbt"
 ```
 
-adapter probe と reconnect までの非対話テストを実行する。
+adapter / pair / reconnect:
 
 ```console
-uv run pytest tests/hardware -m "realdevice and swbt" --bt-adapter usb:0 --bt-key-store .nyxpy/swbt/test-switch.json
+uv run pytest tests/hardware -m "realdevice and swbt" --swbt-adapter usb:0 --swbt-controller-type pro-controller --swbt-key-store .nyxpy/swbt/pro-controller-test-bond.json
 ```
 
-画面観察を含む確認は `-s` と `--swbt-interactive` を付ける。
+画面観察あり:
 
 ```console
-uv run pytest tests/hardware -m "realdevice and swbt" -s --swbt-interactive --bt-adapter usb:0 --bt-key-store .nyxpy/swbt/test-switch.json
+uv run pytest tests/hardware -m "realdevice and swbt" -s --swbt-interactive --swbt-adapter usb:0 --swbt-controller-type pro-controller --swbt-key-store .nyxpy/swbt/pro-controller-test-bond.json
 ```
 
-diagnostics trace の保存先を明示する。
+Joy-Con は key store を分ける。
 
 ```console
-uv run pytest tests/hardware -m "realdevice and swbt" -s --swbt-interactive --bt-adapter usb:0 --bt-key-store .nyxpy/swbt/test-switch.json --bt-diagnostics .nyxpy/swbt/hardware-artifacts/latest/swbt-trace.jsonl
+uv run pytest tests/hardware -m "realdevice and swbt" -s --swbt-interactive --swbt-controller-type joy-con-l --swbt-key-store .nyxpy/swbt/joy-con-l-test-bond.json
+uv run pytest tests/hardware -m "realdevice and swbt" -s --swbt-interactive --swbt-controller-type joy-con-r --swbt-key-store .nyxpy/swbt/joy-con-r-test-bond.json
 ```
-
-### operator 手順
-
-1. Switch を controller pairing 画面または接続待機状態にする。
-2. 初回 pairing test を `--swbt-interactive` なしで実行し、接続と key store 作成を確認する。
-3. Switch 側の controller 接続を切り、同じ key store で reconnect test を実行する。
-4. manual confirmation test を実行する。
-5. Button、D-pad、stick、neutral の各観察結果を terminal prompt へ `pass` または `fail` で入力する。
-6. 失敗時は `operator-confirmation.jsonl` に観察内容、Switch 画面、再現した入力名、trace の該当 event 範囲を残す。
-
-### diagnostics trace 判定
-
-trace では少なくとも次を確認する。
-
-| event | 判定 |
-|-------|------|
-| `adapter_opened` | 指定 adapter が開けた |
-| `connected` | HID control / interrupt channel が開いた |
-| `pairing_completed` または `bond_loaded` | pairing または reconnect の根拠がある |
-| `report_tx` | Button、D-pad、stick、neutral の report が送信された |
-| `neutral_tx` | close / cancel / failure 後に neutral が送信された |
-| `disconnected` | factory close で transport が閉じた |
-
-event 名は実装済み diagnostics の表現に合わせる。名前が異なる場合でも、接続、bond、report、neutral、切断の 5 分類を summary に残す。
 
 ### docs 更新内容
 
-| docs | 追加する内容 |
-|------|--------------|
-| `installation.md` | `nyxpy-fw[swbt]`、`uv sync --extra swbt`、専用 adapter driver の準備 |
-| `device-setup.md` | serial backend と swbt backend の機材差分、adapter probe、key store 保存先、pairing / reconnect |
-| `cli.md` | `--controller serial|swbt`、serial 専用 option、swbt 専用 option、実行例 |
-| `gui.md` | backend 選択、Refresh adapters、Pair once、Reconnect、Disconnect、diagnostics folder |
-| `troubleshooting.md` | adapter 不検出、pairing timeout、reconnect 失敗、入力が残る、stick Y 軸逆転、短押し取りこぼし |
-| `command-api.md` | swbt backend の対応入力と非対応入力 |
-| `testing-rollout.md` | 実機で確定した既定値とリスク判定 |
+| docs | 追加内容 |
+|------|----------|
+| `installation.md` | `nyxpy-fw[swbt]`、`uv sync --extra swbt` |
+| `device-setup.md` | 専用 adapter、adapter discovery、key store、pair/reconnect |
+| `cli.md` | `nyxpy swbt adapters/pair/reconnect`、`nyxpy run --controller swbt` |
+| `gui.md` | backend selector、Refresh adapters、Pair、Reconnect、Disconnect |
+| `troubleshooting.md` | adapter 不検出、timeout、key store 不正、unsupported input、入力残留、short press |
+| `command-api.md` | `Command.imu(...)`、IMU frame 数、非対応 backend |
+| `testing-rollout.md` | stick Y 軸、short press、public flush 要否 |
+
+### エラーハンドリング
+
+| 条件 | 記録 |
+|------|------|
+| adapter 不検出 | adapter 名、aliases、VID/PID の有無 |
+| pair timeout | Switch 側状態、controller type、key store path |
+| reconnect 失敗 | key store の有無、不正判定、controller type 不一致 |
+| unsupported input | controller type、入力名、error code |
+| short press 失敗 | duration、pressed report 有無、neutral report 有無、画面観察 |
+
+### シングルトン管理
+
+実機テストごとに factory / session を作り、test teardown で close する。global singleton は追加しない。
 
 ## 5. テスト方針
 
 | テスト種別 | テスト名 | 検証内容 |
 |------------|----------|----------|
-| ユニット | `test_swbt_realdevice_options_defaults` | pytest option の既定値と path 解決 |
-| ユニット | `test_swbt_evidence_writer_redacts_paths` | summary へ書く情報が個人 path や adapter 固有値を過剰に含まない |
-| ユニット | `test_swbt_operator_confirmation_records_result` | manual confirmation の `pass` / `fail` / `skip` が JSONL に記録される |
-| 結合 | `test_swbt_docs_examples_match_cli_parser` | docs の `--controller swbt` 実行例が CLI parser と一致する |
-| 結合 | `test_mkdocs_build_includes_swbt_pages` | swbt docs を増やした場合に `mkdocs build --strict` が通る |
-| ハードウェア | `test_swbt_adapter_probe_realdevice` | `@pytest.mark.realdevice` / `@pytest.mark.swbt` で adapter を確認する |
-| ハードウェア | `test_swbt_pairing_realdevice` | pairing、key store 作成、trace 保存 |
-| ハードウェア | `test_swbt_reconnect_realdevice` | active reconnect、pairing なし接続、trace 保存 |
-| ハードウェア | `test_swbt_button_dpad_reflection_manual_realdevice` | Button と D-pad の画面反映 |
-| ハードウェア | `test_swbt_stick_reflection_manual_realdevice` | left / right stick と Y 軸既定 |
-| ハードウェア | `test_swbt_neutral_after_close_realdevice` | close 後の neutral |
-| ハードウェア | `test_swbt_short_press_duration_realdevice` | short press と public flush 要否 |
+| ユニット | `test_swbt_realdevice_options_defaults` | pytest option の既定値 |
+| ユニット | `test_swbt_evidence_writer_redacts_paths` | summary が個人 path を過剰に含まない |
+| ユニット | `test_swbt_operator_confirmation_records_result` | operator confirmation JSONL |
+| 結合 | `test_swbt_docs_examples_match_cli_parser` | docs の CLI 例が parser と一致 |
+| 結合 | `test_mkdocs_build_includes_swbt_pages` | swbt docs 追加後の `mkdocs build --strict` |
+| ハードウェア | `test_swbt_adapter_discovery_realdevice` | adapter discovery |
+| ハードウェア | `test_swbt_pair_realdevice` | pairing と key store 作成 |
+| ハードウェア | `test_swbt_reconnect_realdevice` | reconnect |
+| ハードウェア | `test_swbt_button_dpad_manual_realdevice` | Button / D-pad |
+| ハードウェア | `test_swbt_stick_manual_realdevice` | stick と Y 軸 |
+| ハードウェア | `test_swbt_imu_realdevice` | IMU neutral / gyro |
+| ハードウェア | `test_swbt_neutral_after_close_realdevice` | close 後 neutral |
+| ハードウェア | `test_swbt_short_press_duration_realdevice` | short press と flush 要否 |
 
-通常の実装検証は次を使う。
+通常検証:
 
 ```console
 uv run ruff format .
@@ -239,53 +214,19 @@ uv run pytest tests -m "not realdevice and not swbt"
 uv run mkdocs build --strict
 ```
 
-実機検証は環境があるときだけ実行し、結果を `local_026` の完了記録へ要約する。実機検証を実施できない場合、`local_026` は complete へ移さない。
-
 ## 6. 実装チェックリスト
 
-- [ ] `pyproject.toml` に `swbt` marker を追加する。
-- [ ] `tests/conftest.py` に swbt 実機検証用 pytest option を追加する。
-- [ ] `tests/hardware/test_swbt_controller_backend_realdevice.py` を追加する。
-- [ ] adapter probe test を実装し、接続を開始せず adapter を確認できるようにする。
-- [ ] pairing test を実装し、key store 作成と diagnostics trace を記録する。
-- [ ] reconnect test を実装し、`allow_pairing=false` の active reconnect を確認する。
-- [ ] Button と D-pad の manual confirmation test を追加する。
-- [ ] left / right stick と neutral の manual confirmation test を追加する。
+- [ ] pytest の `swbt` marker と実機 option を追加する。
+- [ ] evidence directory writer と operator confirmation writer を追加する。
+- [ ] adapter discovery 実機テストを追加する。
+- [ ] controller type ごとの pair / reconnect 実機テストを追加する。
+- [ ] Button / D-pad / stick / IMU / neutral / short press の実機テストを追加する。
+- [ ] Joy-Con L/R の unsupported input が明確に失敗することを確認する。
 - [ ] stick Y 軸既定値を実機結果で確定する。
-- [ ] short press test を追加し、public flush 要否を判定する。
-- [ ] diagnostics trace と operator confirmation の evidence directory を作成する。
-- [ ] `docs/user-guide/installation.md` に swbt extra 導入手順を追加する。
-- [ ] `docs/user-guide/device-setup.md` に swbt 機材と pairing / reconnect 手順を追加する。
-- [ ] `docs/user-guide/cli.md` に swbt CLI option と実行例を追加する。
-- [ ] `docs/user-guide/gui.md` に swbt GUI 操作を追加する。
-- [ ] `docs/user-guide/troubleshooting.md` に swbt 固有の失敗時確認を追加する。
-- [ ] `docs/macro-development/command-api.md` に swbt 非対応入力を追加する。
-- [ ] `docs/architecture/swbt-integration/testing-rollout.md` に実機で確定した判断を反映する。
-- [ ] `uv run ruff format .` を実行する。
-- [ ] `uv run ruff check .` を実行する。
-- [ ] `uv run ty check src/nyxpy --output-format concise --no-progress` を実行する。
-- [ ] `uv run pytest tests -m "not realdevice and not swbt"` を実行する。
-- [ ] `uv run mkdocs build --strict` を実行する。
-- [ ] `uv run pytest tests/hardware -m "realdevice and swbt"` の実機結果を記録する。
-- [ ] `local_021` と `local_026` に実装結果、検証結果、残課題を反映する。
-- [ ] `local_021` から `local_026` を `spec/agent/complete/` へ移せる状態にする。
-
-## 7. 親計画との依存関係
-
-本仕様は親計画 `local_021` の M6 / M7 を担当する。`local_022` から `local_025` の実装結果を前提にするため、swbt service、factory、runtime / CLI、GUI の責務を再定義しない。
-
-`local_026` で発見した実装不備は、該当する子仕様へ戻す。mapper や Y 軸既定の修正は `local_023`、CLI option の修正は `local_024`、GUI lifetime の修正は `local_025` の責務である。docs と完了記録だけで吸収しない。
-
-## 8. 完了後に次へ渡す成果
-
-完了後に残す成果は次の通りである。
-
-| 成果 | 渡し先 | 内容 |
-|------|--------|------|
-| 実機検証 summary | `spec/agent/complete/local_026/` | pairing、reconnect、Button、D-pad、stick、neutral、short press の判定 |
-| 確定値 | `docs/architecture/swbt-integration/testing-rollout.md` | `invert_stick_y` 既定値、short press 最小推奨 duration、public flush 要否 |
-| 利用者手順 | `docs/user-guide/` | install、device setup、CLI、GUI、troubleshooting |
-| closeout 記録 | `spec/agent/complete/local_021/` | 親計画の完了条件、子仕様の完了状態、検証コマンド |
-| 残課題 | `spec/dev-journal.md` または新規 wip 仕様 | 実装範囲外の改善、追加自動化、upstream swbt-python 要望 |
-
-`local_021` を complete へ移す条件は、serial backend が壊れていないこと、swbt extra 未導入環境で import error が出ないこと、swbt 実機検証が要約付きで残っていること、利用者 docs が `mkdocs build --strict` を通ることである。
+- [ ] short press の最小推奨 duration と public flush 要否を判定する。
+- [ ] 利用者 docs に install、device setup、CLI、GUI、troubleshooting を反映する。
+- [ ] macro development docs に `Command.imu(...)` と swbt 非対応入力を反映する。
+- [ ] `docs/architecture/swbt-integration/testing-rollout.md` に確定値を反映する。
+- [ ] `local_021` から `local_026` に実装結果と検証結果を反映する。
+- [ ] 残課題を `spec/dev-journal.md` または新規 wip 仕様へ分離する。
+- [ ] complete 移動前に `uv run mkdocs build --strict` と通常 gate が通ることを確認する。


### PR DESCRIPTION
## Summary

`docs/architecture/swbt-integration/testing-rollout.md` に沿って、swbt-python 連携の実装仕様を親計画と 5 つの子仕様に整理しました。

## Related

- User request: `testing-rollout.md` に従った swbt-python integration spec 作成

## Changes

- `local_021` を swbt controller backend の親計画として整理し、導入順序と完了条件を子仕様へ割り当てました。
- `local_022` で swbt optional dependency、controller model、settings、IMU command、adapter discovery の foundation を定義しました。
- `local_023` で `SwbtControllerSession`、mapper、port、factory、dummy session の core 実装仕様を定義しました。
- `local_024` で runtime builder と `nyxpy run` / `nyxpy swbt` CLI の連携仕様を定義しました。
- `local_025` で GUI の backend 選択、adapter refresh、pair/reconnect/disconnect、manual input 排他を定義しました。
- `local_026` で実機検証、docs 反映、closeout 条件を定義しました。

## Commit Log

```text
fcd141c docs(swbt): 連携仕様を実装単位へ整理
```

## Testing

```text
git diff --check
# passed; line-ending warnings only

rg -n "SwbtGamepadService|0\.1\.1|<0\.2\.0|io/swbt_adapter\.py|hardware/swbt_service\.py|swbt_adapter\.py" spec/agent/wip/local_021 spec/agent/wip/local_022 spec/agent/wip/local_023 spec/agent/wip/local_024 spec/agent/wip/local_025 spec/agent/wip/local_026
# no matches
```

`ruff`、`ty`、`pytest` は未実行です。仕様書のみの変更で、実装コードは変更していません。

## Checklist

- [x] lint / format チェック通過
- [ ] 既存テスト通過（仕様書のみのため未実行）
- [x] コミット prefix (feat/fix 等) が変更の動機と一致している
- [x] 新規・変更コードに対するテスト追加（該当なし）
- [ ] 型チェック通過（仕様書のみのため未実行）

## Review Notes

- `swbt-python` の対象版は PyPI JSON で `0.2.0` を確認し、仕様上は `>=0.2.0,<0.3.0` に揃えています。
- 旧 `SwbtGamepadService` 方針ではなく、設計文書側の `SwbtControllerSession` / `hardware/swbt` package 方針へ寄せています。