### PR TITLE
feat(swbt): core adapter serviceを追加

### DIFF
--- a/spec/agent/complete/local_023/SWBT_CORE_ADAPTER_SERVICE.md
+++ b/spec/agent/complete/local_023/SWBT_CORE_ADAPTER_SERVICE.md
@@ -4,13 +4,13 @@
 
 ### 1.1 目的
 
-`swbt-python` の async controller API を NyX の同期 `ControllerOutputPort` として扱う core 部品を追加する。対象は `SwbtControllerSession`、diagnostics writer adapter、`NyxSwbtInputMapper`、`SwbtControllerOutputPort`、`SwbtControllerOutputPortFactory`、`DummySwbtControllerSession` である。
+`swbt-python` の同期 controller API を NyX の `ControllerOutputPort` として扱う core 部品を追加する。対象は `SwbtControllerSession`、diagnostics writer adapter、`NyxSwbtInputMapper`、`SwbtControllerOutputPort`、`SwbtControllerOutputPortFactory`、`DummySwbtControllerSession` である。
 
 ### 1.2 用語定義
 
 | 用語 | 定義 |
 |------|------|
-| `SwbtControllerSession` | swbt controller instance、event loop thread、pair/reconnect、apply、neutral、close を所有する backend 内部部品 |
+| `SwbtControllerSession` | swbt controller instance、pair/reconnect、apply、neutral、close を所有する backend 内部部品 |
 | diagnostics writer adapter | swbt 側 diagnostics writer を NyX の `LoggerPort` と実機 evidence writer へ接続する adapter |
 | `DummySwbtControllerSession` | 実機なしテストで `InputState` を記録する session double |
 | `NyxSwbtState` | port が持つ現在入力状態。button、left stick、right stick、IMU frames を含む |
@@ -21,7 +21,7 @@
 
 ### 1.3 背景・問題
 
-serial backend は同期 `send()` で入力を送れる。一方、swbt backend は async resource と report loop を持つため、`ControllerOutputPort` から直接 `swbt-python` の coroutine を呼べない。session が event loop thread と lifecycle を所有し、port は入力状態と mapper に集中する必要がある。
+serial backend は同期 `send()` で入力を送れる。swbt backend も `swbt-python 0.2.0` の公開 controller API は同期呼び出しで扱えるため、NyX 側では session が controller lifecycle と直列化を所有し、port は入力状態と mapper に集中する。
 
 GUI manual input と macro runtime は同じ adapter を同時に開けない。factory は同じ session key の session を cache し、serial factory と同じく接続資源の lifetime を所有する。ただし同じ port object は共有しない。
 
@@ -43,11 +43,17 @@ GUI manual input と macro runtime は同じ adapter を同時に開けない。
 - `hardware/swbt/manual.py`、`SwbtManualInputSession`、`swbt_*.py` module は追加しない。
 - CLI、GUI、runtime builder の接続は `local_024` と `local_025` に残す。
 
+### 1.6 完了結果
+
+- `SwbtControllerSession` は `swbt-python 0.2.0` の同期公開 API に合わせ、event loop thread を持たずに `RLock` で lifecycle と入力適用を直列化する形で実装した。
+- `SwbtControllerOutputPortFactory` は同一 session key の session を再利用し、`create()` では `open()` と `reconnect()` だけを行う。`pair()` は GUI / CLI からの明示操作用として分離した。
+- `SwbtControllerOutputPort` は現在入力状態を保持し、`press` / `hold` / `release` / `imu` ごとに完全な `InputState` を session へ渡す。port close は neutral だけを送り、session close は factory が担う。
+
 ## 2. 対象ファイル
 
 | ファイル | 変更種別 | 変更内容 |
 |----------|----------|----------|
-| `src/nyxpy/framework/core/hardware/swbt/session.py` | 新規 | `SwbtControllerSession`、`DummySwbtControllerSession`、event loop bridge、connection lifecycle を実装する |
+| `src/nyxpy/framework/core/hardware/swbt/session.py` | 新規 | `SwbtControllerSession`、`DummySwbtControllerSession`、connection lifecycle を実装する |
 | `src/nyxpy/framework/core/hardware/swbt/diagnostics.py` | 新規 | swbt diagnostics writer を `LoggerPort` と JSONL evidence writer へ接続する adapter を実装する |
 | `src/nyxpy/framework/core/hardware/swbt/mapper.py` | 新規 | `NyxSwbtState`、`NyxSwbtInputMapper`、button / D-pad / stick / IMU mapping を実装する |
 | `src/nyxpy/framework/core/hardware/swbt/controller.py` | 新規 | `SwbtControllerOutputPort` を実装する |
@@ -76,7 +82,7 @@ GUI manual input と macro runtime は同じ adapter を同時に開けない。
 
 ### レイヤー構成
 
-`controller.py` は port contract、`mapper.py` は入力変換、`session.py` は async lifecycle、`factory.py` は session cache と pair/reconnect/disconnect/status 操作を担当する。factory 以外が GUI state や runtime builder を知らない。
+`controller.py` は port contract、`mapper.py` は入力変換、`session.py` は controller lifecycle、`factory.py` は session cache と pair/reconnect/disconnect/status 操作を担当する。factory 以外が GUI state や runtime builder を知らない。
 
 ### 性能要件
 
@@ -90,7 +96,7 @@ GUI manual input と macro runtime は同じ adapter を同時に開けない。
 
 ### 並行性・スレッド安全性
 
-session は event loop thread と `RLock` を持ち、connection operation と input apply を直列化する。`Future.result()` を待つ間に不要な lock を保持し続けない。port は自身の `NyxSwbtState` を `RLock` で守る。
+session は `RLock` を持ち、connection operation と input apply を直列化する。swbt 公開 API が同期 API であるため、event loop thread は追加しない。port は自身の `NyxSwbtState` を `RLock` で守る。
 
 ## 4. 実装仕様
 
@@ -224,7 +230,9 @@ reset_on_port_create
 |------------|----------|----------|
 | ユニット | `test_session_open_does_not_pair_or_reconnect` | `open()` が接続操作を開始しない |
 | ユニット | `test_factory_create_reconnects_without_pairing` | `create()` が reconnect のみ行う |
-| ユニット | `test_session_close_trails_neutral_and_stops_loop` | close 時に neutral と loop stop を行う |
+| ユニット | `test_session_pair_reconnect_apply_status_and_close` | pair / reconnect / apply / status / close の同期 lifecycle |
+| ユニット | `test_session_requires_adapter_before_open` | adapter 未選択時の session open 失敗 |
+| ユニット | `test_dummy_session_records_state_without_bluetooth_transport` | dummy session が Bluetooth transport を開かず state を記録する |
 | ユニット | `test_diagnostics_writer_logs_to_logger_port` | swbt diagnostics が technical log へ流れる |
 | ユニット | `test_diagnostics_writer_can_tee_to_jsonl` | 実機 evidence 用 tee writer |
 | ユニット | `test_mapper_maps_buttons_with_current_nyx_names` | `CAP` / `LS` / `RS` を swbt 名へ変換する |
@@ -232,11 +240,13 @@ reset_on_port_create
 | ユニット | `test_mapper_converts_stick_xy_and_rejects_joycon_missing_stick` | stick 変換と Joy-Con capability |
 | ユニット | `test_mapper_normalizes_imu_one_or_three_frames` | IMU frame 数の規則 |
 | ユニット | `test_port_press_hold_release_apply_complete_state` | port 操作が完全 state を apply する |
+| ユニット | `test_port_imu_and_release_all_use_neutral` | IMU と release all が neutral state を使う |
 | ユニット | `test_port_close_sends_neutral_without_session_close` | port close は transport を閉じない |
-| ユニット | `test_factory_reuses_session_for_same_key` | 同じ key で session を共有し port は新規 |
-| ユニット | `test_factory_pair_reconnect_are_explicit_operations` | pair/reconnect が明示操作として session へ渡る |
-| ユニット | `test_factory_disconnect_closes_cached_session_only` | disconnect が cached session だけを閉じる |
-| ユニット | `test_factory_status_returns_cached_session_status` | status が factory-managed session 状態を返す |
+| ユニット | `test_port_rejects_backend_unsupported_apis` | touch / keyboard / sleep control を silent no-op にしない |
+| ユニット | `test_factory_reuses_session_for_same_key_and_ports_are_new` | 同じ key で session を共有し port は新規 |
+| ユニット | `test_factory_allows_dummy_fallback_only_for_create` | dummy fallback が create だけに限定される |
+| ユニット | `test_factory_pair_reconnect_disconnect_and_status_are_explicit_operations` | pair / reconnect / disconnect / status が明示操作として session へ渡る |
+| ユニット | `test_factory_close_closes_cached_sessions` | factory close が cached session を閉じる |
 | ユニット | `test_factory_does_not_create_manual_session_type` | `SwbtManualInputSession` が存在しない |
 
 検証コマンド:
@@ -246,22 +256,24 @@ uv run ruff format .
 uv run ruff check .
 uv run ty check src/nyxpy --output-format concise --no-progress
 uv run pytest tests/unit/framework/hardware/swbt/test_session.py tests/unit/framework/hardware/swbt/test_diagnostics.py tests/unit/framework/hardware/swbt/test_mapper.py tests/unit/framework/hardware/swbt/test_controller.py tests/unit/framework/hardware/swbt/test_factory.py
+uv run pytest tests/unit/framework/hardware/swbt tests/unit/framework/io/test_controller_config.py tests/unit/framework/io/test_ports.py tests/unit/framework/runtime/test_default_command_ports.py tests/unit/cli/test_swbt_cli.py tests/unit/cli/test_run_cli_parser.py tests/unit/framework/settings/test_settings_schema.py
+uv run pytest tests/unit -m "not realdevice and not swbt"
 ```
 
 ## 6. 実装チェックリスト
 
-- [ ] `SwbtControllerSession` を実装し、open と pair/reconnect を分離する。
-- [ ] `start()` を追加せず、factory `create()` から `open()` + `reconnect()` を呼ぶ。
-- [ ] session の event loop thread、operation timeout、close idempotency を実装する。
-- [ ] swbt diagnostics writer を `LoggerPort` と JSONL evidence writer へ接続する adapter を実装する。
-- [ ] `DummySwbtControllerSession` を実装し、Bluetooth transport を開かず state を記録する。
-- [ ] `NyxSwbtState` と `NyxSwbtInputMapper` を実装する。
-- [ ] button、D-pad、stick、IMU、Joy-Con capability の mapper test を追加する。
-- [ ] `SwbtControllerOutputPort` を実装し、非対応入力を silent no-op にしない。
-- [ ] port close と release all で IMU を含め neutral に戻す。
-- [ ] port close が session を閉じないことを確認する。
-- [ ] `SwbtControllerOutputPortFactory` を実装し、session key と session cache を管理する。
-- [ ] `create()` が暗黙 pairing せず reconnect のみ行うことを確認する。
-- [ ] `pair()` / `reconnect()` / `disconnect()` / `status()` を明示 lifecycle 操作として実装する。
-- [ ] `pair()` / `reconnect()` が dummy fallback しないことを確認する。
-- [ ] `hardware/swbt/manual.py`、`SwbtManualInputSession`、`swbt_*.py` module がないことを静的に確認する。
+- [x] `SwbtControllerSession` を実装し、open と pair/reconnect を分離する。
+- [x] `start()` を追加せず、factory `create()` から `open()` + `reconnect()` を呼ぶ。
+- [x] `swbt-python 0.2.0` の同期公開 API に合わせ、session の直列化と close idempotency を実装する。
+- [x] swbt diagnostics writer を `LoggerPort` と JSONL evidence writer へ接続する adapter を実装する。
+- [x] `DummySwbtControllerSession` を実装し、Bluetooth transport を開かず state を記録する。
+- [x] `NyxSwbtState` と `NyxSwbtInputMapper` を実装する。
+- [x] button、D-pad、stick、IMU、Joy-Con capability の mapper test を追加する。
+- [x] `SwbtControllerOutputPort` を実装し、非対応入力を silent no-op にしない。
+- [x] port close と release all で IMU を含め neutral に戻す。
+- [x] port close が session を閉じないことを確認する。
+- [x] `SwbtControllerOutputPortFactory` を実装し、session key と session cache を管理する。
+- [x] `create()` が暗黙 pairing せず reconnect のみ行うことを確認する。
+- [x] `pair()` / `reconnect()` / `disconnect()` / `status()` を明示 lifecycle 操作として実装する。
+- [x] `pair()` / `reconnect()` が dummy fallback しないことを確認する。
+- [x] `hardware/swbt/manual.py`、`SwbtManualInputSession`、`swbt_*.py` module がないことを静的に確認する。

--- a/src/nyxpy/framework/core/hardware/swbt/__init__.py
+++ b/src/nyxpy/framework/core/hardware/swbt/__init__.py
@@ -9,10 +9,26 @@ from nyxpy.framework.core.hardware.swbt.config import (
     resolve_controller_model,
     supported_controller_models,
 )
+from nyxpy.framework.core.hardware.swbt.controller import SwbtControllerOutputPort
 from nyxpy.framework.core.hardware.swbt.discovery import (
     SwbtAdapterDiscoveryService,
     SwbtAdapterView,
     resolve_adapter,
+)
+from nyxpy.framework.core.hardware.swbt.factory import (
+    SwbtControllerOutputPortFactory,
+    SwbtSessionKey,
+    session_key,
+)
+from nyxpy.framework.core.hardware.swbt.mapper import (
+    NyxSwbtInputMapper,
+    NyxSwbtState,
+    normalize_imu_frames,
+)
+from nyxpy.framework.core.hardware.swbt.session import (
+    DummySwbtControllerSession,
+    DummySwbtStatus,
+    SwbtControllerSession,
 )
 
 __all__ = [
@@ -20,10 +36,20 @@ __all__ = [
     "SwbtAdapterView",
     "SwbtControllerConfig",
     "SwbtControllerModel",
+    "SwbtControllerOutputPort",
+    "SwbtControllerOutputPortFactory",
+    "SwbtControllerSession",
     "SwbtControllerType",
     "SwbtInputCapabilities",
+    "SwbtSessionKey",
+    "DummySwbtControllerSession",
+    "DummySwbtStatus",
+    "NyxSwbtInputMapper",
+    "NyxSwbtState",
+    "normalize_imu_frames",
     "parse_controller_type",
     "resolve_adapter",
     "resolve_controller_model",
+    "session_key",
     "supported_controller_models",
 ]

--- a/src/nyxpy/framework/core/hardware/swbt/controller.py
+++ b/src/nyxpy/framework/core/hardware/swbt/controller.py
@@ -1,0 +1,104 @@
+"""swbt ControllerOutputPort 実装。"""
+
+from __future__ import annotations
+
+from threading import RLock
+
+from nyxpy.framework.core.constants import IMUFrame, KeyCode, KeyType, SpecialKeyCode
+from nyxpy.framework.core.hardware.swbt.config import SwbtControllerModel
+from nyxpy.framework.core.hardware.swbt.errors import swbt_port_closed
+from nyxpy.framework.core.hardware.swbt.mapper import NyxSwbtInputMapper, NyxSwbtState
+from nyxpy.framework.core.io.ports import ControllerOutputPort
+
+
+class SwbtControllerOutputPort(ControllerOutputPort):
+    """swbt session に完全な InputState を渡す controller port。"""
+
+    def __init__(
+        self,
+        *,
+        session,
+        model: SwbtControllerModel,
+        mapper: NyxSwbtInputMapper | None = None,
+    ) -> None:
+        """session、model、mapper、初期 state を保持し、neutral を送る。"""
+        self._session = session
+        self._mapper = mapper or NyxSwbtInputMapper(model)
+        self._state = NyxSwbtState.neutral()
+        self._lock = RLock()
+        self._closed = False
+        self._session.neutral()
+
+    @property
+    def supports_imu(self) -> bool:
+        """Swbt backend は IMU 入力に対応する。"""
+        return True
+
+    def press(self, keys: tuple[KeyType, ...]) -> None:
+        """Keys を現在状態へ追加して送信する。"""
+        with self._lock:
+            self._ensure_open()
+            self._state = self._mapper.press(self._state, keys)
+            self._apply_locked()
+
+    def hold(self, keys: tuple[KeyType, ...]) -> None:
+        """現在状態を破棄し、keys だけを保持して送信する。"""
+        with self._lock:
+            self._ensure_open()
+            self._state = self._mapper.hold(keys)
+            self._apply_locked()
+
+    def release(self, keys: tuple[KeyType, ...] = ()) -> None:
+        """Keys を解放する。keys が空なら全入力を neutral に戻す。"""
+        with self._lock:
+            self._ensure_open()
+            self._state = self._mapper.release(self._state, keys)
+            if keys:
+                self._apply_locked()
+            else:
+                self._session.neutral()
+
+    def imu(self, *frames: IMUFrame) -> None:
+        """IMU frame を現在状態へ反映して送信する。"""
+        with self._lock:
+            self._ensure_open()
+            self._state = self._mapper.set_imu(self._state, frames)
+            self._apply_locked()
+
+    def keyboard(self, text: str) -> None:
+        """Swbt backend は keyboard 入力を持たない。"""
+        raise NotImplementedError("swbt backend does not support keyboard input.")
+
+    def type_key(self, key: KeyCode | SpecialKeyCode) -> None:
+        """Swbt backend は keyboard 入力を持たない。"""
+        raise NotImplementedError("swbt backend does not support keyboard input.")
+
+    def touch_down(self, x: int, y: int) -> None:
+        """Swbt backend は touch 入力を持たない。"""
+        raise NotImplementedError("swbt backend does not support touch input.")
+
+    def touch_up(self) -> None:
+        """Swbt backend は touch 入力を持たない。"""
+        raise NotImplementedError("swbt backend does not support touch input.")
+
+    def disable_sleep(self, enabled: bool = True) -> None:
+        """Swbt backend は sleep control を持たない。"""
+        raise NotImplementedError("swbt backend does not support sleep control.")
+
+    def close(self) -> None:
+        """Neutral を試みるが session 自体は閉じない。"""
+        with self._lock:
+            if self._closed:
+                return
+            self._state = NyxSwbtState.neutral()
+            try:
+                self._session.neutral()
+            finally:
+                self._closed = True
+
+    def _apply_locked(self) -> None:
+        self._session.apply(self._mapper.to_input_state(self._state))
+
+    def _ensure_open(self) -> None:
+        if self._closed:
+            raise swbt_port_closed()

--- a/src/nyxpy/framework/core/hardware/swbt/diagnostics.py
+++ b/src/nyxpy/framework/core/hardware/swbt/diagnostics.py
@@ -1,0 +1,57 @@
+"""swbt diagnostics writer adapter。"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from pathlib import Path
+from typing import TextIO
+
+from nyxpy.framework.core.logger.ports import LoggerPort
+
+
+class LoggerDiagnosticsWriter:
+    """swbt diagnostics trace を NyX technical log へ流す writer。"""
+
+    def __init__(self, logger: LoggerPort) -> None:
+        """出力先 logger を保持する。"""
+        self._logger = logger
+
+    def write(self, text: str) -> int:
+        """Trace text を行単位で technical log に記録する。"""
+        for line in text.splitlines():
+            if line:
+                self._logger.technical(
+                    "DEBUG",
+                    line,
+                    component="SwbtDiagnostics",
+                    event="swbt.diagnostics",
+                )
+        return len(text)
+
+    def flush(self) -> None:
+        """Logger 出力には明示 flush がないため何もしない。"""
+
+
+class TeeDiagnosticsWriter:
+    """複数 writer へ同じ diagnostics trace を流す writer。"""
+
+    def __init__(self, writers: Iterable[TextIO]) -> None:
+        """Tee 先 writer を tuple として保持する。"""
+        self._writers = tuple(writers)
+
+    def write(self, text: str) -> int:
+        """すべての writer へ text を書き込む。"""
+        for writer in self._writers:
+            writer.write(text)
+        return len(text)
+
+    def flush(self) -> None:
+        """Flush を持つ writer へ反映する。"""
+        for writer in self._writers:
+            writer.flush()
+
+
+def open_diagnostics_trace(path: Path) -> TextIO:
+    """JSONL evidence 用 diagnostics trace file を開く。"""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    return path.open("a", encoding="utf-8")

--- a/src/nyxpy/framework/core/hardware/swbt/errors.py
+++ b/src/nyxpy/framework/core/hardware/swbt/errors.py
@@ -44,3 +44,94 @@ def swbt_device_error(
         component=component,
         cause=cause,
     )
+
+
+def imu_frame_count_invalid(count: int) -> DeviceError:
+    """IMU frame 数不正を NyX の device error へ変換する。"""
+    return DeviceError(
+        "IMU input requires exactly 1 or 3 frames",
+        code="NYX_IMU_FRAME_COUNT_INVALID",
+        component="NyxSwbtInputMapper",
+        details={"count": count},
+    )
+
+
+def swbt_port_closed() -> DeviceError:
+    """Close 後の port 操作を NyX の device error へ変換する。"""
+    return DeviceError(
+        "swbt controller output port is closed",
+        code="NYX_SWBT_PORT_CLOSED",
+        component="SwbtControllerOutputPort",
+    )
+
+
+def swbt_not_connected(component: str = "SwbtControllerSession") -> DeviceError:
+    """未接続 session 操作を NyX の device error へ変換する。"""
+    return DeviceError(
+        "swbt controller is not connected",
+        code="NYX_SWBT_NOT_CONNECTED",
+        component=component,
+    )
+
+
+def swbt_input_unsupported(message: str, *, component: str = "NyxSwbtInputMapper") -> DeviceError:
+    """Controller type 非対応入力を NyX の device error へ変換する。"""
+    return DeviceError(
+        message,
+        code="NYX_SWBT_INPUT_UNSUPPORTED",
+        component=component,
+    )
+
+
+def swbt_input_invalid(message: str, *, component: str = "NyxSwbtInputMapper") -> DeviceError:
+    """Swbt 入力値不正を NyX の device error へ変換する。"""
+    return DeviceError(
+        message,
+        code="NYX_SWBT_INPUT_INVALID",
+        component=component,
+    )
+
+
+def map_swbt_exception(exc: BaseException, *, component: str) -> ConfigurationError | DeviceError:
+    """swbt-python の公開例外を framework error に変換する。"""
+    name = type(exc).__name__
+    if name == "TransportOpenError":
+        return ConfigurationError(
+            "swbt transport open failed",
+            code="NYX_SWBT_TRANSPORT_OPEN_FAILED",
+            component=component,
+            cause=exc,
+        )
+    if name == "ConnectionTimeoutError":
+        return ConfigurationError(
+            "swbt connection timed out",
+            code="NYX_SWBT_CONNECTION_TIMED_OUT",
+            component=component,
+            cause=exc,
+        )
+    if name == "ConnectionFailedError":
+        return ConfigurationError(
+            "swbt connection failed",
+            code="NYX_SWBT_CONNECTION_FAILED",
+            component=component,
+            cause=exc,
+        )
+    if name == "InvalidKeyStoreError":
+        return ConfigurationError(
+            "swbt key store is invalid",
+            code="NYX_SWBT_KEY_STORE_INVALID",
+            component=component,
+            cause=exc,
+        )
+    if name == "UnsupportedInputError":
+        return swbt_input_unsupported("swbt input is unsupported", component=component)
+    if name == "InvalidInputError":
+        return swbt_input_invalid("swbt input is invalid", component=component)
+    if name == "ClosedError":
+        return swbt_not_connected(component)
+    return ConfigurationError(
+        "swbt operation failed",
+        code="NYX_SWBT_CONNECTION_FAILED",
+        component=component,
+        cause=exc,
+    )

--- a/src/nyxpy/framework/core/hardware/swbt/factory.py
+++ b/src/nyxpy/framework/core/hardware/swbt/factory.py
@@ -1,0 +1,132 @@
+"""swbt ControllerOutputPort factory。"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+
+from nyxpy.framework.core.hardware.swbt.config import SwbtControllerConfig, SwbtControllerType
+from nyxpy.framework.core.hardware.swbt.controller import SwbtControllerOutputPort
+from nyxpy.framework.core.hardware.swbt.session import (
+    DummySwbtControllerSession,
+    SwbtControllerSession,
+    SwbtControllerSessionProtocol,
+)
+from nyxpy.framework.core.macro.exceptions import ConfigurationError, DeviceError
+
+type SessionFactory = Callable[[SwbtControllerConfig], SwbtControllerSessionProtocol]
+type DummySessionFactory = Callable[[], SwbtControllerSessionProtocol]
+
+
+@dataclass(frozen=True, slots=True)
+class SwbtSessionKey:
+    """factory session cache の key。"""
+
+    controller_type: SwbtControllerType
+    adapter: str | None
+    key_store_path: Path
+    report_period_us: int | None
+
+
+class SwbtControllerOutputPortFactory:
+    """swbt session cache と lifecycle 操作を所有する factory。"""
+
+    def __init__(
+        self,
+        *,
+        session_factory: SessionFactory | None = None,
+        dummy_session_factory: DummySessionFactory | None = None,
+    ) -> None:
+        """Session factory と cache を初期化する。"""
+        self._session_factory = session_factory or (lambda config: SwbtControllerSession(config))
+        self._dummy_session_factory = dummy_session_factory or DummySwbtControllerSession
+        self._sessions: dict[SwbtSessionKey, SwbtControllerSessionProtocol] = {}
+
+    def create(
+        self,
+        *,
+        config: SwbtControllerConfig,
+        allow_dummy: bool,
+        timeout_sec: float | None = None,
+    ) -> SwbtControllerOutputPort:
+        """Runtime / GUI lifetime 用 port を作る。pairing は暗黙実行しない。"""
+        key = session_key(config)
+        session = self._sessions.get(key)
+        if session is None:
+            session = self._session_factory(config)
+            self._sessions[key] = session
+        try:
+            session.open()
+            if not session.connected:
+                session.reconnect(timeout_sec=timeout_sec or config.connect_timeout_sec)
+        except (ConfigurationError, DeviceError):
+            if not allow_dummy:
+                raise
+            session = self._dummy_session_factory()
+            session.open()
+            session.reconnect(timeout_sec=timeout_sec or config.connect_timeout_sec)
+            self._sessions[key] = session
+        return SwbtControllerOutputPort(session=session, model=config.model)
+
+    def pair(self, config: SwbtControllerConfig, *, timeout_sec: float | None = None) -> object:
+        """明示 pairing を実行する。dummy fallback はしない。"""
+        session = self._session_for(config)
+        session.open()
+        return session.pair(timeout_sec=timeout_sec or config.connect_timeout_sec)
+
+    def reconnect(
+        self, config: SwbtControllerConfig, *, timeout_sec: float | None = None
+    ) -> object:
+        """明示 reconnect を実行する。dummy fallback はしない。"""
+        session = self._session_for(config)
+        session.open()
+        return session.reconnect(timeout_sec=timeout_sec or config.connect_timeout_sec)
+
+    def disconnect(self, config: SwbtControllerConfig) -> None:
+        """factory-managed cached session だけを閉じる。"""
+        session = self._sessions.pop(session_key(config), None)
+        if session is None:
+            return
+        try:
+            session.neutral()
+        finally:
+            session.close()
+
+    def status(self, config: SwbtControllerConfig) -> object | None:
+        """factory-managed cached session の status を返す。"""
+        session = self._sessions.get(session_key(config))
+        if session is None:
+            return None
+        return session.status()
+
+    def close(self) -> None:
+        """Cache している session をすべて閉じる。"""
+        errors: list[Exception] = []
+        sessions = tuple(self._sessions.values())
+        self._sessions.clear()
+        for session in sessions:
+            try:
+                session.close()
+            except Exception as exc:
+                errors.append(exc)
+        if errors:
+            raise ExceptionGroup("SwbtControllerOutputPortFactory close failed", errors)
+
+    def _session_for(self, config: SwbtControllerConfig) -> SwbtControllerSessionProtocol:
+        key = session_key(config)
+        session = self._sessions.get(key)
+        if session is None:
+            session = self._session_factory(config)
+            self._sessions[key] = session
+        return session
+
+
+def session_key(config: SwbtControllerConfig) -> SwbtSessionKey:
+    """Config から session cache key を作る。"""
+    return SwbtSessionKey(
+        controller_type=config.model.controller_type,
+        adapter=config.adapter,
+        key_store_path=config.key_store_path,
+        report_period_us=config.report_period_us,
+    )

--- a/src/nyxpy/framework/core/hardware/swbt/mapper.py
+++ b/src/nyxpy/framework/core/hardware/swbt/mapper.py
@@ -1,0 +1,244 @@
+"""NyX controller 入力から swbt InputState への mapper。"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from nyxpy.framework.core.constants import (
+    Button,
+    Hat,
+    IMUFrame,
+    KeyType,
+    LStick,
+    RStick,
+)
+from nyxpy.framework.core.hardware.swbt.config import SwbtControllerModel
+from nyxpy.framework.core.hardware.swbt.errors import (
+    imu_frame_count_invalid,
+    swbt_input_invalid,
+    swbt_input_unsupported,
+)
+
+
+def _neutral_imu_frames() -> tuple[IMUFrame, IMUFrame, IMUFrame]:
+    frame = IMUFrame.neutral()
+    return (frame, frame, frame)
+
+
+@dataclass(frozen=True, slots=True)
+class NyxSwbtState:
+    """SwbtControllerOutputPort が保持する NyX 側入力状態。"""
+
+    buttons: frozenset[Button] = field(default_factory=frozenset)
+    dpad_buttons: frozenset[object] = field(default_factory=frozenset)
+    left_stick: LStick | None = None
+    right_stick: RStick | None = None
+    imu_frames: tuple[IMUFrame, IMUFrame, IMUFrame] = field(default_factory=_neutral_imu_frames)
+
+    @classmethod
+    def neutral(cls) -> NyxSwbtState:
+        """全入力を neutral にした状態を返す。"""
+        return cls()
+
+
+class NyxSwbtInputMapper:
+    """NyX の入力 model を swbt の入力 model へ変換する。"""
+
+    def __init__(self, model: SwbtControllerModel) -> None:
+        """Controller model と capabilities を保持する。"""
+        self.model = model
+
+    def press(self, state: NyxSwbtState, keys: tuple[KeyType, ...]) -> NyxSwbtState:
+        """既存状態へ keys を追加または反映する。"""
+        next_state = state
+        for key in keys:
+            next_state = self._press_one(next_state, key)
+        return next_state
+
+    def hold(self, keys: tuple[KeyType, ...]) -> NyxSwbtState:
+        """既存状態を破棄して keys のみを保持する。"""
+        return self.press(NyxSwbtState.neutral(), keys)
+
+    def release(self, state: NyxSwbtState, keys: tuple[KeyType, ...] = ()) -> NyxSwbtState:
+        """状態から keys を解除する。keys が空なら全入力を neutral にする。"""
+        if not keys:
+            return NyxSwbtState.neutral()
+        next_state = state
+        for key in keys:
+            next_state = self._release_one(next_state, key)
+        return next_state
+
+    def set_imu(self, state: NyxSwbtState, frames: tuple[IMUFrame, ...]) -> NyxSwbtState:
+        """IMU frame だけを置き換える。"""
+        return NyxSwbtState(
+            buttons=state.buttons,
+            dpad_buttons=state.dpad_buttons,
+            left_stick=state.left_stick,
+            right_stick=state.right_stick,
+            imu_frames=normalize_imu_frames(frames),
+        )
+
+    def to_input_state(self, state: NyxSwbtState):
+        """NyX 側状態を swbt.InputState に変換する。"""
+        from swbt import InputState
+
+        buttons = {_swbt_button(button) for button in state.buttons}
+        buttons.update(state.dpad_buttons)
+        input_state = InputState.neutral().with_buttons(buttons)
+        input_state = input_state.with_sticks(
+            left_stick=_swbt_stick(state.left_stick),
+            right_stick=_swbt_stick(state.right_stick),
+        )
+        return input_state.with_imu(*(_swbt_imu_frame(frame) for frame in state.imu_frames))
+
+    def _press_one(self, state: NyxSwbtState, key: KeyType) -> NyxSwbtState:
+        if isinstance(key, Button):
+            self._require_button(key)
+            return NyxSwbtState(
+                buttons=state.buttons | {key},
+                dpad_buttons=state.dpad_buttons,
+                left_stick=state.left_stick,
+                right_stick=state.right_stick,
+                imu_frames=state.imu_frames,
+            )
+        if isinstance(key, Hat):
+            return NyxSwbtState(
+                buttons=state.buttons,
+                dpad_buttons=_swbt_dpad_buttons(key),
+                left_stick=state.left_stick,
+                right_stick=state.right_stick,
+                imu_frames=state.imu_frames,
+            )
+        if isinstance(key, LStick):
+            self._require_left_stick()
+            return NyxSwbtState(
+                buttons=state.buttons,
+                dpad_buttons=state.dpad_buttons,
+                left_stick=key,
+                right_stick=state.right_stick,
+                imu_frames=state.imu_frames,
+            )
+        if isinstance(key, RStick):
+            self._require_right_stick()
+            return NyxSwbtState(
+                buttons=state.buttons,
+                dpad_buttons=state.dpad_buttons,
+                left_stick=state.left_stick,
+                right_stick=key,
+                imu_frames=state.imu_frames,
+            )
+        raise swbt_input_unsupported(f"swbt backend does not support input: {type(key).__name__}")
+
+    def _release_one(self, state: NyxSwbtState, key: KeyType) -> NyxSwbtState:
+        if isinstance(key, Button):
+            return NyxSwbtState(
+                buttons=state.buttons - {key},
+                dpad_buttons=state.dpad_buttons,
+                left_stick=state.left_stick,
+                right_stick=state.right_stick,
+                imu_frames=state.imu_frames,
+            )
+        if isinstance(key, Hat):
+            return NyxSwbtState(
+                buttons=state.buttons,
+                dpad_buttons=frozenset(),
+                left_stick=state.left_stick,
+                right_stick=state.right_stick,
+                imu_frames=state.imu_frames,
+            )
+        if isinstance(key, LStick):
+            return NyxSwbtState(
+                buttons=state.buttons,
+                dpad_buttons=state.dpad_buttons,
+                left_stick=None,
+                right_stick=state.right_stick,
+                imu_frames=state.imu_frames,
+            )
+        if isinstance(key, RStick):
+            return NyxSwbtState(
+                buttons=state.buttons,
+                dpad_buttons=state.dpad_buttons,
+                left_stick=state.left_stick,
+                right_stick=None,
+                imu_frames=state.imu_frames,
+            )
+        raise swbt_input_unsupported(f"swbt backend does not support input: {type(key).__name__}")
+
+    def _require_button(self, button: Button) -> None:
+        if button not in self.model.capabilities.buttons:
+            raise swbt_input_unsupported(
+                f"{self.model.display_name} does not support button {button.name}"
+            )
+
+    def _require_left_stick(self) -> None:
+        if not self.model.capabilities.left_stick:
+            raise swbt_input_unsupported(f"{self.model.display_name} does not support left stick")
+
+    def _require_right_stick(self) -> None:
+        if not self.model.capabilities.right_stick:
+            raise swbt_input_unsupported(f"{self.model.display_name} does not support right stick")
+
+
+def normalize_imu_frames(frames: tuple[IMUFrame, ...]) -> tuple[IMUFrame, IMUFrame, IMUFrame]:
+    """Swbt の規則に合わせて IMU frame 数を 3 frame に正規化する。"""
+    if len(frames) == 1:
+        return (frames[0], frames[0], frames[0])
+    if len(frames) == 3:
+        return (frames[0], frames[1], frames[2])
+    raise imu_frame_count_invalid(len(frames))
+
+
+def _swbt_button(button: Button):
+    from swbt import Button as SwbtButton
+
+    mapping = {
+        Button.A: SwbtButton.A,
+        Button.B: SwbtButton.B,
+        Button.X: SwbtButton.X,
+        Button.Y: SwbtButton.Y,
+        Button.L: SwbtButton.L,
+        Button.R: SwbtButton.R,
+        Button.ZL: SwbtButton.ZL,
+        Button.ZR: SwbtButton.ZR,
+        Button.PLUS: SwbtButton.PLUS,
+        Button.MINUS: SwbtButton.MINUS,
+        Button.HOME: SwbtButton.HOME,
+        Button.CAP: SwbtButton.CAPTURE,
+        Button.LS: SwbtButton.LEFT_STICK,
+        Button.RS: SwbtButton.RIGHT_STICK,
+    }
+    try:
+        return mapping[button]
+    except KeyError as exc:
+        raise swbt_input_invalid(f"unsupported NyX button: {button}") from exc
+
+
+def _swbt_dpad_buttons(hat: Hat) -> frozenset[object]:
+    from swbt import Button as SwbtButton
+
+    mapping = {
+        Hat.UP: (SwbtButton.DPAD_UP,),
+        Hat.UPRIGHT: (SwbtButton.DPAD_UP, SwbtButton.DPAD_RIGHT),
+        Hat.RIGHT: (SwbtButton.DPAD_RIGHT,),
+        Hat.DOWNRIGHT: (SwbtButton.DPAD_DOWN, SwbtButton.DPAD_RIGHT),
+        Hat.DOWN: (SwbtButton.DPAD_DOWN,),
+        Hat.DOWNLEFT: (SwbtButton.DPAD_DOWN, SwbtButton.DPAD_LEFT),
+        Hat.LEFT: (SwbtButton.DPAD_LEFT,),
+        Hat.UPLEFT: (SwbtButton.DPAD_UP, SwbtButton.DPAD_LEFT),
+        Hat.CENTER: (),
+    }
+    return frozenset(mapping[hat])
+
+
+def _swbt_stick(stick: LStick | RStick | None):
+    from swbt import Stick
+
+    if stick is None:
+        return Stick.center()
+    return Stick.raw(x=stick.x, y=stick.y)
+
+
+def _swbt_imu_frame(frame: IMUFrame):
+    from swbt import IMUFrame as SwbtIMUFrame
+
+    return SwbtIMUFrame.raw(accel=frame.accelerometer, gyro=frame.gyroscope)

--- a/src/nyxpy/framework/core/hardware/swbt/session.py
+++ b/src/nyxpy/framework/core/hardware/swbt/session.py
@@ -1,0 +1,259 @@
+"""swbt controller lifecycle session。"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from threading import RLock
+from typing import Protocol, TextIO
+
+from nyxpy.framework.core.hardware.swbt.config import SwbtControllerConfig, SwbtControllerType
+from nyxpy.framework.core.hardware.swbt.errors import (
+    map_swbt_exception,
+    swbt_configuration_error,
+    swbt_not_connected,
+)
+
+type SwbtControllerFactory = Callable[[SwbtControllerConfig, TextIO | None], object]
+
+
+class SwbtControllerSessionProtocol(Protocol):
+    """Factory と port が使う swbt session protocol。"""
+
+    @property
+    def connected(self) -> bool: ...
+
+    def open(self) -> None: ...
+
+    def pair(self, *, timeout_sec: float) -> object: ...
+
+    def reconnect(self, *, timeout_sec: float) -> object: ...
+
+    def apply(self, state: object) -> None: ...
+
+    def neutral(self) -> None: ...
+
+    def status(self) -> object: ...
+
+    def close(self) -> None: ...
+
+
+@dataclass(frozen=True, slots=True)
+class DummySwbtStatus:
+    """Dummy session が返す最小 status。"""
+
+    connected: bool
+    message: str = "dummy"
+
+
+class SwbtControllerSession:
+    """swbt controller instance と lifecycle を所有する session。"""
+
+    def __init__(
+        self,
+        config: SwbtControllerConfig,
+        *,
+        controller_factory: SwbtControllerFactory | None = None,
+        diagnostics_writer: TextIO | None = None,
+    ) -> None:
+        """config、controller factory、diagnostics writer を保持する。"""
+        self.config = config
+        self._controller_factory = controller_factory or create_swbt_controller
+        self._diagnostics_writer = diagnostics_writer
+        self._controller: object | None = None
+        self._lock = RLock()
+        self._opened = False
+        self._connected = False
+        self._closed = False
+
+    @property
+    def connected(self) -> bool:
+        """Session が接続済みかどうか。"""
+        return self._connected
+
+    def open(self) -> None:
+        """Controller resource を開く。pairing / reconnect は開始しない。"""
+        with self._lock:
+            if self._opened:
+                return
+            if not self.config.adapter:
+                raise swbt_configuration_error(
+                    "swbt adapter is not selected",
+                    code="NYX_SWBT_ADAPTER_NOT_SELECTED",
+                    component=type(self).__name__,
+                )
+            controller = self._controller_factory(self.config, self._diagnostics_writer)
+            try:
+                getattr(controller, "open")()
+            except Exception as exc:
+                raise map_swbt_exception(exc, component=type(self).__name__) from exc
+            self._controller = controller
+            self._opened = True
+            self._closed = False
+
+    def pair(self, *, timeout_sec: float) -> object:
+        """明示 pairing を実行する。"""
+        with self._lock:
+            self.open()
+            controller = self._require_controller()
+            try:
+                result = getattr(controller, "pair")(timeout=timeout_sec)
+            except Exception as exc:
+                raise map_swbt_exception(exc, component=type(self).__name__) from exc
+            self._connected = True
+            return result
+
+    def reconnect(self, *, timeout_sec: float) -> object:
+        """保存済み pairing key に基づく reconnect を実行する。"""
+        with self._lock:
+            self.open()
+            controller = self._require_controller()
+            try:
+                result = getattr(controller, "reconnect")(timeout=timeout_sec)
+            except Exception as exc:
+                raise map_swbt_exception(exc, component=type(self).__name__) from exc
+            self._connected = True
+            return result
+
+    def apply(self, state: object) -> None:
+        """完全な swbt InputState を controller へ適用する。"""
+        with self._lock:
+            controller = self._require_connected_controller()
+            try:
+                getattr(controller, "apply")(state)
+            except Exception as exc:
+                raise map_swbt_exception(exc, component=type(self).__name__) from exc
+
+    def neutral(self) -> None:
+        """全入力を neutral に戻す。"""
+        with self._lock:
+            controller = self._require_connected_controller()
+            try:
+                getattr(controller, "neutral")()
+            except Exception as exc:
+                raise map_swbt_exception(exc, component=type(self).__name__) from exc
+
+    def status(self) -> object:
+        """Controller status を返す。"""
+        with self._lock:
+            controller = self._require_controller()
+            try:
+                return getattr(controller, "status")()
+            except Exception as exc:
+                raise map_swbt_exception(exc, component=type(self).__name__) from exc
+
+    def close(self) -> None:
+        """neutral=True で controller を閉じる。idempotent。"""
+        with self._lock:
+            if self._closed:
+                return
+            controller = self._controller
+            self._connected = False
+            self._opened = False
+            self._closed = True
+            if controller is None:
+                return
+            try:
+                getattr(controller, "close")(neutral=True)
+            except Exception as exc:
+                raise map_swbt_exception(exc, component=type(self).__name__) from exc
+
+    def _require_controller(self) -> object:
+        if self._controller is None:
+            raise swbt_not_connected(type(self).__name__)
+        return self._controller
+
+    def _require_connected_controller(self) -> object:
+        if not self._connected:
+            raise swbt_not_connected(type(self).__name__)
+        return self._require_controller()
+
+
+class DummySwbtControllerSession:
+    """実機なしテストで InputState を記録する session double。"""
+
+    def __init__(self) -> None:
+        """記録用の状態を初期化する。"""
+        self.opened = False
+        self.connected = False
+        self.closed = False
+        self.pair_calls = 0
+        self.reconnect_calls = 0
+        self.states: list[object] = []
+        self.neutral_calls = 0
+
+    def open(self) -> None:
+        """Bluetooth transport を開かず opened にする。"""
+        self.opened = True
+        self.closed = False
+
+    def pair(self, *, timeout_sec: float) -> DummySwbtStatus:
+        """Dummy pairing を記録する。"""
+        self.open()
+        self.pair_calls += 1
+        self.connected = True
+        return DummySwbtStatus(connected=True, message="paired")
+
+    def reconnect(self, *, timeout_sec: float) -> DummySwbtStatus:
+        """Dummy reconnect を記録する。"""
+        self.open()
+        self.reconnect_calls += 1
+        self.connected = True
+        return DummySwbtStatus(connected=True, message="reconnected")
+
+    def apply(self, state: object) -> None:
+        """適用された state を記録する。"""
+        if not self.connected:
+            raise swbt_not_connected(type(self).__name__)
+        self.states.append(state)
+
+    def neutral(self) -> None:
+        """Neutral 呼び出しを記録する。"""
+        if not self.connected:
+            raise swbt_not_connected(type(self).__name__)
+        self.neutral_calls += 1
+
+    def status(self) -> DummySwbtStatus:
+        """Dummy status を返す。"""
+        return DummySwbtStatus(connected=self.connected)
+
+    def close(self) -> None:
+        """Dummy session を閉じる。"""
+        self.closed = True
+        self.connected = False
+
+
+def create_swbt_controller(
+    config: SwbtControllerConfig,
+    diagnostics_writer: TextIO | None = None,
+) -> object:
+    """SwbtControllerConfig から swbt controller instance を作る。"""
+    controller_cls = resolve_swbt_controller_class(config.model.controller_type)
+    diagnostics = None
+    if diagnostics_writer is not None:
+        from swbt import DiagnosticsConfig
+
+        diagnostics = DiagnosticsConfig(trace_writer=diagnostics_writer)
+    return controller_cls(
+        adapter=config.adapter,
+        key_store_path=str(config.key_store_path),
+        report_period_us=config.report_period_us,
+        diagnostics=diagnostics,
+    )
+
+
+def resolve_swbt_controller_class(controller_type: SwbtControllerType):
+    """Controller type に対応する swbt root module の class を返す。"""
+    from swbt import JoyConL, JoyConR, ProController
+
+    if controller_type is SwbtControllerType.PRO_CONTROLLER:
+        return ProController
+    if controller_type is SwbtControllerType.JOY_CON_L:
+        return JoyConL
+    if controller_type is SwbtControllerType.JOY_CON_R:
+        return JoyConR
+    raise swbt_configuration_error(
+        f"unsupported swbt controller type: {controller_type}",
+        code="NYX_SWBT_CONTROLLER_TYPE_UNSUPPORTED",
+        component="SwbtControllerSession",
+    )

--- a/tests/unit/framework/hardware/swbt/test_controller.py
+++ b/tests/unit/framework/hardware/swbt/test_controller.py
@@ -1,0 +1,88 @@
+import pytest
+from swbt import Button as SwbtButton
+
+from nyxpy.framework.core.constants import Button, IMUFrame
+from nyxpy.framework.core.hardware.swbt.config import resolve_controller_model
+from nyxpy.framework.core.hardware.swbt.controller import SwbtControllerOutputPort
+
+
+class RecordingSession:
+    def __init__(self) -> None:
+        self.applied = []
+        self.neutral_calls = 0
+        self.close_calls = 0
+
+    def apply(self, state) -> None:
+        self.applied.append(state)
+
+    def neutral(self) -> None:
+        self.neutral_calls += 1
+
+    def close(self) -> None:
+        self.close_calls += 1
+
+
+def port(
+    session: RecordingSession | None = None,
+) -> tuple[SwbtControllerOutputPort, RecordingSession]:
+    actual = session or RecordingSession()
+    return (
+        SwbtControllerOutputPort(
+            session=actual,
+            model=resolve_controller_model("pro-controller"),
+        ),
+        actual,
+    )
+
+
+def test_port_press_hold_release_apply_complete_state() -> None:
+    controller, session = port()
+
+    controller.press((Button.A,))
+    controller.press((Button.B,))
+    controller.release((Button.A,))
+    controller.hold((Button.X,))
+
+    assert session.neutral_calls == 1
+    assert session.applied[0].buttons == frozenset({SwbtButton.A})
+    assert session.applied[1].buttons == frozenset({SwbtButton.A, SwbtButton.B})
+    assert session.applied[2].buttons == frozenset({SwbtButton.B})
+    assert session.applied[3].buttons == frozenset({SwbtButton.X})
+
+
+def test_port_imu_and_release_all_use_neutral() -> None:
+    controller, session = port()
+    frame = IMUFrame.gyro(x=10)
+
+    controller.imu(frame)
+    controller.release()
+
+    assert session.applied[-1].imu_frames[0].gyro_x == 10
+    assert session.neutral_calls == 2
+
+
+def test_port_close_sends_neutral_without_session_close() -> None:
+    controller, session = port()
+
+    controller.close()
+    controller.close()
+
+    assert session.neutral_calls == 2
+    assert session.close_calls == 0
+
+    with pytest.raises(Exception) as exc_info:
+        controller.press((Button.A,))
+    assert getattr(exc_info.value, "code", None) == "NYX_SWBT_PORT_CLOSED"
+
+
+def test_port_rejects_backend_unsupported_apis() -> None:
+    controller, _session = port()
+
+    with pytest.raises(NotImplementedError, match="keyboard input"):
+        controller.keyboard("A")
+    with pytest.raises(NotImplementedError, match="keyboard input"):
+        controller.type_key("A")
+    with pytest.raises(NotImplementedError, match="touch input"):
+        controller.touch_down(1, 2)
+    with pytest.raises(NotImplementedError, match="sleep control"):
+        controller.disable_sleep(True)

--- a/tests/unit/framework/hardware/swbt/test_diagnostics.py
+++ b/tests/unit/framework/hardware/swbt/test_diagnostics.py
@@ -1,0 +1,35 @@
+from pathlib import Path
+
+from nyxpy.framework.core.hardware.swbt.diagnostics import (
+    LoggerDiagnosticsWriter,
+    TeeDiagnosticsWriter,
+    open_diagnostics_trace,
+)
+from tests.support.fakes import FakeLoggerPort
+
+
+def test_diagnostics_writer_logs_to_logger_port() -> None:
+    logger = FakeLoggerPort()
+    writer = LoggerDiagnosticsWriter(logger)
+
+    assert writer.write("one\n\ntwo\n") == len("one\n\ntwo\n")
+    writer.flush()
+
+    assert [log.event.message for log in logger.technical_logs] == ["one", "two"]
+    assert [log.event.event for log in logger.technical_logs] == [
+        "swbt.diagnostics",
+        "swbt.diagnostics",
+    ]
+
+
+def test_diagnostics_writer_can_tee_to_jsonl(tmp_path: Path) -> None:
+    logger = FakeLoggerPort()
+    trace_path = tmp_path / "hardware" / "swbt" / "trace.jsonl"
+
+    with open_diagnostics_trace(trace_path) as trace:
+        writer = TeeDiagnosticsWriter((LoggerDiagnosticsWriter(logger), trace))
+        writer.write('{"event":"open"}\n')
+        writer.flush()
+
+    assert trace_path.read_text(encoding="utf-8") == '{"event":"open"}\n'
+    assert logger.technical_logs[-1].event.message == '{"event":"open"}'

--- a/tests/unit/framework/hardware/swbt/test_factory.py
+++ b/tests/unit/framework/hardware/swbt/test_factory.py
@@ -1,0 +1,149 @@
+from pathlib import Path
+
+import pytest
+
+from nyxpy.framework.core.hardware.swbt.config import SwbtControllerConfig, resolve_controller_model
+from nyxpy.framework.core.hardware.swbt.factory import (
+    SwbtControllerOutputPortFactory,
+    session_key,
+)
+from nyxpy.framework.core.macro.exceptions import ConfigurationError
+
+
+class RecordingSession:
+    def __init__(self, *, fail_reconnect: bool = False) -> None:
+        self.fail_reconnect = fail_reconnect
+        self.open_calls = 0
+        self.pair_calls = 0
+        self.reconnect_calls = 0
+        self.neutral_calls = 0
+        self.close_calls = 0
+        self.connected = False
+
+    def open(self) -> None:
+        self.open_calls += 1
+
+    def pair(self, *, timeout_sec: float):
+        self.pair_calls += 1
+        self.connected = True
+        return ("pair", timeout_sec)
+
+    def reconnect(self, *, timeout_sec: float):
+        self.reconnect_calls += 1
+        if self.fail_reconnect:
+            raise ConfigurationError("reconnect failed", code="NYX_SWBT_CONNECTION_FAILED")
+        self.connected = True
+        return ("reconnect", timeout_sec)
+
+    def apply(self, state) -> None:
+        pass
+
+    def neutral(self) -> None:
+        self.neutral_calls += 1
+
+    def status(self):
+        return {"open_calls": self.open_calls}
+
+    def close(self) -> None:
+        self.close_calls += 1
+        self.connected = False
+
+
+def config(adapter: str = "usb:0") -> SwbtControllerConfig:
+    model = resolve_controller_model("pro-controller")
+    return SwbtControllerConfig(
+        model=model,
+        adapter=adapter,
+        key_store_path=Path(".nyxpy/swbt/pro-controller-bond.json"),
+    )
+
+
+def test_factory_create_reconnects_without_pairing() -> None:
+    sessions: list[RecordingSession] = []
+
+    def make_session(_config):
+        session = RecordingSession()
+        sessions.append(session)
+        return session
+
+    factory = SwbtControllerOutputPortFactory(session_factory=make_session)
+
+    port = factory.create(config=config(), allow_dummy=False, timeout_sec=3.0)
+
+    assert port.supports_imu is True
+    assert sessions[0].open_calls == 1
+    assert sessions[0].reconnect_calls == 1
+    assert sessions[0].pair_calls == 0
+    assert sessions[0].neutral_calls == 1
+
+
+def test_factory_reuses_session_for_same_key_and_ports_are_new() -> None:
+    session = RecordingSession()
+    factory = SwbtControllerOutputPortFactory(session_factory=lambda _config: session)
+
+    first = factory.create(config=config(), allow_dummy=False, timeout_sec=1.0)
+    second = factory.create(config=config(), allow_dummy=False, timeout_sec=1.0)
+
+    assert first is not second
+    assert session.reconnect_calls == 1
+    assert session_key(config()) == session_key(config())
+
+
+def test_factory_allows_dummy_fallback_only_for_create() -> None:
+    real = RecordingSession(fail_reconnect=True)
+    factory = SwbtControllerOutputPortFactory(session_factory=lambda _config: real)
+
+    port = factory.create(config=config(), allow_dummy=True, timeout_sec=1.0)
+
+    assert port.supports_imu is True
+    assert real.reconnect_calls == 1
+
+    explicit = RecordingSession(fail_reconnect=True)
+    explicit_factory = SwbtControllerOutputPortFactory(session_factory=lambda _config: explicit)
+
+    with pytest.raises(ConfigurationError):
+        explicit_factory.reconnect(config(), timeout_sec=1.0)
+
+
+def test_factory_pair_reconnect_disconnect_and_status_are_explicit_operations() -> None:
+    session = RecordingSession()
+    factory = SwbtControllerOutputPortFactory(session_factory=lambda _config: session)
+    cfg = config()
+
+    assert factory.pair(cfg, timeout_sec=2.0) == ("pair", 2.0)
+    assert factory.reconnect(cfg, timeout_sec=3.0) == ("reconnect", 3.0)
+    assert factory.status(cfg) == {"open_calls": 2}
+
+    factory.disconnect(cfg)
+    factory.disconnect(cfg)
+
+    assert session.pair_calls == 1
+    assert session.reconnect_calls == 1
+    assert session.neutral_calls == 1
+    assert session.close_calls == 1
+    assert factory.status(cfg) is None
+
+
+def test_factory_close_closes_cached_sessions() -> None:
+    first = RecordingSession()
+    second = RecordingSession()
+    sessions = iter((first, second))
+    factory = SwbtControllerOutputPortFactory(session_factory=lambda _config: next(sessions))
+
+    factory.pair(config("usb:0"))
+    factory.pair(config("usb:1"))
+    factory.close()
+
+    assert first.close_calls == 1
+    assert second.close_calls == 1
+
+
+def test_factory_does_not_create_manual_session_type() -> None:
+    root = Path("src/nyxpy/framework/core/hardware/swbt")
+
+    assert not (root / "manual.py").exists()
+    assert not any(path.name.startswith("swbt_") for path in root.glob("*.py"))
+
+    import nyxpy.framework.core.hardware.swbt as swbt_backend
+
+    assert not hasattr(swbt_backend, "SwbtManualInputSession")

--- a/tests/unit/framework/hardware/swbt/test_mapper.py
+++ b/tests/unit/framework/hardware/swbt/test_mapper.py
@@ -1,0 +1,80 @@
+import pytest
+from swbt import Button as SwbtButton
+from swbt import Stick as SwbtStick
+
+from nyxpy.framework.core.constants import Button, Hat, IMUFrame, LStick, RStick
+from nyxpy.framework.core.hardware.swbt.config import resolve_controller_model
+from nyxpy.framework.core.hardware.swbt.mapper import (
+    NyxSwbtInputMapper,
+    NyxSwbtState,
+    normalize_imu_frames,
+)
+
+
+def mapper(controller_type: str = "pro-controller") -> NyxSwbtInputMapper:
+    return NyxSwbtInputMapper(resolve_controller_model(controller_type))
+
+
+def test_mapper_maps_buttons_with_current_nyx_names() -> None:
+    state = mapper().hold((Button.A, Button.CAP, Button.LS, Button.RS))
+    input_state = mapper().to_input_state(state)
+
+    assert input_state.buttons == frozenset(
+        {
+            SwbtButton.A,
+            SwbtButton.CAPTURE,
+            SwbtButton.LEFT_STICK,
+            SwbtButton.RIGHT_STICK,
+        }
+    )
+
+
+def test_mapper_replaces_dpad_direction() -> None:
+    m = mapper()
+    state = m.press(NyxSwbtState.neutral(), (Hat.UPRIGHT,))
+    state = m.press(state, (Hat.LEFT,))
+
+    input_state = m.to_input_state(state)
+
+    assert input_state.buttons == frozenset({SwbtButton.DPAD_LEFT})
+
+
+def test_mapper_converts_stick_xy_and_rejects_joycon_missing_stick() -> None:
+    m = mapper()
+    state = m.hold(
+        (
+            LStick.UP,
+            RStick.DOWN,
+        )
+    )
+    input_state = m.to_input_state(state)
+
+    assert input_state.left_stick == SwbtStick.raw(x=LStick.UP.x, y=LStick.UP.y)
+    assert input_state.right_stick == SwbtStick.raw(x=RStick.DOWN.x, y=RStick.DOWN.y)
+
+    with pytest.raises(Exception) as left_error:
+        mapper("joy-con-r").hold((LStick.UP,))
+    assert getattr(left_error.value, "code", None) == "NYX_SWBT_INPUT_UNSUPPORTED"
+
+    with pytest.raises(Exception) as right_error:
+        mapper("joy-con-l").hold((RStick.UP,))
+    assert getattr(right_error.value, "code", None) == "NYX_SWBT_INPUT_UNSUPPORTED"
+
+
+def test_mapper_normalizes_imu_one_or_three_frames() -> None:
+    frame = IMUFrame.gyro(x=100)
+    first = IMUFrame.accel(x=1)
+    second = IMUFrame.accel(y=2)
+    third = IMUFrame.accel(z=3)
+
+    assert normalize_imu_frames((frame,)) == (frame, frame, frame)
+    assert normalize_imu_frames((first, second, third)) == (first, second, third)
+
+    state = mapper().set_imu(NyxSwbtState.neutral(), (frame,))
+    input_state = mapper().to_input_state(state)
+
+    assert [sample.gyro_x for sample in input_state.imu_frames] == [100, 100, 100]
+
+    with pytest.raises(Exception) as exc_info:
+        normalize_imu_frames((first, second))
+    assert getattr(exc_info.value, "code", None) == "NYX_IMU_FRAME_COUNT_INVALID"

--- a/tests/unit/framework/hardware/swbt/test_session.py
+++ b/tests/unit/framework/hardware/swbt/test_session.py
@@ -1,0 +1,117 @@
+from pathlib import Path
+
+import pytest
+
+from nyxpy.framework.core.hardware.swbt.config import SwbtControllerConfig, resolve_controller_model
+from nyxpy.framework.core.hardware.swbt.session import (
+    DummySwbtControllerSession,
+    SwbtControllerSession,
+)
+
+
+class FakeSwbtController:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, object]] = []
+        self.closed = False
+
+    def open(self) -> None:
+        self.calls.append(("open", None))
+
+    def pair(self, *, timeout: float) -> str:
+        self.calls.append(("pair", timeout))
+        return "paired"
+
+    def reconnect(self, *, timeout: float) -> str:
+        self.calls.append(("reconnect", timeout))
+        return "reconnected"
+
+    def apply(self, state) -> None:
+        self.calls.append(("apply", state))
+
+    def neutral(self) -> None:
+        self.calls.append(("neutral", None))
+
+    def status(self) -> str:
+        self.calls.append(("status", None))
+        return "connected"
+
+    def close(self, *, neutral: bool = True) -> None:
+        self.calls.append(("close", neutral))
+        self.closed = True
+
+
+def config() -> SwbtControllerConfig:
+    model = resolve_controller_model("pro-controller")
+    return SwbtControllerConfig(
+        model=model,
+        adapter="usb:0",
+        key_store_path=Path(".nyxpy/swbt/pro-controller-bond.json"),
+    )
+
+
+def test_session_open_does_not_pair_or_reconnect() -> None:
+    fake = FakeSwbtController()
+    session = SwbtControllerSession(config(), controller_factory=lambda _config, _writer: fake)
+
+    session.open()
+    session.open()
+
+    assert fake.calls == [("open", None)]
+    assert not session.connected
+
+
+def test_session_pair_reconnect_apply_status_and_close() -> None:
+    fake = FakeSwbtController()
+    session = SwbtControllerSession(config(), controller_factory=lambda _config, _writer: fake)
+
+    assert session.pair(timeout_sec=10.0) == "paired"
+    session.apply("state")
+    assert session.status() == "connected"
+    assert session.reconnect(timeout_sec=20.0) == "reconnected"
+    session.neutral()
+    session.close()
+    session.close()
+
+    assert fake.calls == [
+        ("open", None),
+        ("pair", 10.0),
+        ("apply", "state"),
+        ("status", None),
+        ("reconnect", 20.0),
+        ("neutral", None),
+        ("close", True),
+    ]
+    assert fake.closed is True
+
+
+def test_session_requires_adapter_before_open() -> None:
+    model = resolve_controller_model("pro-controller")
+    session = SwbtControllerSession(
+        SwbtControllerConfig(
+            model=model,
+            adapter=None,
+            key_store_path=Path(".nyxpy/swbt/pro-controller-bond.json"),
+        )
+    )
+
+    with pytest.raises(Exception) as exc_info:
+        session.open()
+
+    assert getattr(exc_info.value, "code", None) == "NYX_SWBT_ADAPTER_NOT_SELECTED"
+
+
+def test_dummy_session_records_state_without_bluetooth_transport() -> None:
+    session = DummySwbtControllerSession()
+
+    session.open()
+    result = session.reconnect(timeout_sec=1.0)
+    session.apply("state")
+    session.neutral()
+    session.close()
+
+    assert result.connected is True
+    assert session.opened is True
+    assert session.reconnect_calls == 1
+    assert session.states == ["state"]
+    assert session.neutral_calls == 1
+    assert session.closed is True


### PR DESCRIPTION
## Summary

swbt controller backend の session / mapper / port / factory を追加し、NyX の同期 ControllerOutputPort として扱える core 部品を実装した。

## Related

- spec/agent/complete/local_023/SWBT_CORE_ADAPTER_SERVICE.md

## Changes

- swbt controller session、dummy session、diagnostics writer adapter を追加した
- NyX の button / D-pad / stick / IMU 入力を swbt InputState へ変換する mapper と port を追加した
- session key ごとの cache、明示 pair / reconnect / disconnect / status を持つ factory を追加した
- local_023 仕様書を complete へ移動し、swbt 0.2.0 の同期公開 API に合わせた完了結果を記録した

## Commit Log

```text
4f99667 feat(swbt): core adapter serviceを追加
```

## Testing

```text
uv run ruff format .
uv run ruff check .
uv run ty check src/nyxpy --output-format concise --no-progress
uv run pytest tests/unit/framework/hardware/swbt tests/unit/framework/io/test_controller_config.py tests/unit/framework/io/test_ports.py tests/unit/framework/runtime/test_default_command_ports.py tests/unit/cli/test_swbt_cli.py tests/unit/cli/test_run_cli_parser.py tests/unit/framework/settings/test_settings_schema.py
uv run pytest tests/unit -m "not realdevice and not swbt"
git diff --cached --check
```

## Checklist

- [x] lint / format チェック通過
- [x] 既存テスト通過
- [x] コミット prefix (feat/fix 等) が変更の動機と一致している
- [x] 新規・変更コードに対するテスト追加（該当する場合）
- [x] 型チェック通過

## Review Notes

swbt-python 0.2.0 の root module 公開 API は同期 API だったため、event loop thread は追加していない。session の RLock で lifecycle と input apply を直列化している。
