### PR TITLE
feat(swbt): runtimeとCLI連携を追加

### DIFF
--- a/spec/agent/complete/local_024/SWBT_RUNTIME_CLI_INTEGRATION.md
+++ b/spec/agent/complete/local_024/SWBT_RUNTIME_CLI_INTEGRATION.md
@@ -41,6 +41,13 @@ Pairing は利用者の明示操作である。macro run が key store 不足を
 - CLI に clipboard / command copy / GUI 連携用 preview は追加しない。
 - `nyxpy swbt status` は初期範囲外とする。
 
+### 1.6 完了結果
+
+- `create_device_runtime_builder()` は `ControllerConfig` を受け取り、`SerialControllerConfig` では `SerialControllerOutputPortFactory`、`SwbtControllerConfig` では `SwbtControllerOutputPortFactory` を選ぶ構成にした。
+- `nyxpy run` は settings と CLI override から controller config を作る。`--controller swbt` では serial protocol を生成しない。
+- `nyxpy swbt pair` / `reconnect` / `disconnect` を追加し、CLI override が settings を保存しないことをテストで確認した。
+- `swbt-python 0.2.0` の公開 controller API は同期 API であるため、CLI も同期処理として factory / session を呼ぶ。event loop thread は追加していない。
+
 ## 2. 対象ファイル
 
 | ファイル | 変更種別 | 変更内容 |
@@ -84,7 +91,7 @@ backend 選択は runtime builder を作る構成処理で完了させる。`Mac
 
 ### 並行性・スレッド安全性
 
-CLI は同期処理として session / factory を呼ぶ。event loop thread は `SwbtControllerSession` が所有する。CLI 終了時は `finally` で runtime builder または factory を close する。
+CLI は同期処理として session / factory を呼ぶ。swbt 公開 API が同期 API であるため、event loop thread は追加しない。CLI 終了時は `finally` で runtime builder または factory を close する。
 
 ## 4. 実装仕様
 
@@ -173,19 +180,21 @@ uv run ruff format .
 uv run ruff check .
 uv run ty check src/nyxpy --output-format concise --no-progress
 uv run pytest tests/unit/cli/test_run_cli_parser.py tests/unit/cli/test_swbt_cli.py tests/unit/framework/runtime/test_runtime_builder.py tests/integration/test_swbt_runtime_cli_integration.py -m "not realdevice and not swbt"
+uv run pytest tests/unit -m "not realdevice and not swbt"
+uv run pytest tests/integration -m "not realdevice and not swbt"
 ```
 
 ## 6. 実装チェックリスト
 
-- [ ] `SerialControllerOutputPortFactory` を正名として扱い、旧名 alias を残さない。
-- [ ] `make_controller_port_factory()` を追加し、backend 分岐を構成処理に閉じる。
-- [ ] `create_device_runtime_builder()` と `create_runtime_builder()` を `ControllerConfig` ベースへ更新する。
-- [ ] swbt backend で serial protocol 生成を呼ばないことをテストする。
-- [ ] `nyxpy run` に swbt option を追加する。
-- [ ] `--serial` と `--capture` の parser 必須を外し、validation へ移す。
-- [ ] `nyxpy swbt pair` と `nyxpy swbt reconnect` を追加する。
-- [ ] `nyxpy swbt disconnect` を追加する。
-- [ ] `supported_controller_models()` から CLI choices を作る。
-- [ ] CLI override が settings を書き換えないことを確認する。
-- [ ] runtime shutdown で swbt factory close が呼ばれることを確認する。
-- [ ] dummy session を使った runtime integration test を追加する。
+- [x] `SerialControllerOutputPortFactory` を正名として扱い、旧名 alias を残さない。
+- [x] `make_controller_port_factory()` を追加し、backend 分岐を構成処理に閉じる。
+- [x] `create_device_runtime_builder()` と `create_runtime_builder()` を `ControllerConfig` ベースへ更新する。
+- [x] swbt backend で serial protocol 生成を呼ばないことをテストする。
+- [x] `nyxpy run` に swbt option を追加する。
+- [x] `--serial` と `--capture` の parser 必須を外し、validation へ移す。
+- [x] `nyxpy swbt pair` と `nyxpy swbt reconnect` を追加する。
+- [x] `nyxpy swbt disconnect` を追加する。
+- [x] `supported_controller_models()` から CLI choices を作る。
+- [x] CLI override が settings を書き換えないことを確認する。
+- [x] runtime shutdown で swbt factory close が呼ばれることを確認する。
+- [x] dummy session を使った runtime integration test を追加する。

--- a/src/nyxpy/cli/run_cli.py
+++ b/src/nyxpy/cli/run_cli.py
@@ -3,15 +3,22 @@
 import argparse
 import pathlib
 import sys
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from typing import Any
 
 from nyxpy.framework.core.hardware.device_discovery import DeviceDiscoveryService
 from nyxpy.framework.core.hardware.protocol import SerialProtocolInterface
 from nyxpy.framework.core.hardware.protocol_factory import ProtocolFactory
+from nyxpy.framework.core.hardware.swbt.config import supported_controller_models
+from nyxpy.framework.core.hardware.swbt.factory import SwbtControllerOutputPortFactory
+from nyxpy.framework.core.io.controller_config import (
+    ControllerConfig,
+    SerialControllerConfig,
+    controller_config_from_overrides,
+)
 from nyxpy.framework.core.io.device_factories import (
-    ControllerOutputPortFactory,
     FrameSourcePortFactory,
+    SerialControllerOutputPortFactory,
 )
 from nyxpy.framework.core.logger import LoggerPort, LoggingComponents, create_default_logging
 from nyxpy.framework.core.macro.exceptions import ConfigurationError
@@ -99,34 +106,32 @@ def create_protocol(protocol_name: str) -> SerialProtocolInterface:
 
 
 def create_runtime_builder(
-    protocol: SerialProtocolInterface,
     logger: LoggerPort,
     *,
+    controller_config: ControllerConfig,
     project_root: pathlib.Path | None = None,
-    serial_name: str | None = None,
     capture_name: str | None = None,
-    baudrate: int | None = None,
     detection_timeout_sec: float = 2.0,
     settings_store: SettingsStore | None = None,
     secrets_store: SecretsStore | None = None,
     device_discovery: DeviceDiscoveryService | None = None,
-    controller_output_factory: ControllerOutputPortFactory | None = None,
+    serial_controller_factory: SerialControllerOutputPortFactory | None = None,
+    swbt_controller_factory: SwbtControllerOutputPortFactory | None = None,
     frame_source_factory: FrameSourcePortFactory | None = None,
 ) -> MacroRuntimeBuilder:
     """CLI で利用する Runtime builder を作成します。
 
     Args:
-        protocol: 使用するプロトコル実装
         logger: Runtime に注入する logger
+        controller_config: 使用する controller backend 設定
         project_root: 使用する NyX workspace root
-        serial_name: 使用するシリアルデバイス名
         capture_name: 使用するキャプチャデバイス名
-        baudrate: シリアルボーレート
         detection_timeout_sec: デバイス自動検出のタイムアウト秒数
         settings_store: 差し替え用の設定 store。未指定の場合は workspace から読み込みます
         secrets_store: 差し替え用の secrets store。未指定の場合は workspace から読み込みます
         device_discovery: 差し替え用のデバイス検出 service
-        controller_output_factory: 差し替え用の controller output factory
+        serial_controller_factory: 差し替え用の serial controller output factory
+        swbt_controller_factory: 差し替え用の swbt controller output factory
         frame_source_factory: 差し替え用の frame source factory
 
     Returns:
@@ -143,10 +148,6 @@ def create_runtime_builder(
     settings = settings_store or SettingsStore(config_dir=paths.config_dir, strict_load=False)
     secrets = secrets_store or SecretsStore(config_dir=paths.config_dir, strict_load=False)
     discovery = device_discovery or DeviceDiscoveryService(logger=logger)
-    controller_factory = controller_output_factory or ControllerOutputPortFactory(
-        discovery=discovery,
-        protocol=protocol,
-    )
     frame_factory = frame_source_factory or FrameSourcePortFactory(
         discovery=discovery,
         logger=logger,
@@ -158,13 +159,12 @@ def create_runtime_builder(
         project_root=paths.project_root,
         registry=registry,
         device_discovery=discovery,
-        controller_output_factory=controller_factory,
+        controller_config=controller_config,
+        serial_controller_factory=serial_controller_factory,
+        swbt_controller_factory=swbt_controller_factory,
         frame_source_factory=frame_factory,
-        serial_name=serial_name,
         capture_name=capture_name,
-        baudrate=baudrate,
         detection_timeout_sec=detection_timeout_sec,
-        protocol=protocol,
         notification_handler=notification_handler,
         logger=logger,
         settings=settings.snapshot(),
@@ -267,16 +267,18 @@ def cli_main(args: argparse.Namespace) -> int:
         )
         logger = logging.logger
 
-        baudrate = ProtocolFactory.resolve_baudrate(args.protocol, getattr(args, "baud", None))
-
-        protocol = create_protocol(args.protocol)
+        settings = SettingsStore(config_dir=paths.config_dir, strict_load=False)
+        controller_config = _controller_config_from_args(
+            args,
+            settings_snapshot=settings.snapshot(),
+            workspace_root=paths.project_root,
+        )
         runtime_builder = create_runtime_builder(
-            protocol=protocol,
             logger=logger,
+            controller_config=controller_config,
             project_root=paths.project_root,
-            serial_name=args.serial,
             capture_name=args.capture,
-            baudrate=baudrate,
+            settings_store=settings,
         )
 
         # マクロ実行引数の解析
@@ -339,15 +341,40 @@ def build_parser() -> argparse.ArgumentParser:
 def add_run_arguments(parser: argparse.ArgumentParser) -> None:
     """マクロ実行 command の共通引数を parser に追加します。"""
     parser.add_argument("macro_name", help="実行するマクロ名")
-    parser.add_argument("-s", "--serial", required=True, help="シリアルデバイス名")
-    parser.add_argument("-c", "--capture", required=True, help="キャプチャデバイス名")
+    parser.add_argument(
+        "--controller",
+        choices=("serial", "swbt"),
+        default=None,
+        help="controller backend override",
+    )
+    parser.add_argument("-s", "--serial", default=None, help="シリアルデバイス名")
+    parser.add_argument("-c", "--capture", default=None, help="キャプチャデバイス名")
     parser.add_argument(
         "-p",
         "--protocol",
-        default="CH552",
-        help="通信プロトコル (default: CH552)",
+        default=None,
+        help="通信プロトコル",
     )
     parser.add_argument("--baud", type=int, default=None, help="シリアルボーレート")
+    parser.add_argument("--swbt-adapter", default=None, help="swbt adapter override")
+    parser.add_argument(
+        "--swbt-controller-type",
+        choices=tuple(model.settings_value for model in supported_controller_models()),
+        default=None,
+        help="swbt controller type override",
+    )
+    parser.add_argument(
+        "--swbt-key-store",
+        type=pathlib.Path,
+        default=None,
+        help="swbt pairing key store path override",
+    )
+    parser.add_argument(
+        "--swbt-timeout",
+        type=float,
+        default=None,
+        help="swbt connect timeout seconds override",
+    )
     parser.add_argument("--silence", action="store_true", help="ログ出力を最小限に抑制")
     parser.add_argument("--verbose", action="store_true", help="詳細なログ出力を有効化")
     parser.add_argument(
@@ -356,6 +383,35 @@ def add_run_arguments(parser: argparse.ArgumentParser) -> None:
         help="マクロ実行時の変数定義 (key=value形式)",
         default=[],
     )
+
+
+def _controller_config_from_args(
+    args: argparse.Namespace,
+    *,
+    settings_snapshot,
+    workspace_root: pathlib.Path,
+) -> ControllerConfig:
+    config = controller_config_from_overrides(
+        settings_snapshot,
+        workspace_root=workspace_root,
+        backend=getattr(args, "controller", None),
+        serial_device=getattr(args, "serial", None),
+        serial_protocol=getattr(args, "protocol", None),
+        serial_baudrate=getattr(args, "baud", None),
+        swbt_adapter=getattr(args, "swbt_adapter", None),
+        swbt_controller_type=getattr(args, "swbt_controller_type", None),
+        swbt_key_store_path=getattr(args, "swbt_key_store", None),
+        swbt_connect_timeout_sec=getattr(args, "swbt_timeout", None),
+    )
+    if isinstance(config, SerialControllerConfig):
+        protocol_override = getattr(args, "protocol", None)
+        baud_override = getattr(args, "baud", None)
+        if protocol_override is not None and baud_override is None:
+            return replace(
+                config,
+                baudrate=ProtocolFactory.resolve_baudrate(config.protocol, None),
+            )
+    return config
 
 
 def main():

--- a/src/nyxpy/cli/swbt_cli.py
+++ b/src/nyxpy/cli/swbt_cli.py
@@ -4,12 +4,21 @@ import argparse
 import json
 import sys
 from dataclasses import asdict
+from pathlib import Path
 from typing import TextIO
 
+from nyxpy.framework.core.hardware.swbt.config import (
+    SwbtControllerConfig,
+    supported_controller_models,
+)
 from nyxpy.framework.core.hardware.swbt.discovery import (
     SwbtAdapterDiscoveryService,
     SwbtAdapterView,
 )
+from nyxpy.framework.core.hardware.swbt.factory import SwbtControllerOutputPortFactory
+from nyxpy.framework.core.io.controller_config import controller_config_from_overrides
+from nyxpy.framework.core.settings.global_settings import SettingsStore
+from nyxpy.framework.core.settings.workspace import ensure_workspace, resolve_project_root
 
 
 def add_swbt_arguments(subparsers: argparse._SubParsersAction) -> None:
@@ -25,12 +34,21 @@ def add_swbt_arguments(subparsers: argparse._SubParsersAction) -> None:
         help="List swbt USB Bluetooth adapters",
     )
     adapters_parser.add_argument("--json", action="store_true", help="Print full JSON output")
+    for command in ("pair", "reconnect", "disconnect"):
+        lifecycle_parser = swbt_subparsers.add_parser(
+            command,
+            help=f"{command} swbt controller",
+        )
+        _add_lifecycle_options(lifecycle_parser)
 
 
 def cli_main(
     args: argparse.Namespace,
     *,
     discovery_service: SwbtAdapterDiscoveryService | None = None,
+    controller_factory: SwbtControllerOutputPortFactory | None = None,
+    settings_store: SettingsStore | None = None,
+    project_root: Path | None = None,
     stdout: TextIO | None = None,
 ) -> int:
     """解析済み `nyxpy swbt` 引数を実行する。"""
@@ -43,6 +61,26 @@ def cli_main(
         else:
             _print_adapters(adapters, output)
         return 0
+    if args.swbt_command in {"pair", "reconnect", "disconnect"}:
+        factory = controller_factory or SwbtControllerOutputPortFactory()
+        try:
+            config = _controller_config_from_args(
+                args,
+                settings_store=settings_store,
+                project_root=project_root,
+            )
+            if args.swbt_command == "pair":
+                factory.pair(config, timeout_sec=config.connect_timeout_sec)
+                print("swbt pair completed.", file=output)
+            elif args.swbt_command == "reconnect":
+                factory.reconnect(config, timeout_sec=config.connect_timeout_sec)
+                print("swbt reconnect completed.", file=output)
+            else:
+                factory.disconnect(config)
+                print("swbt disconnect completed.", file=output)
+            return 0
+        finally:
+            factory.close()
     raise ValueError(f"Unknown swbt command: {args.swbt_command}")
 
 
@@ -58,3 +96,51 @@ def _print_adapters(adapters: tuple[SwbtAdapterView, ...], output: TextIO) -> No
     for adapter in adapters:
         aliases = ", ".join(adapter.aliases) if adapter.aliases else "-"
         print(f"{adapter.name}\t{adapter.display_name}\taliases: {aliases}", file=output)
+
+
+def _add_lifecycle_options(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("--adapter", default=None, help="swbt adapter override")
+    parser.add_argument(
+        "--controller-type",
+        choices=tuple(model.settings_value for model in supported_controller_models()),
+        default=None,
+        help="swbt controller type override",
+    )
+    parser.add_argument(
+        "--key-store",
+        type=Path,
+        default=None,
+        help="swbt pairing key store path override",
+    )
+    parser.add_argument(
+        "--timeout",
+        type=float,
+        default=None,
+        help="swbt connect timeout seconds override",
+    )
+
+
+def _controller_config_from_args(
+    args: argparse.Namespace,
+    *,
+    settings_store: SettingsStore | None,
+    project_root: Path | None,
+) -> SwbtControllerConfig:
+    resolved_root = resolve_project_root(
+        explicit_root=project_root,
+        allow_current_as_new=False,
+    )
+    paths = ensure_workspace(resolved_root)
+    settings = settings_store or SettingsStore(config_dir=paths.config_dir, strict_load=False)
+    config = controller_config_from_overrides(
+        settings.snapshot(),
+        workspace_root=paths.project_root,
+        backend="swbt",
+        swbt_adapter=getattr(args, "adapter", None),
+        swbt_controller_type=getattr(args, "controller_type", None),
+        swbt_key_store_path=getattr(args, "key_store", None),
+        swbt_connect_timeout_sec=getattr(args, "timeout", None),
+    )
+    if not isinstance(config, SwbtControllerConfig):
+        raise TypeError(f"expected SwbtControllerConfig, got {type(config).__name__}")
+    return config

--- a/src/nyxpy/framework/core/io/__init__.py
+++ b/src/nyxpy/framework/core/io/__init__.py
@@ -11,12 +11,13 @@ from nyxpy.framework.core.io.controller_config import (
     ControllerBackend,
     ControllerConfig,
     SerialControllerConfig,
+    controller_config_from_overrides,
     controller_config_from_settings,
     parse_controller_backend,
 )
 from nyxpy.framework.core.io.device_factories import (
-    ControllerOutputPortFactory,
     FrameSourcePortFactory,
+    SerialControllerOutputPortFactory,
 )
 from nyxpy.framework.core.io.ports import (
     ControllerOutputPort,
@@ -50,7 +51,6 @@ __all__ = [
     "ControllerBackend",
     "ControllerConfig",
     "CaptureFrameSourcePort",
-    "ControllerOutputPortFactory",
     "DefaultResourcePathGuard",
     "DummyFrameSourcePort",
     "FrameSourcePortFactory",
@@ -78,6 +78,8 @@ __all__ = [
     "RunArtifactStore",
     "SerialControllerOutputPort",
     "SerialControllerConfig",
+    "SerialControllerOutputPortFactory",
+    "controller_config_from_overrides",
     "controller_config_from_settings",
     "parse_controller_backend",
 ]

--- a/src/nyxpy/framework/core/io/controller_config.py
+++ b/src/nyxpy/framework/core/io/controller_config.py
@@ -13,7 +13,7 @@ from nyxpy.framework.core.hardware.swbt.config import (
     resolve_controller_model,
 )
 from nyxpy.framework.core.macro.exceptions import ConfigurationError
-from nyxpy.framework.core.settings.schema import dotted_get
+from nyxpy.framework.core.settings.schema import dotted_get, dotted_set
 
 _LEGACY_SERIAL_KEYS = ("serial_device", "serial_baud", "serial_protocol")
 
@@ -75,6 +75,40 @@ def controller_config_from_settings(
             key="controller.swbt.report_period_us",
         ),
     )
+
+
+def controller_config_from_overrides(
+    settings: Mapping[str, Any],
+    *,
+    workspace_root: Path | None = None,
+    backend: str | ControllerBackend | None = None,
+    serial_device: str | None = None,
+    serial_protocol: str | None = None,
+    serial_baudrate: int | None = None,
+    swbt_adapter: str | None = None,
+    swbt_controller_type: str | None = None,
+    swbt_key_store_path: Path | str | None = None,
+    swbt_connect_timeout_sec: float | None = None,
+) -> ControllerConfig:
+    """Settings の copy に CLI override を重ねて ControllerConfig を作る。"""
+    data = _settings_copy(settings)
+    if backend is not None:
+        dotted_set(data, "controller.backend", str(backend))
+    if serial_device is not None:
+        dotted_set(data, "controller.serial.device", serial_device)
+    if serial_protocol is not None:
+        dotted_set(data, "controller.serial.protocol", serial_protocol)
+    if serial_baudrate is not None:
+        dotted_set(data, "controller.serial.baudrate", serial_baudrate)
+    if swbt_adapter is not None:
+        dotted_set(data, "controller.swbt.adapter", swbt_adapter)
+    if swbt_controller_type is not None:
+        dotted_set(data, "controller.swbt.controller_type", swbt_controller_type)
+    if swbt_key_store_path is not None:
+        dotted_set(data, "controller.swbt.key_store_path", str(swbt_key_store_path))
+    if swbt_connect_timeout_sec is not None:
+        dotted_set(data, "controller.swbt.connect_timeout_sec", swbt_connect_timeout_sec)
+    return controller_config_from_settings(data, workspace_root=workspace_root)
 
 
 def parse_controller_backend(value: object) -> ControllerBackend:
@@ -149,3 +183,11 @@ def _invalid_positive(key: str) -> ConfigurationError:
         component="ControllerConfig",
         details={"key": key},
     )
+
+
+def _settings_copy(value: Any) -> Any:
+    if isinstance(value, Mapping):
+        return {str(key): _settings_copy(nested) for key, nested in value.items()}
+    if isinstance(value, list | tuple):
+        return [_settings_copy(item) for item in value]
+    return value

--- a/src/nyxpy/framework/core/io/device_factories.py
+++ b/src/nyxpy/framework/core/io/device_factories.py
@@ -37,7 +37,7 @@ from nyxpy.framework.core.logger import LoggerPort, NullLoggerPort
 from nyxpy.framework.core.macro.exceptions import ConfigurationError
 
 
-class ControllerOutputPortFactory:
+class SerialControllerOutputPortFactory:
     """シリアル device 設定から controller output port を生成します。"""
 
     def __init__(
@@ -101,7 +101,7 @@ class ControllerOutputPortFactory:
                 errors.append(exc)
         self._devices.clear()
         if errors:
-            raise ExceptionGroup("ControllerOutputPortFactory close failed", errors)
+            raise ExceptionGroup("SerialControllerOutputPortFactory close failed", errors)
 
     def _dummy_serial(self) -> SerialCommInterface:
         device = self._devices.get(DUMMY_DEVICE_NAME)

--- a/src/nyxpy/framework/core/runtime/builder.py
+++ b/src/nyxpy/framework/core/runtime/builder.py
@@ -10,14 +10,17 @@ from uuid import uuid4
 
 from nyxpy.framework.core.hardware.capture_source import capture_source_from_settings
 from nyxpy.framework.core.hardware.device_discovery import DeviceDiscoveryService
-from nyxpy.framework.core.hardware.protocol import SerialProtocolInterface
+from nyxpy.framework.core.hardware.protocol_factory import ProtocolFactory
+from nyxpy.framework.core.hardware.swbt.config import SwbtControllerConfig
+from nyxpy.framework.core.hardware.swbt.factory import SwbtControllerOutputPortFactory
 from nyxpy.framework.core.io.adapters import (
     NoopNotificationAdapter,
     NotificationHandlerAdapter,
 )
+from nyxpy.framework.core.io.controller_config import ControllerConfig, SerialControllerConfig
 from nyxpy.framework.core.io.device_factories import (
-    ControllerOutputPortFactory,
     FrameSourcePortFactory,
+    SerialControllerOutputPortFactory,
 )
 from nyxpy.framework.core.io.ports import (
     ControllerOutputPort,
@@ -182,40 +185,38 @@ def create_device_runtime_builder(
     *,
     project_root: Path,
     registry: MacroRegistry,
-    protocol: SerialProtocolInterface,
+    controller_config: ControllerConfig,
     notification_handler,
     logger: LoggerPort,
     device_discovery: DeviceDiscoveryService | None = None,
-    controller_output_factory: ControllerOutputPortFactory | None = None,
+    serial_controller_factory: SerialControllerOutputPortFactory | None = None,
+    swbt_controller_factory: SwbtControllerOutputPortFactory | None = None,
     frame_source_factory: FrameSourcePortFactory | None = None,
-    serial_name: str | None = None,
     capture_name: str | None = None,
-    baudrate: int | None = None,
     detection_timeout_sec: float = 2.0,
     settings: SettingsSnapshot | None = None,
     lifetime_allow_dummy: bool | None = None,
 ) -> MacroRuntimeBuilder:
     """Device discovery と Port factory を Runtime builder へ接続する。"""
     settings_snapshot = dict(settings or {})
-    resolved_serial_name = _optional_name(
-        serial_name if serial_name is not None else settings_snapshot.get("serial_device")
-    )
     resolved_capture_name = _optional_name(capture_name)
     capture_source_type = str(settings_snapshot.get("capture_source_type", "camera") or "camera")
     capture_source = capture_source_from_settings(
         settings_snapshot,
         capture_name_override=resolved_capture_name if capture_source_type == "camera" else None,
     )
-    resolved_baudrate = _optional_int(
-        baudrate if baudrate is not None else settings_snapshot.get("serial_baud")
-    )
     lifetime_request = RuntimeBuildRequest(macro_id="__gui_lifetime__")
     discovery = device_discovery or DeviceDiscoveryService(logger=logger)
     discovery.detect(detection_timeout_sec)
-    controller_factory = controller_output_factory or ControllerOutputPortFactory(
-        discovery=discovery,
-        protocol=protocol,
-    )
+    serial_factory = serial_controller_factory
+    swbt_factory = swbt_controller_factory
+    if isinstance(controller_config, SerialControllerConfig) and serial_factory is None:
+        serial_factory = SerialControllerOutputPortFactory(
+            discovery=discovery,
+            protocol=ProtocolFactory.create_protocol(controller_config.protocol),
+        )
+    if isinstance(controller_config, SwbtControllerConfig) and swbt_factory is None:
+        swbt_factory = SwbtControllerOutputPortFactory()
     frame_factory = frame_source_factory or FrameSourcePortFactory(
         discovery=discovery,
         logger=logger,
@@ -229,16 +230,24 @@ def create_device_runtime_builder(
             return lifetime_allow_dummy
         return allow_dummy(lifetime_request)
 
+    controller_port_factory = make_controller_port_factory(
+        config=controller_config,
+        serial_factory=serial_factory,
+        swbt_factory=swbt_factory,
+        allow_dummy=allow_dummy,
+        detection_timeout_sec=detection_timeout_sec,
+    )
+    shutdown_callbacks = _controller_shutdown_callbacks(
+        config=controller_config,
+        serial_factory=serial_factory,
+        swbt_factory=swbt_factory,
+    ) + (frame_factory.close,)
+
     return MacroRuntimeBuilder(
         project_root=project_root,
         registry=registry,
         settings=settings_snapshot,
-        controller_factory=lambda request, _definition: controller_factory.create(
-            name=resolved_serial_name,
-            baudrate=resolved_baudrate,
-            allow_dummy=allow_dummy(request),
-            timeout_sec=detection_timeout_sec,
-        ),
+        controller_factory=controller_port_factory,
         frame_source_factory=lambda request, _definition: frame_factory.create(
             source=capture_source,
             allow_dummy=allow_dummy(request),
@@ -269,14 +278,78 @@ def create_device_runtime_builder(
             allow_dummy=lifetime_dummy(),
             timeout_sec=detection_timeout_sec,
         ),
-        manual_controller_factory=lambda: controller_factory.create(
-            name=resolved_serial_name,
-            baudrate=resolved_baudrate,
+        manual_controller_factory=lambda: _create_controller_port(
+            config=controller_config,
+            serial_factory=serial_factory,
+            swbt_factory=swbt_factory,
             allow_dummy=lifetime_dummy(),
-            timeout_sec=detection_timeout_sec,
+            detection_timeout_sec=detection_timeout_sec,
         ),
-        shutdown_callbacks=(controller_factory.close, frame_factory.close),
+        shutdown_callbacks=shutdown_callbacks,
     )
+
+
+def make_controller_port_factory(
+    *,
+    config: ControllerConfig,
+    serial_factory: SerialControllerOutputPortFactory | None,
+    swbt_factory: SwbtControllerOutputPortFactory | None,
+    allow_dummy: Callable[[RuntimeBuildRequest], bool],
+    detection_timeout_sec: float,
+) -> PortFactory[ControllerOutputPort]:
+    """ControllerConfig に対応する runtime controller port factory を作る。"""
+
+    def create(request: RuntimeBuildRequest, _definition: MacroDefinition) -> ControllerOutputPort:
+        return _create_controller_port(
+            config=config,
+            serial_factory=serial_factory,
+            swbt_factory=swbt_factory,
+            allow_dummy=allow_dummy(request),
+            detection_timeout_sec=detection_timeout_sec,
+        )
+
+    return create
+
+
+def _create_controller_port(
+    *,
+    config: ControllerConfig,
+    serial_factory: SerialControllerOutputPortFactory | None,
+    swbt_factory: SwbtControllerOutputPortFactory | None,
+    allow_dummy: bool,
+    detection_timeout_sec: float,
+) -> ControllerOutputPort:
+    if isinstance(config, SerialControllerConfig):
+        if serial_factory is None:
+            raise RuntimeError("serial controller factory is not configured")
+        return serial_factory.create(
+            name=config.device,
+            baudrate=config.baudrate,
+            allow_dummy=allow_dummy,
+            timeout_sec=detection_timeout_sec,
+        )
+    if isinstance(config, SwbtControllerConfig):
+        if swbt_factory is None:
+            raise RuntimeError("swbt controller factory is not configured")
+        return swbt_factory.create(
+            config=config,
+            allow_dummy=allow_dummy,
+            timeout_sec=config.connect_timeout_sec,
+        )
+    raise TypeError(f"unsupported controller config: {type(config).__name__}")
+
+
+def _controller_shutdown_callbacks(
+    *,
+    config: ControllerConfig,
+    serial_factory: SerialControllerOutputPortFactory | None,
+    swbt_factory: SwbtControllerOutputPortFactory | None,
+) -> tuple[ShutdownCallback, ...]:
+    if isinstance(config, SerialControllerConfig):
+        return () if serial_factory is None else (serial_factory.close,)
+    if isinstance(config, SwbtControllerConfig):
+        return () if swbt_factory is None else (swbt_factory.close,)
+    return ()
 
 
 def _allow_dummy(settings: dict[str, Any], request: RuntimeBuildRequest) -> bool:

--- a/src/nyxpy/gui/app_services.py
+++ b/src/nyxpy/gui/app_services.py
@@ -17,8 +17,8 @@ from nyxpy.framework.core.hardware.device_discovery import (
 )
 from nyxpy.framework.core.hardware.protocol_factory import ProtocolFactory
 from nyxpy.framework.core.hardware.window_discovery import WindowInfo, resolve_window
+from nyxpy.framework.core.io.controller_config import controller_config_from_settings
 from nyxpy.framework.core.io.device_factories import (
-    ControllerOutputPortFactory,
     FrameSourcePortFactory,
 )
 from nyxpy.framework.core.io.ports import ControllerOutputPort, FrameSourcePort
@@ -85,9 +85,15 @@ FRAME_SOURCE_SETTING_KEYS = (
 
 CONTROLLER_SETTING_KEYS = frozenset(
     {
-        "serial_device",
-        "serial_baud",
-        "serial_protocol",
+        "controller.backend",
+        "controller.serial.device",
+        "controller.serial.baudrate",
+        "controller.serial.protocol",
+        "controller.swbt.adapter",
+        "controller.swbt.controller_type",
+        "controller.swbt.key_store_path",
+        "controller.swbt.connect_timeout_sec",
+        "controller.swbt.report_period_us",
     }
 )
 
@@ -268,12 +274,9 @@ class GuiAppServices:
 
     def _replace_runtime_builder(self) -> None:
         previous_builder = self.runtime_builder
-        protocol = ProtocolFactory.create_protocol(
-            self.global_settings.get("serial_protocol", "CH552")
-        )
-        controller_factory = ControllerOutputPortFactory(
-            discovery=self.device_discovery,
-            protocol=protocol,
+        controller_config = controller_config_from_settings(
+            self.global_settings.data,
+            workspace_root=self.project_root,
         )
         frame_factory = FrameSourcePortFactory(
             discovery=self.device_discovery,
@@ -287,12 +290,9 @@ class GuiAppServices:
             project_root=self.project_root,
             registry=self.registry,
             device_discovery=self.device_discovery,
-            controller_output_factory=controller_factory,
+            controller_config=controller_config,
             frame_source_factory=frame_factory,
-            serial_name=self.global_settings.get("serial_device"),
             capture_name=self.global_settings.get("capture_device"),
-            baudrate=self.global_settings.get("serial_baud", 9600),
-            protocol=protocol,
             notification_handler=notification_handler,
             logger=self.logger,
             settings=self.global_settings.data,
@@ -345,7 +345,7 @@ class GuiAppServices:
         if not isinstance(result, DeviceDiscoveryResult):
             return
 
-        serial_device = str(self.global_settings.get("serial_device", "") or "").strip()
+        serial_device = str(self.global_settings.get("controller.serial.device", "") or "").strip()
         if (
             serial_device
             and serial_device != DUMMY_DEVICE_NAME
@@ -353,8 +353,8 @@ class GuiAppServices:
             and not _has_discovery_error(result, "serial")
             and not _serial_exists(result, serial_device)
         ):
-            self.global_settings.set("serial_device", "")
-            discarded_keys.append("serial_device")
+            self.global_settings.set("controller.serial.device", "")
+            discarded_keys.append("controller.serial.device")
 
         if source_type == "window":
             discarded_keys.extend(self._discard_unavailable_window_settings())
@@ -443,8 +443,8 @@ class GuiAppServices:
         return WindowDiscoveryResult(window_sources=windows)
 
     def _log_setting_changes(self, changed_keys: set[str]) -> None:
-        if {"serial_device", "serial_baud"} & changed_keys:
-            serial_identifier = str(self.global_settings.get("serial_device", "") or "")
+        if {"controller.serial.device", "controller.serial.baudrate"} & changed_keys:
+            serial_identifier = str(self.global_settings.get("controller.serial.device", "") or "")
             discovery = getattr(self, "device_discovery", None)
             display_name = getattr(discovery, "serial_display_name", None)
             serial_display = (
@@ -454,7 +454,7 @@ class GuiAppServices:
             )
             self.logger.user(
                 "INFO",
-                f"シリアルデバイス設定を更新しました: {serial_display} ({self.global_settings.get('serial_baud', 9600)} bps)",
+                f"シリアルデバイス設定を更新しました: {serial_display} ({self.global_settings.get('controller.serial.baudrate', 9600)} bps)",
                 component="GuiAppServices",
                 event="configuration.changed",
             )
@@ -465,11 +465,13 @@ class GuiAppServices:
                 component="GuiAppServices",
                 event="configuration.changed",
             )
-        if "serial_protocol" in changed_keys:
-            ProtocolFactory.create_protocol(self.global_settings.get("serial_protocol", "CH552"))
+        if "controller.serial.protocol" in changed_keys:
+            ProtocolFactory.create_protocol(
+                self.global_settings.get("controller.serial.protocol", "CH552")
+            )
             self.logger.user(
                 "INFO",
-                f"コントローラープロトコルを切り替えました: {self.global_settings.get('serial_protocol', 'CH552')}",
+                f"コントローラープロトコルを切り替えました: {self.global_settings.get('controller.serial.protocol', 'CH552')}",
                 component="GuiAppServices",
                 event="configuration.changed",
             )

--- a/tests/hardware/test_macro_runtime_realdevice.py
+++ b/tests/hardware/test_macro_runtime_realdevice.py
@@ -9,9 +9,10 @@ from nyxpy.framework.core.hardware.camera_capture import CameraCaptureDevice
 from nyxpy.framework.core.hardware.device_discovery import DeviceDiscoveryResult, DeviceInfo
 from nyxpy.framework.core.hardware.protocol_factory import ProtocolFactory
 from nyxpy.framework.core.hardware.serial_comm import SerialComm
+from nyxpy.framework.core.io.controller_config import SerialControllerConfig
 from nyxpy.framework.core.io.device_factories import (
-    ControllerOutputPortFactory,
     FrameSourcePortFactory,
+    SerialControllerOutputPortFactory,
 )
 from nyxpy.framework.core.logger import NullLoggerPort
 from nyxpy.framework.core.macro.registry import MacroRegistry
@@ -87,7 +88,7 @@ def test_macro_runtime_runs_with_real_serial_and_capture(tmp_path: Path) -> None
 
     discovery = StaticDiscovery(serial_port, capture_index)
     protocol = ProtocolFactory.create_protocol(protocol_name)
-    controller_factory = ControllerOutputPortFactory(
+    controller_factory = SerialControllerOutputPortFactory(
         discovery=discovery,
         protocol=protocol,
         serial_factory=SerialComm,
@@ -101,12 +102,14 @@ def test_macro_runtime_runs_with_real_serial_and_capture(tmp_path: Path) -> None
         project_root=tmp_path,
         registry=registry,
         device_discovery=discovery,
-        controller_output_factory=controller_factory,
+        controller_config=SerialControllerConfig(
+            device=serial_port,
+            protocol=protocol_name,
+            baudrate=baudrate,
+        ),
+        serial_controller_factory=controller_factory,
         frame_source_factory=frame_factory,
-        serial_name=serial_port,
         capture_name=str(capture_index),
-        baudrate=baudrate,
-        protocol=protocol,
         notification_handler=NotificationHandler([]),
         logger=NullLoggerPort(),
     )

--- a/tests/integration/test_capture_source_runtime.py
+++ b/tests/integration/test_capture_source_runtime.py
@@ -4,6 +4,7 @@ import numpy as np
 import pytest
 
 from nyxpy.framework.core.hardware.capture_source import PonkanCaptureSourceConfig
+from nyxpy.framework.core.io.controller_config import SerialControllerConfig
 from nyxpy.framework.core.macro.command import DefaultCommand
 from nyxpy.framework.core.macro.exceptions import ConfigurationError
 from nyxpy.framework.core.macro.registry import MacroDefinition
@@ -69,10 +70,10 @@ def test_runtime_builder_rejects_removed_screen_region_source(tmp_path: Path) ->
         create_device_runtime_builder(
             project_root=tmp_path,
             registry=Registry(definition(tmp_path)),
-            protocol=object(),
+            controller_config=SerialControllerConfig(device=None),
             notification_handler=None,
             logger=FakeLoggerPort(),
-            controller_output_factory=ControllerFactory(),
+            serial_controller_factory=ControllerFactory(),
             frame_source_factory=frame_factory,
             settings={
                 "capture_source_type": "screen_region",
@@ -99,10 +100,10 @@ def test_runtime_uses_ponkan_capture_frame_source(tmp_path: Path) -> None:
     builder = create_device_runtime_builder(
         project_root=tmp_path,
         registry=Registry(definition(tmp_path)),
-        protocol=object(),
+        controller_config=SerialControllerConfig(device=None),
         notification_handler=None,
         logger=FakeLoggerPort(),
-        controller_output_factory=ControllerFactory(),
+        serial_controller_factory=ControllerFactory(),
         frame_source_factory=frame_factory,
         settings={
             "capture_source_type": "capture",

--- a/tests/integration/test_cli_runtime_adapter.py
+++ b/tests/integration/test_cli_runtime_adapter.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from unittest.mock import MagicMock
 
 from nyxpy.cli import run_cli
+from nyxpy.framework.core.io.controller_config import SerialControllerConfig
 from nyxpy.framework.core.runtime.result import RunResult, RunStatus
 
 
@@ -83,13 +84,13 @@ def test_cli_notification_settings_source_is_secrets_store(monkeypatch, tmp_path
     logger = Logger()
 
     run_cli.create_runtime_builder(
-        MagicMock(),
         logger=logger,
+        controller_config=SerialControllerConfig(device="COM1"),
         project_root=tmp_path,
         settings_store=settings_store,
         secrets_store=secrets_store,
         device_discovery=discovery,
-        controller_output_factory=controller_factory,
+        serial_controller_factory=controller_factory,
         frame_source_factory=frame_factory,
     )
 

--- a/tests/integration/test_swbt_runtime_cli_integration.py
+++ b/tests/integration/test_swbt_runtime_cli_integration.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+import inspect
+import sys
+import textwrap
+from pathlib import Path
+
+from swbt import Button as SwbtButton
+
+from nyxpy.framework.core.hardware.swbt.config import SwbtControllerConfig, resolve_controller_model
+from nyxpy.framework.core.hardware.swbt.factory import SwbtControllerOutputPortFactory
+from nyxpy.framework.core.hardware.swbt.session import DummySwbtControllerSession
+from nyxpy.framework.core.macro.command import Command
+from nyxpy.framework.core.macro.registry import MacroRegistry
+from nyxpy.framework.core.runtime.builder import create_device_runtime_builder
+from nyxpy.framework.core.runtime.context import ExecutionContext, RuntimeBuildRequest
+from nyxpy.framework.core.runtime.result import RunStatus
+from nyxpy.framework.core.runtime.runtime import MacroRuntime
+from tests.support.fakes import FakeFrameSourcePort, FakeLoggerPort
+
+
+class FrameFactory:
+    def create(self, *, source, allow_dummy: bool, timeout_sec: float):
+        return FakeFrameSourcePort()
+
+    def close(self) -> None:
+        pass
+
+
+def test_swbt_runtime_runs_press_and_imu_with_dummy_session(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    _write_swbt_macro(tmp_path, monkeypatch)
+    registry = MacroRegistry(project_root=tmp_path)
+    registry.reload()
+    session = DummySwbtControllerSession()
+    swbt_factory = SwbtControllerOutputPortFactory(session_factory=lambda _config: session)
+    config = SwbtControllerConfig(
+        model=resolve_controller_model("pro-controller"),
+        adapter="dummy-adapter",
+        key_store_path=tmp_path / ".nyxpy" / "swbt" / "pro-controller-bond.json",
+    )
+    builder = create_device_runtime_builder(
+        project_root=tmp_path,
+        registry=registry,
+        controller_config=config,
+        swbt_controller_factory=swbt_factory,
+        frame_source_factory=FrameFactory(),
+        notification_handler=None,
+        logger=FakeLoggerPort(),
+    )
+
+    result = builder.run(RuntimeBuildRequest(macro_id="swbt_runtime_sample"))
+    builder.shutdown()
+
+    assert result.status is RunStatus.SUCCESS
+    assert any(SwbtButton.A in state.buttons for state in session.states)
+    assert any(state.imu_frames[0].gyro_x == 7 for state in session.states)
+    assert session.closed is True
+
+
+def test_command_runtime_context_do_not_import_swbt() -> None:
+    surfaces = (Command, MacroRuntime, ExecutionContext)
+
+    for surface in surfaces:
+        assert "swbt" not in inspect.getsource(surface)
+
+
+def _write_swbt_macro(project_root: Path, monkeypatch) -> None:
+    macros_dir = project_root / "macros"
+    package_dir = macros_dir / "swbt_runtime_sample"
+    package_dir.mkdir(parents=True)
+    monkeypatch.syspath_prepend(project_root)
+    _clear_macro_modules()
+    (package_dir / "__init__.py").write_text(
+        "from .macro import SwbtRuntimeSample\n__all__ = ['SwbtRuntimeSample']\n",
+        encoding="utf-8",
+    )
+    (package_dir / "macro.py").write_text(
+        textwrap.dedent(
+            """
+            from nyxpy.framework.core.constants import Button, IMUFrame
+            from nyxpy.framework.core.macro.base import MacroBase
+            from nyxpy.framework.core.macro.command import Command
+
+
+            class SwbtRuntimeSample(MacroBase):
+                def initialize(self, cmd: Command, args: dict) -> None:
+                    pass
+
+                def run(self, cmd: Command) -> None:
+                    cmd.press(Button.A, dur=0, wait=0)
+                    cmd.imu(IMUFrame.gyro(x=7))
+
+                def finalize(self, cmd: Command) -> None:
+                    pass
+            """
+        ),
+        encoding="utf-8",
+    )
+
+
+def _clear_macro_modules() -> None:
+    for module_name in list(sys.modules):
+        if module_name in {"macro", "macros"} or module_name.startswith(("macro.", "macros.")):
+            del sys.modules[module_name]

--- a/tests/unit/cli/test_main.py
+++ b/tests/unit/cli/test_main.py
@@ -14,6 +14,7 @@ from nyxpy.cli.run_cli import (
     execute_macro,
 )
 from nyxpy.framework.core.hardware.protocol import CH552SerialProtocol, ThreeDSSerialProtocol
+from nyxpy.framework.core.io.controller_config import SerialControllerConfig
 from nyxpy.framework.core.macro.exceptions import ConfigurationError, ErrorInfo, ErrorKind
 from nyxpy.framework.core.runtime.result import RunResult, RunStatus
 
@@ -146,21 +147,24 @@ def test_create_runtime_builder_delegates_device_selection_to_builder(monkeypatc
 
     logger = MockLogger()
     create_runtime_builder(
-        MagicMock(),
         logger=logger,
+        controller_config=SerialControllerConfig(device="COM1"),
         project_root=tmp_path,
         settings_store=settings_store,
         secrets_store=secrets_store,
         device_discovery=discovery,
-        controller_output_factory=controller_factory,
+        serial_controller_factory=controller_factory,
         frame_source_factory=frame_factory,
     )
 
     mock_registry.assert_called_once_with(project_root=tmp_path)
     registry.reload.assert_called_once()
     assert mock_builder.call_args.kwargs["device_discovery"] is discovery
-    assert mock_builder.call_args.kwargs["controller_output_factory"] is controller_factory
+    assert mock_builder.call_args.kwargs["serial_controller_factory"] is controller_factory
     assert mock_builder.call_args.kwargs["frame_source_factory"] is frame_factory
+    assert mock_builder.call_args.kwargs["controller_config"] == SerialControllerConfig(
+        device="COM1"
+    )
     assert mock_builder.call_args.kwargs["settings"] == {"runtime.allow_dummy": False}
     assert "serial_device" not in mock_builder.call_args.kwargs
     assert "capture_device" not in mock_builder.call_args.kwargs
@@ -185,7 +189,11 @@ def test_create_runtime_builder_passes_project_config_dir_to_stores(monkeypatch,
     )
     monkeypatch.setattr("nyxpy.cli.run_cli.create_device_runtime_builder", mock_builder)
 
-    create_runtime_builder(MagicMock(), logger=MockLogger(), project_root=tmp_path)
+    create_runtime_builder(
+        logger=MockLogger(),
+        controller_config=SerialControllerConfig(device=None),
+        project_root=tmp_path,
+    )
 
     mock_settings_store.assert_called_once_with(
         config_dir=tmp_path.resolve() / ".nyxpy",
@@ -243,10 +251,15 @@ def test_cli_does_not_accept_notification_secret_args() -> None:
 
 def make_args():
     args = MagicMock()
+    args.controller = None
     args.serial = "COM1"
     args.capture = "Camera1"
     args.protocol = "CH552"
     args.baud = None
+    args.swbt_adapter = None
+    args.swbt_controller_type = None
+    args.swbt_key_store = None
+    args.swbt_timeout = None
     args.macro_name = "Sample"
     args.silence = False
     args.verbose = False
@@ -270,13 +283,11 @@ def test_cli_main_success(monkeypatch, tmp_path):
     paths = patch_cli_workspace(monkeypatch, tmp_path)
     mock_logging = MockLoggingComponents()
     mock_configure = MagicMock(return_value=mock_logging)
-    mock_protocol = MagicMock()
     mock_builder = MagicMock()
     mock_create_builder = MagicMock(return_value=mock_builder)
     mock_execute = MagicMock(return_value=result(RunStatus.SUCCESS))
 
     monkeypatch.setattr("nyxpy.cli.run_cli.configure_logging", mock_configure)
-    monkeypatch.setattr("nyxpy.cli.run_cli.create_protocol", lambda name: mock_protocol)
     monkeypatch.setattr(
         "nyxpy.cli.run_cli.create_runtime_builder",
         mock_create_builder,
@@ -291,12 +302,15 @@ def test_cli_main_success(monkeypatch, tmp_path):
         base_dir=paths.logs_dir,
     )
     mock_create_builder.assert_called_once_with(
-        protocol=mock_protocol,
         logger=mock_logging.logger,
+        controller_config=SerialControllerConfig(
+            device="COM1",
+            protocol="CH552",
+            baudrate=9600,
+        ),
         project_root=paths.project_root,
-        serial_name="COM1",
         capture_name="Camera1",
-        baudrate=9600,
+        settings_store=mock_create_builder.call_args.kwargs["settings_store"],
     )
     mock_execute.assert_called_once_with(
         runtime_builder=mock_builder,
@@ -329,7 +343,7 @@ def test_cli_main_uses_3ds_default_baudrate(monkeypatch, tmp_path):
     create_builder = __import__(
         "nyxpy.cli.run_cli", fromlist=["create_runtime_builder"]
     ).create_runtime_builder
-    assert create_builder.call_args.kwargs["baudrate"] == 115200
+    assert create_builder.call_args.kwargs["controller_config"].baudrate == 115200
 
 
 def test_cli_main_baud_override(monkeypatch, tmp_path):
@@ -356,7 +370,7 @@ def test_cli_main_baud_override(monkeypatch, tmp_path):
     create_builder = __import__(
         "nyxpy.cli.run_cli", fromlist=["create_runtime_builder"]
     ).create_runtime_builder
-    assert create_builder.call_args.kwargs["baudrate"] == 9600
+    assert create_builder.call_args.kwargs["controller_config"].baudrate == 9600
 
 
 def test_cli_main_value_error(monkeypatch, mock_log_manager, tmp_path):
@@ -368,8 +382,8 @@ def test_cli_main_value_error(monkeypatch, mock_log_manager, tmp_path):
         "nyxpy.cli.run_cli.configure_logging", MagicMock(return_value=mock_log_manager)
     )
     monkeypatch.setattr(
-        "nyxpy.cli.run_cli.create_protocol",
-        lambda name: (_ for _ in ()).throw(ValueError("invalid protocol")),
+        "nyxpy.cli.run_cli.controller_config_from_overrides",
+        lambda *args, **kwargs: (_ for _ in ()).throw(ValueError("invalid protocol")),
     )
 
     assert cli_main(args) == 1
@@ -383,8 +397,8 @@ def test_cli_main_exception(monkeypatch, mock_log_manager, tmp_path):
         "nyxpy.cli.run_cli.configure_logging", MagicMock(return_value=mock_log_manager)
     )
     monkeypatch.setattr(
-        "nyxpy.cli.run_cli.create_protocol",
-        lambda name: (_ for _ in ()).throw(Exception("Unexpected error")),
+        "nyxpy.cli.run_cli.controller_config_from_overrides",
+        lambda *args, **kwargs: (_ for _ in ()).throw(Exception("Unexpected error")),
     )
 
     assert cli_main(args) == 2
@@ -403,8 +417,8 @@ def test_cli_unhandled_exception_uses_fixed_user_message(
         "nyxpy.cli.run_cli.configure_logging", MagicMock(return_value=mock_log_manager)
     )
     monkeypatch.setattr(
-        "nyxpy.cli.run_cli.create_protocol",
-        lambda name: (_ for _ in ()).throw(
+        "nyxpy.cli.run_cli.controller_config_from_overrides",
+        lambda *args, **kwargs: (_ for _ in ()).throw(
             RuntimeError("secret value leaked from E:\\secret\\payload.txt")
         ),
     )
@@ -425,8 +439,10 @@ def test_cli_configuration_error_returns_1(monkeypatch, mock_log_manager, tmp_pa
         "nyxpy.cli.run_cli.configure_logging", MagicMock(return_value=mock_log_manager)
     )
     monkeypatch.setattr(
-        "nyxpy.cli.run_cli.create_protocol",
-        lambda name: (_ for _ in ()).throw(ConfigurationError("invalid protocol settings")),
+        "nyxpy.cli.run_cli.controller_config_from_overrides",
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            ConfigurationError("invalid protocol settings")
+        ),
     )
 
     assert cli_main(args) == 1
@@ -441,7 +457,6 @@ def test_cli_cleanup_failures_are_logged(monkeypatch, tmp_path):
     builder.shutdown = MagicMock(side_effect=RuntimeError("shutdown failed"))
 
     monkeypatch.setattr("nyxpy.cli.run_cli.configure_logging", MagicMock(return_value=logging))
-    monkeypatch.setattr("nyxpy.cli.run_cli.create_protocol", lambda name: MagicMock())
     monkeypatch.setattr(
         "nyxpy.cli.run_cli.create_runtime_builder",
         MagicMock(return_value=builder),

--- a/tests/unit/cli/test_run_cli_parser.py
+++ b/tests/unit/cli/test_run_cli_parser.py
@@ -84,13 +84,36 @@ def test_cli_parser_keeps_existing_options() -> None:
     )
 
     assert args.macro_name == "sample"
+    assert args.controller is None
     assert args.serial == "serial-1"
     assert args.capture == "capture-1"
     assert args.protocol == "ch552"
     assert args.baud == 115200
+    assert args.swbt_adapter is None
+    assert args.swbt_controller_type is None
     assert args.silence is True
     assert args.verbose is True
     assert args.define == ["count=3", 'name="nyx"']
+
+
+def test_run_parser_accepts_swbt_without_serial() -> None:
+    parser = run_cli.build_parser()
+
+    args = parser.parse_args(["sample", "--controller", "swbt", "--swbt-adapter", "usb:0"])
+
+    assert args.controller == "swbt"
+    assert args.serial is None
+    assert args.capture is None
+    assert args.swbt_adapter == "usb:0"
+
+
+def test_run_parser_accepts_settings_capture_without_capture_option() -> None:
+    parser = run_cli.build_parser()
+
+    args = parser.parse_args(["sample", "--serial", "serial-1"])
+
+    assert args.serial == "serial-1"
+    assert args.capture is None
 
 
 def test_top_level_parser_accepts_swbt_adapters_command() -> None:
@@ -101,6 +124,29 @@ def test_top_level_parser_accepts_swbt_adapters_command() -> None:
     assert args.command == "swbt"
     assert args.swbt_command == "adapters"
     assert args.json is True
+
+
+def test_top_level_parser_accepts_swbt_pair_command() -> None:
+    from nyxpy.__main__ import parse_arguments
+
+    args = parse_arguments(
+        [
+            "swbt",
+            "pair",
+            "--adapter",
+            "usb:0",
+            "--controller-type",
+            "pro-controller",
+            "--timeout",
+            "5",
+        ]
+    )
+
+    assert args.command == "swbt"
+    assert args.swbt_command == "pair"
+    assert args.adapter == "usb:0"
+    assert args.controller_type == "pro-controller"
+    assert args.timeout == 5.0
 
 
 def test_cli_does_not_accept_notification_secret_args() -> None:

--- a/tests/unit/cli/test_swbt_cli.py
+++ b/tests/unit/cli/test_swbt_cli.py
@@ -1,8 +1,11 @@
 import io
 import json
+from pathlib import Path
 
 from nyxpy.cli.swbt_cli import cli_main
+from nyxpy.framework.core.hardware.swbt.config import SwbtControllerConfig
 from nyxpy.framework.core.hardware.swbt.discovery import SwbtAdapterView
+from nyxpy.framework.core.settings.global_settings import SettingsStore
 
 
 class Discovery:
@@ -13,6 +16,26 @@ class Discovery:
     def list_adapters(self) -> tuple[SwbtAdapterView, ...]:
         self.calls += 1
         return self.adapters
+
+
+class RecordingFactory:
+    def __init__(self) -> None:
+        self.calls = []
+        self.closed = False
+
+    def pair(self, config: SwbtControllerConfig, *, timeout_sec: float):
+        self.calls.append(("pair", config, timeout_sec))
+        return object()
+
+    def reconnect(self, config: SwbtControllerConfig, *, timeout_sec: float):
+        self.calls.append(("reconnect", config, timeout_sec))
+        return object()
+
+    def disconnect(self, config: SwbtControllerConfig) -> None:
+        self.calls.append(("disconnect", config, None))
+
+    def close(self) -> None:
+        self.closed = True
 
 
 def adapter_view() -> SwbtAdapterView:
@@ -54,3 +77,104 @@ def test_swbt_adapters_cli_prints_empty_result() -> None:
     assert cli_main(args, discovery_service=discovery, stdout=stdout) == 0
 
     assert stdout.getvalue().strip() == "No swbt USB Bluetooth adapter found."
+
+
+def test_swbt_pair_cli_calls_factory_pair(tmp_path: Path) -> None:
+    factory = RecordingFactory()
+    stdout = io.StringIO()
+    args = type(
+        "Args",
+        (),
+        {
+            "swbt_command": "pair",
+            "adapter": "usb:0",
+            "controller_type": "pro-controller",
+            "key_store": tmp_path / "bond.json",
+            "timeout": 5.0,
+        },
+    )()
+
+    exit_code = cli_main(args, controller_factory=factory, project_root=tmp_path, stdout=stdout)
+
+    assert exit_code == 0
+    assert factory.closed is True
+    assert factory.calls[0][0] == "pair"
+    assert factory.calls[0][1].adapter == "usb:0"
+    assert factory.calls[0][1].key_store_path == tmp_path / "bond.json"
+    assert factory.calls[0][2] == 5.0
+    assert stdout.getvalue().strip() == "swbt pair completed."
+
+
+def test_swbt_reconnect_cli_calls_factory_reconnect(tmp_path: Path) -> None:
+    factory = RecordingFactory()
+    args = type(
+        "Args",
+        (),
+        {
+            "swbt_command": "reconnect",
+            "adapter": "usb:0",
+            "controller_type": "pro-controller",
+            "key_store": None,
+            "timeout": 6.0,
+        },
+    )()
+
+    assert cli_main(args, controller_factory=factory, project_root=tmp_path) == 0
+
+    assert factory.closed is True
+    assert factory.calls[0][0] == "reconnect"
+    assert factory.calls[0][2] == 6.0
+
+
+def test_swbt_disconnect_cli_calls_factory_disconnect(tmp_path: Path) -> None:
+    factory = RecordingFactory()
+    args = type(
+        "Args",
+        (),
+        {
+            "swbt_command": "disconnect",
+            "adapter": "usb:0",
+            "controller_type": "joy-con-l",
+            "key_store": None,
+            "timeout": None,
+        },
+    )()
+
+    assert cli_main(args, controller_factory=factory, project_root=tmp_path) == 0
+
+    assert factory.closed is True
+    assert factory.calls[0][0] == "disconnect"
+    assert factory.calls[0][1].model.settings_value == "joy-con-l"
+
+
+def test_swbt_cli_overrides_do_not_mutate_settings(tmp_path: Path) -> None:
+    settings = SettingsStore(config_dir=tmp_path / ".nyxpy", strict_load=False)
+    settings.set("controller.swbt.adapter", "settings-adapter")
+    settings.set("controller.swbt.controller_type", "joy-con-r")
+    factory = RecordingFactory()
+    args = type(
+        "Args",
+        (),
+        {
+            "swbt_command": "pair",
+            "adapter": "usb:0",
+            "controller_type": "pro-controller",
+            "key_store": None,
+            "timeout": 2.0,
+        },
+    )()
+
+    assert (
+        cli_main(
+            args,
+            controller_factory=factory,
+            settings_store=settings,
+            project_root=tmp_path,
+        )
+        == 0
+    )
+
+    assert factory.calls[0][1].adapter == "usb:0"
+    assert factory.calls[0][1].model.settings_value == "pro-controller"
+    assert settings.get("controller.swbt.adapter") == "settings-adapter"
+    assert settings.get("controller.swbt.controller_type") == "joy-con-r"

--- a/tests/unit/framework/io/test_controller_config.py
+++ b/tests/unit/framework/io/test_controller_config.py
@@ -6,6 +6,7 @@ from nyxpy.framework.core.hardware.swbt.config import SwbtControllerConfig, Swbt
 from nyxpy.framework.core.io.controller_config import (
     ControllerBackend,
     SerialControllerConfig,
+    controller_config_from_overrides,
     controller_config_from_settings,
     parse_controller_backend,
 )
@@ -85,6 +86,35 @@ def test_swbt_controller_config_does_not_keep_controller_type_string() -> None:
     assert config.model.controller_type is SwbtControllerType.PRO_CONTROLLER
     assert config.adapter == "usb:0"
     assert config.key_store_path == Path(".nyxpy/swbt/pro.json")
+
+
+def test_controller_config_overrides_do_not_mutate_settings(tmp_path: Path) -> None:
+    settings = {
+        "controller": {
+            "backend": "serial",
+            "swbt": {
+                "controller_type": "joy-con-r",
+                "adapter": "settings-adapter",
+            },
+        }
+    }
+
+    config = controller_config_from_overrides(
+        settings,
+        workspace_root=tmp_path,
+        backend="swbt",
+        swbt_controller_type="pro-controller",
+        swbt_adapter="usb:0",
+        swbt_connect_timeout_sec=5.0,
+    )
+
+    assert isinstance(config, SwbtControllerConfig)
+    assert config.model.controller_type is SwbtControllerType.PRO_CONTROLLER
+    assert config.adapter == "usb:0"
+    assert config.connect_timeout_sec == 5.0
+    assert settings["controller"]["backend"] == "serial"
+    assert settings["controller"]["swbt"]["controller_type"] == "joy-con-r"
+    assert settings["controller"]["swbt"]["adapter"] == "settings-adapter"
 
 
 def test_controller_config_rejects_invalid_backend_and_non_positive_values() -> None:

--- a/tests/unit/framework/io/test_device_factories.py
+++ b/tests/unit/framework/io/test_device_factories.py
@@ -12,8 +12,8 @@ from nyxpy.framework.core.hardware.device_discovery import (
 )
 from nyxpy.framework.core.hardware.window_capture import WindowCaptureBackend, WindowCaptureSession
 from nyxpy.framework.core.io.device_factories import (
-    ControllerOutputPortFactory,
     FrameSourcePortFactory,
+    SerialControllerOutputPortFactory,
 )
 from nyxpy.framework.core.macro.exceptions import ConfigurationError
 
@@ -124,7 +124,7 @@ class Backend(WindowCaptureBackend):
 
 def test_controller_factory_reuses_named_device_and_closes_once() -> None:
     SerialDevice.instances.clear()
-    factory = ControllerOutputPortFactory(
+    factory = SerialControllerOutputPortFactory(
         discovery=Discovery(),
         protocol=Protocol(),
         serial_factory=SerialDevice,
@@ -301,7 +301,7 @@ def test_frame_source_factory_falls_back_to_dummy_when_window_not_selected() -> 
 
 def test_controller_factory_uses_serial_identifier() -> None:
     SerialDevice.instances.clear()
-    factory = ControllerOutputPortFactory(
+    factory = SerialControllerOutputPortFactory(
         discovery=Discovery(),
         protocol=Protocol(),
         serial_factory=SerialDevice,
@@ -314,7 +314,7 @@ def test_controller_factory_uses_serial_identifier() -> None:
 
 @pytest.mark.parametrize("name", [None, DUMMY_DEVICE_NAME])
 def test_controller_factory_rejects_dummy_without_explicit_permission(name) -> None:
-    factory = ControllerOutputPortFactory(
+    factory = SerialControllerOutputPortFactory(
         discovery=Discovery(),
         protocol=Protocol(),
         serial_factory=SerialDevice,
@@ -329,7 +329,7 @@ def test_controller_factory_falls_back_to_dummy_when_open_fails_and_dummy_allowe
         def open(self, baudrate: int) -> None:
             raise OSError("port unavailable")
 
-    factory = ControllerOutputPortFactory(
+    factory = SerialControllerOutputPortFactory(
         discovery=Discovery(),
         protocol=Protocol(),
         serial_factory=FailingSerialDevice,

--- a/tests/unit/framework/runtime/test_runtime_builder.py
+++ b/tests/unit/framework/runtime/test_runtime_builder.py
@@ -5,10 +5,12 @@ import pytest
 
 from nyxpy.framework.core.hardware.capture_source import WindowCaptureSourceConfig
 from nyxpy.framework.core.hardware.device_discovery import DeviceDiscoveryResult, DeviceInfo
+from nyxpy.framework.core.hardware.swbt.config import SwbtControllerConfig, resolve_controller_model
 from nyxpy.framework.core.io.adapters import NoopNotificationAdapter, NotificationHandlerAdapter
+from nyxpy.framework.core.io.controller_config import SerialControllerConfig
 from nyxpy.framework.core.io.device_factories import (
-    ControllerOutputPortFactory,
     FrameSourcePortFactory,
+    SerialControllerOutputPortFactory,
 )
 from nyxpy.framework.core.io.resources import MacroResourceScope
 from nyxpy.framework.core.macro.exceptions import ConfigurationError
@@ -111,6 +113,19 @@ class RecordingFrameFactory:
         self.closed = True
 
 
+class RecordingSwbtFactory:
+    def __init__(self) -> None:
+        self.creates = []
+        self.closed = False
+
+    def create(self, *, config, allow_dummy: bool, timeout_sec: float):
+        self.creates.append((config, allow_dummy, timeout_sec))
+        return FakeControllerOutputPort()
+
+    def close(self) -> None:
+        self.closed = True
+
+
 def definition(tmp_path: Path) -> MacroDefinition:
     return MacroDefinition(
         id="sample",
@@ -131,7 +146,14 @@ def make_builder(tmp_path: Path, discovery: Discovery, **kwargs):
     notification_handler = kwargs.pop("notification_handler", None)
     frame_source_factory = kwargs.pop("frame_source_factory", None)
     macro_settings = kwargs.pop("macro_settings", None)
-    controller_factory = ControllerOutputPortFactory(
+    serial_name = kwargs.pop("serial_name", None)
+    baudrate = kwargs.pop("baudrate", 9600)
+    capture_name = kwargs.pop("capture_name", None)
+    controller_config = kwargs.pop(
+        "controller_config",
+        SerialControllerConfig(device=serial_name, protocol="CH552", baudrate=baudrate),
+    )
+    controller_factory = SerialControllerOutputPortFactory(
         discovery=discovery,
         protocol=object(),
         serial_factory=SerialDevice,
@@ -145,9 +167,10 @@ def make_builder(tmp_path: Path, discovery: Discovery, **kwargs):
         project_root=tmp_path,
         registry=Registry(definition(tmp_path), macro_settings),
         device_discovery=discovery,
-        controller_output_factory=controller_factory,
+        controller_config=controller_config,
+        serial_controller_factory=controller_factory,
         frame_source_factory=frame_factory,
-        protocol=object(),
+        capture_name=capture_name,
         notification_handler=notification_handler,
         logger=FakeLoggerPort(),
         **kwargs,
@@ -293,12 +316,67 @@ def test_runtime_builder_rejects_legacy_manager_arguments(tmp_path: Path) -> Non
         create_device_runtime_builder(
             project_root=tmp_path,
             registry=Registry(definition(tmp_path)),
+            controller_config=SerialControllerConfig(device=None),
             serial_manager=object(),
             capture_manager=object(),
-            protocol=object(),
             notification_handler=None,
             logger=FakeLoggerPort(),
         )
+
+
+def test_make_controller_port_factory_selects_swbt(tmp_path: Path) -> None:
+    swbt_factory = RecordingSwbtFactory()
+    frame_factory = RecordingFrameFactory()
+    swbt_config = SwbtControllerConfig(
+        model=resolve_controller_model("pro-controller"),
+        adapter="usb:0",
+        key_store_path=tmp_path / ".nyxpy" / "swbt" / "pro-controller-bond.json",
+        connect_timeout_sec=4.0,
+    )
+    builder = create_device_runtime_builder(
+        project_root=tmp_path,
+        registry=Registry(definition(tmp_path)),
+        device_discovery=Discovery(),
+        controller_config=swbt_config,
+        swbt_controller_factory=swbt_factory,
+        frame_source_factory=frame_factory,
+        notification_handler=None,
+        logger=FakeLoggerPort(),
+    )
+
+    context = builder.build(RuntimeBuildRequest(macro_id="sample"))
+    builder.shutdown()
+
+    assert isinstance(context.controller, FakeControllerOutputPort)
+    assert swbt_factory.creates == [(swbt_config, False, 4.0)]
+    assert swbt_factory.closed is True
+
+
+def test_run_swbt_does_not_resolve_serial_protocol(monkeypatch, tmp_path: Path) -> None:
+    def fail_create_protocol(_name):
+        raise AssertionError("serial protocol should not be created for swbt")
+
+    monkeypatch.setattr(
+        "nyxpy.framework.core.runtime.builder.ProtocolFactory.create_protocol",
+        fail_create_protocol,
+    )
+    swbt_config = SwbtControllerConfig(
+        model=resolve_controller_model("pro-controller"),
+        adapter="usb:0",
+        key_store_path=tmp_path / ".nyxpy" / "swbt" / "pro-controller-bond.json",
+    )
+    builder = create_device_runtime_builder(
+        project_root=tmp_path,
+        registry=Registry(definition(tmp_path)),
+        device_discovery=Discovery(),
+        controller_config=swbt_config,
+        swbt_controller_factory=RecordingSwbtFactory(),
+        frame_source_factory=RecordingFrameFactory(),
+        notification_handler=None,
+        logger=FakeLoggerPort(),
+    )
+
+    builder.build(RuntimeBuildRequest(macro_id="sample"))
 
 
 def test_runtime_builder_exposes_and_shutdowns_gui_lifetime_ports(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

swbt controller backend を runtime builder と CLI に接続し、nyxpy run と nyxpy swbt の明示 lifecycle command から利用できるようにした。

## Related

- spec/agent/complete/local_024/SWBT_RUNTIME_CLI_INTEGRATION.md

## Changes

- runtime builder を ControllerConfig ベースへ変更し、serial / swbt の controller factory 選択を構成処理に閉じた
- serial controller factory を SerialControllerOutputPortFactory へ改名し、旧名 alias を残さない形にした
- nyxpy run に --controller swbt と swbt override option を追加した
- nyxpy swbt pair / reconnect / disconnect を追加した
- dummy swbt session を使う runtime integration test を追加した
- local_024 仕様書を complete へ移動し、同期 API 前提の完了結果を記録した

## Commit Log

```text
a982c2b feat(swbt): runtimeとCLI連携を追加
```

## Testing

```text
uv run ruff format .
uv run ruff check .
uv run ty check src/nyxpy --output-format concise --no-progress
uv run pytest tests/unit/cli/test_run_cli_parser.py tests/unit/cli/test_swbt_cli.py tests/unit/cli/test_main.py tests/unit/framework/runtime/test_runtime_builder.py tests/unit/framework/io/test_controller_config.py tests/unit/framework/io/test_device_factories.py tests/integration/test_swbt_runtime_cli_integration.py tests/integration/test_capture_source_runtime.py tests/integration/test_cli_runtime_adapter.py -m "not realdevice and not swbt"
uv run pytest tests/unit -m "not realdevice and not swbt"
uv run pytest tests/integration -m "not realdevice and not swbt"
git diff --cached --check
```

## Checklist

- [x] lint / format チェック通過
- [x] 既存テスト通過
- [x] コミット prefix (feat/fix 等) が変更の動機と一致している
- [x] 新規・変更コードに対するテスト追加（該当する場合）
- [x] 型チェック通過

## Review Notes

swbt backend では serial protocol 生成を呼ばない。serial backend の protocol / baud 既存挙動は serial config の解決時だけ維持している。
