### PR TITLE
fix(gui): コントローラー設定と接続メニューを改善

### DIFF
--- a/src/nyxpy/framework/core/hardware/swbt/errors.py
+++ b/src/nyxpy/framework/core/hardware/swbt/errors.py
@@ -2,6 +2,38 @@
 
 from nyxpy.framework.core.macro.exceptions import ConfigurationError, DeviceError
 
+_CONNECT_CANCELLED_CODES = frozenset({"NYX_SWBT_PAIR_CANCELLED", "NYX_SWBT_RECONNECT_CANCELLED"})
+
+
+def is_swbt_connect_cancelled(error: BaseException) -> bool:
+    """Nested ExceptionGroup を含む接続操作の cancellation を識別する。"""
+    if getattr(error, "code", None) in _CONNECT_CANCELLED_CODES:
+        return True
+    if isinstance(error, BaseExceptionGroup):
+        return any(is_swbt_connect_cancelled(nested) for nested in error.exceptions)
+    return False
+
+
+def swbt_connect_cancel_code(error: BaseException) -> str | None:
+    """Nested ExceptionGroup から接続キャンセルcodeを返す。"""
+    code = getattr(error, "code", None)
+    if code in _CONNECT_CANCELLED_CODES:
+        return str(code)
+    if isinstance(error, BaseExceptionGroup):
+        for nested in error.exceptions:
+            nested_code = swbt_connect_cancel_code(nested)
+            if nested_code is not None:
+                return nested_code
+    return None
+
+
+def is_swbt_pair_cancelled(error: BaseException) -> bool:
+    """Pair cancellation の後方互換 helper。"""
+    return getattr(error, "code", None) == "NYX_SWBT_PAIR_CANCELLED" or (
+        isinstance(error, BaseExceptionGroup)
+        and any(is_swbt_pair_cancelled(nested) for nested in error.exceptions)
+    )
+
 
 def adapter_discovery_failed(exc: BaseException) -> ConfigurationError:
     """Adapter discovery 失敗を NyX の設定エラーへ変換する。"""

--- a/src/nyxpy/framework/core/hardware/swbt/factory.py
+++ b/src/nyxpy/framework/core/hardware/swbt/factory.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
-from threading import RLock
+from threading import Event, RLock
 
 from nyxpy.framework.core.hardware.swbt.config import SwbtControllerConfig, SwbtControllerType
 from nyxpy.framework.core.hardware.swbt.controller import SwbtControllerOutputPort
@@ -95,7 +95,13 @@ class SwbtControllerOutputPortFactory:
                 self._dummy_session_keys.add(key)
             return self._activate_port(key, session, config)
 
-    def pair(self, config: SwbtControllerConfig, *, timeout_sec: float | None = None) -> None:
+    def pair(
+        self,
+        config: SwbtControllerConfig,
+        *,
+        timeout_sec: float | None = None,
+        cancellation_event: Event | None = None,
+    ) -> None:
         """明示 pairing を実行する。dummy fallback はしない。"""
         with self._lock:
             key = session_key(config)
@@ -104,7 +110,14 @@ class SwbtControllerOutputPortFactory:
             session = self._session_for(config)
             try:
                 session.open()
-                session.pair(timeout_sec=timeout_sec or config.connect_timeout_sec)
+                effective_timeout = timeout_sec or config.connect_timeout_sec
+                if cancellation_event is None:
+                    session.pair(timeout_sec=effective_timeout)
+                else:
+                    session.pair(
+                        timeout_sec=effective_timeout,
+                        cancellation_event=cancellation_event,
+                    )
             except (ConfigurationError, DeviceError) as primary_error:
                 self._discard_failed_session(
                     key,
@@ -114,7 +127,13 @@ class SwbtControllerOutputPortFactory:
                 )
                 raise
 
-    def reconnect(self, config: SwbtControllerConfig, *, timeout_sec: float | None = None) -> None:
+    def reconnect(
+        self,
+        config: SwbtControllerConfig,
+        *,
+        timeout_sec: float | None = None,
+        cancellation_event: Event | None = None,
+    ) -> None:
         """明示 reconnect を実行する。dummy fallback はしない。"""
         with self._lock:
             key = session_key(config)
@@ -123,7 +142,14 @@ class SwbtControllerOutputPortFactory:
             session = self._session_for(config)
             try:
                 session.open()
-                session.reconnect(timeout_sec=timeout_sec or config.connect_timeout_sec)
+                effective_timeout = timeout_sec or config.connect_timeout_sec
+                if cancellation_event is None:
+                    session.reconnect(timeout_sec=effective_timeout)
+                else:
+                    session.reconnect(
+                        timeout_sec=effective_timeout,
+                        cancellation_event=cancellation_event,
+                    )
             except (ConfigurationError, DeviceError) as primary_error:
                 self._discard_failed_session(
                     key,

--- a/src/nyxpy/framework/core/hardware/swbt/session.py
+++ b/src/nyxpy/framework/core/hardware/swbt/session.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import inspect
+import time
 from collections.abc import Awaitable, Callable
 from concurrent.futures import TimeoutError as FutureTimeoutError
 from dataclasses import dataclass, field
@@ -30,9 +31,9 @@ class SwbtControllerSessionProtocol(Protocol):
 
     def open(self) -> None: ...
 
-    def pair(self, *, timeout_sec: float) -> None: ...
+    def pair(self, *, timeout_sec: float, cancellation_event: Event | None = None) -> None: ...
 
-    def reconnect(self, *, timeout_sec: float) -> None: ...
+    def reconnect(self, *, timeout_sec: float, cancellation_event: Event | None = None) -> None: ...
 
     def apply(self, state: object) -> None: ...
 
@@ -126,7 +127,7 @@ class SwbtControllerSession:
             self._opened = True
             self._closed = False
 
-    def pair(self, *, timeout_sec: float) -> None:
+    def pair(self, *, timeout_sec: float, cancellation_event: Event | None = None) -> None:
         """明示 pairing を実行する。"""
         with self._lock:
             self.open()
@@ -137,6 +138,8 @@ class SwbtControllerSession:
                     "pair",
                     timeout=timeout_sec,
                     _wait_timeout_sec=self._connection_wait_timeout(timeout_sec),
+                    _cancellation_event=cancellation_event,
+                    _cancellation_code="NYX_SWBT_PAIR_CANCELLED",
                 )
                 status = self._call_controller(controller, "status")
             except (ConfigurationError, DeviceError):
@@ -147,7 +150,7 @@ class SwbtControllerSession:
             if not self._connected:
                 raise swbt_not_connected(type(self).__name__)
 
-    def reconnect(self, *, timeout_sec: float) -> None:
+    def reconnect(self, *, timeout_sec: float, cancellation_event: Event | None = None) -> None:
         """保存済み pairing key に基づく reconnect を実行する。"""
         with self._lock:
             self.open()
@@ -158,6 +161,8 @@ class SwbtControllerSession:
                     "reconnect",
                     timeout=timeout_sec,
                     _wait_timeout_sec=self._connection_wait_timeout(timeout_sec),
+                    _cancellation_event=cancellation_event,
+                    _cancellation_code="NYX_SWBT_RECONNECT_CANCELLED",
                 )
                 status = self._call_controller(controller, "status")
             except (ConfigurationError, DeviceError):
@@ -259,6 +264,8 @@ class SwbtControllerSession:
         method_name: str,
         *args,
         _wait_timeout_sec: float | None = None,
+        _cancellation_event: Event | None = None,
+        _cancellation_code: str = "NYX_SWBT_OPERATION_CANCELLED",
         **kwargs,
     ) -> object:
         if self._loop_stopping:
@@ -273,10 +280,19 @@ class SwbtControllerSession:
             return self._run_awaitable(
                 result,
                 timeout_sec=_wait_timeout_sec or self._operation_timeout_sec,
+                cancellation_event=_cancellation_event,
+                cancellation_code=_cancellation_code,
             )
         return result
 
-    def _run_awaitable(self, awaitable: Awaitable[object], *, timeout_sec: float) -> object:
+    def _run_awaitable(
+        self,
+        awaitable: Awaitable[object],
+        *,
+        timeout_sec: float,
+        cancellation_event: Event | None = None,
+        cancellation_code: str = "NYX_SWBT_OPERATION_CANCELLED",
+    ) -> object:
         loop = self._loop
         if loop is None or not loop.is_running():
             raise swbt_configuration_error(
@@ -287,7 +303,26 @@ class SwbtControllerSession:
         completed = Event()
         future = asyncio.run_coroutine_threadsafe(_await_result(awaitable, completed), loop)
         try:
-            return future.result(timeout=timeout_sec)
+            if cancellation_event is None:
+                return future.result(timeout=timeout_sec)
+            deadline = time.monotonic() + timeout_sec
+            while True:
+                if cancellation_event.is_set():
+                    future.cancel()
+                    completed.wait(timeout=self._cancellation_timeout_sec)
+                    raise DeviceError(
+                        "swbt connection operation was cancelled",
+                        code=cancellation_code,
+                        component=type(self).__name__,
+                        recoverable=True,
+                    )
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    return future.result(timeout=0)
+                try:
+                    return future.result(timeout=min(0.05, remaining))
+                except FutureTimeoutError:
+                    continue
         except FutureTimeoutError:
             future.cancel()
             if not completed.wait(timeout=self._cancellation_timeout_sec):
@@ -413,13 +448,13 @@ class DummySwbtControllerSession:
         self.opened = True
         self.closed = False
 
-    def pair(self, *, timeout_sec: float) -> None:
+    def pair(self, *, timeout_sec: float, cancellation_event: Event | None = None) -> None:
         """Dummy pairing を記録する。"""
         self.open()
         self.pair_calls += 1
         self.connected = True
 
-    def reconnect(self, *, timeout_sec: float) -> None:
+    def reconnect(self, *, timeout_sec: float, cancellation_event: Event | None = None) -> None:
         """Dummy reconnect を記録する。"""
         self.open()
         self.reconnect_calls += 1

--- a/src/nyxpy/gui/app_services.py
+++ b/src/nyxpy/gui/app_services.py
@@ -6,6 +6,7 @@ from collections.abc import Mapping
 from copy import deepcopy
 from dataclasses import dataclass, replace
 from pathlib import Path
+from threading import Event
 from typing import Any
 
 from nyxpy.framework.core.hardware.capture_source import WindowCaptureSourceConfig
@@ -388,13 +389,22 @@ class GuiAppServices:
     def pair_swbt_prepared(
         self,
         config: SwbtControllerConfig,
+        *,
+        cancellation_event: Event | None = None,
     ) -> SwbtControllerStatusView:
         """列挙済みcanonical configでpairingを1回だけ実行する。"""
         try:
-            self.swbt_controller_factory.pair(
-                config,
-                timeout_sec=config.connect_timeout_sec,
-            )
+            if cancellation_event is None:
+                self.swbt_controller_factory.pair(
+                    config,
+                    timeout_sec=config.connect_timeout_sec,
+                )
+            else:
+                self.swbt_controller_factory.pair(
+                    config,
+                    timeout_sec=config.connect_timeout_sec,
+                    cancellation_event=cancellation_event,
+                )
             view = self._connected_swbt_status(config, operation="pair")
         except Exception:
             self._active_swbt_config = None
@@ -409,13 +419,22 @@ class GuiAppServices:
     def reconnect_swbt_prepared(
         self,
         config: SwbtControllerConfig,
+        *,
+        cancellation_event: Event | None = None,
     ) -> SwbtControllerStatusView:
         """列挙済みcanonical configでreconnectを1回だけ実行する。"""
         try:
-            self.swbt_controller_factory.reconnect(
-                config,
-                timeout_sec=config.connect_timeout_sec,
-            )
+            if cancellation_event is None:
+                self.swbt_controller_factory.reconnect(
+                    config,
+                    timeout_sec=config.connect_timeout_sec,
+                )
+            else:
+                self.swbt_controller_factory.reconnect(
+                    config,
+                    timeout_sec=config.connect_timeout_sec,
+                    cancellation_event=cancellation_event,
+                )
             view = self._connected_swbt_status(config, operation="reconnect")
         except Exception:
             self._active_swbt_config = None

--- a/src/nyxpy/gui/dialogs/settings/device_tab.py
+++ b/src/nyxpy/gui/dialogs/settings/device_tab.py
@@ -177,16 +177,16 @@ class DeviceSettingsTab(QWidget):
         controller_form = QFormLayout()
 
         self.controller_backend = QComboBox()
-        self.controller_backend.addItem("Serial", "serial")
+        self.controller_backend.addItem("serial", "serial")
         self.controller_backend.addItem("swbt", "swbt")
         self._set_controller_backend(self.settings.get("controller.backend", "serial"))
         self.controller_backend.currentIndexChanged.connect(
             lambda _index: self._update_controller_field_state()
         )
-        controller_form.addRow(QLabel("Backend:"), self.controller_backend)
+        controller_form.addRow(QLabel("方式:"), self.controller_backend)
         controller_group_layout.addLayout(controller_form)
 
-        self.ser_group = QGroupBox("Serial")
+        self.ser_group = QGroupBox("serial")
         ser_group = self.ser_group
         ser_group_layout = QVBoxLayout(ser_group)
         ser_form = QFormLayout()
@@ -199,7 +199,7 @@ class DeviceSettingsTab(QWidget):
         refresh_ser_btn.clicked.connect(self.refresh_serial_devices)
         ser_row.addWidget(self.ser_device)
         ser_row.addWidget(refresh_ser_btn)
-        ser_form.addRow(QLabel("Device:"), ser_row)
+        ser_form.addRow(QLabel("デバイス:"), ser_row)
 
         self.ser_protocol = QComboBox()
         protocol_options = ProtocolFactory.get_protocol_names()
@@ -227,8 +227,8 @@ class DeviceSettingsTab(QWidget):
             self.ser_baud.setCurrentText(current_baud)
         else:
             self.ser_baud.setCurrentText("9600")
-        ser_form.addRow(QLabel("Protocol:"), self.ser_protocol)
-        ser_form.addRow(QLabel("Baud Rate:"), self.ser_baud)
+        ser_form.addRow(QLabel("プロトコル:"), self.ser_protocol)
+        ser_form.addRow(QLabel("ボーレート:"), self.ser_baud)
         ser_group_layout.addLayout(ser_form)
         controller_group_layout.addWidget(ser_group)
 
@@ -243,7 +243,6 @@ class DeviceSettingsTab(QWidget):
             self.swbt_controller_type,
             self.settings.get("controller.swbt.controller_type", "pro-controller"),
         )
-        swbt_form.addRow(QLabel("Controller:"), self.swbt_controller_type)
 
         adapter_row = QHBoxLayout()
         self.swbt_adapter = QComboBox()
@@ -259,7 +258,8 @@ class DeviceSettingsTab(QWidget):
         self.refresh_swbt_btn.clicked.connect(self.refresh_swbt_adapters)
         adapter_row.addWidget(self.swbt_adapter)
         adapter_row.addWidget(self.refresh_swbt_btn)
-        swbt_form.addRow(QLabel("Adapter:"), adapter_row)
+        swbt_form.addRow(QLabel("デバイス:"), adapter_row)
+        swbt_form.addRow(QLabel("タイプ:"), self.swbt_controller_type)
 
         self.swbt_key_store = QComboBox()
         self.swbt_key_store.setEditable(True)
@@ -270,7 +270,7 @@ class DeviceSettingsTab(QWidget):
         self.swbt_controller_type.currentIndexChanged.connect(
             self._update_swbt_key_store_for_controller
         )
-        swbt_form.addRow(QLabel("Key Store:"), self.swbt_key_store)
+        swbt_form.addRow(QLabel("キーストア:"), self.swbt_key_store)
 
         lifecycle_row = QHBoxLayout()
         self.swbt_pair_btn = QPushButton("Pair")
@@ -282,10 +282,10 @@ class DeviceSettingsTab(QWidget):
         lifecycle_row.addWidget(self.swbt_pair_btn)
         lifecycle_row.addWidget(self.swbt_reconnect_btn)
         lifecycle_row.addWidget(self.swbt_disconnect_btn)
-        swbt_form.addRow(QLabel("Connection:"), lifecycle_row)
+        swbt_form.addRow(QLabel("接続:"), lifecycle_row)
 
         self.swbt_status_label = QLabel("disconnected")
-        swbt_form.addRow(QLabel("Status:"), self.swbt_status_label)
+        swbt_form.addRow(QLabel("状態:"), self.swbt_status_label)
         swbt_group_layout.addLayout(swbt_form)
         controller_group_layout.addWidget(self.swbt_group)
         layout.addWidget(self.controller_group)

--- a/src/nyxpy/gui/dialogs/settings/device_tab.py
+++ b/src/nyxpy/gui/dialogs/settings/device_tab.py
@@ -1,6 +1,7 @@
 """Device 設定 tab。"""
 
 from collections.abc import Callable
+from pathlib import Path
 
 from PySide6.QtWidgets import (
     QCheckBox,
@@ -19,6 +20,10 @@ from nyxpy.framework.core.hardware.device_discovery import DeviceDiscoveryServic
 from nyxpy.framework.core.hardware.protocol_factory import ProtocolFactory
 from nyxpy.framework.core.hardware.swbt.config import supported_controller_models
 from nyxpy.framework.core.hardware.swbt.discovery import SwbtAdapterView
+from nyxpy.framework.core.hardware.swbt.errors import (
+    is_swbt_connect_cancelled,
+    swbt_connect_cancel_code,
+)
 from nyxpy.framework.core.settings.global_settings import GlobalSettings
 from nyxpy.framework.core.settings.secrets_settings import SecretsSettings
 from nyxpy.gui.background_task import BackgroundTask
@@ -33,7 +38,7 @@ _CAPTURE_SOURCE_OPTION = ("キャプチャ", "capture")
 
 type SwbtLifecycleAction = Callable[
     [Callable[[object], None], Callable[[BaseException], None]],
-    None,
+    Callable[[], None] | None,
 ]
 
 
@@ -68,6 +73,8 @@ class DeviceSettingsTab(QWidget):
         self.swbt_actions_enabled = bool(swbt_actions_enabled)
         self._swbt_busy = False
         self._swbt_connected = False
+        self._cancel_swbt_connect: Callable[[], None] | None = None
+        self._swbt_connect_operation: str | None = None
         self._background_tasks: set[BackgroundTask] = set()
         self.ponkan_capture_available = (
             is_ponkan_capture_available()
@@ -257,9 +264,12 @@ class DeviceSettingsTab(QWidget):
         self.swbt_key_store = QComboBox()
         self.swbt_key_store.setEditable(True)
         current_key_store = str(self.settings.get("controller.swbt.key_store_path", "") or "")
-        if current_key_store:
-            self.swbt_key_store.addItem(current_key_store, current_key_store)
-            self.swbt_key_store.setCurrentText(current_key_store)
+        for key_store_path in self._swbt_key_store_candidates(current_key_store):
+            self.swbt_key_store.addItem(key_store_path, key_store_path)
+        self.swbt_key_store.setCurrentText(current_key_store or self._default_swbt_key_store_path())
+        self.swbt_controller_type.currentIndexChanged.connect(
+            self._update_swbt_key_store_for_controller
+        )
         swbt_form.addRow(QLabel("Key Store:"), self.swbt_key_store)
 
         lifecycle_row = QHBoxLayout()
@@ -459,6 +469,35 @@ class DeviceSettingsTab(QWidget):
         swbt_key_store = self.swbt_key_store.currentText().strip()
         self.settings.set("controller.swbt.key_store_path", swbt_key_store or None)
 
+    def _swbt_key_store_candidates(self, current: str) -> tuple[str, ...]:
+        candidates = [
+            str(model.default_key_store_path()).replace("\\", "/")
+            for model in supported_controller_models()
+        ]
+        config_dir = getattr(self.settings, "config_dir", None)
+        if config_dir is not None:
+            for path in sorted((Path(config_dir) / "swbt").glob("*.json")):
+                candidates.append(f".nyxpy/swbt/{path.name}")
+        if current:
+            candidates.append(current)
+        return tuple(dict.fromkeys(candidates))
+
+    def _default_swbt_key_store_path(self) -> str:
+        controller_type = self.swbt_controller_type.currentData()
+        for model in supported_controller_models():
+            if model.settings_value == controller_type:
+                return str(model.default_key_store_path()).replace("\\", "/")
+        return ""
+
+    def _update_swbt_key_store_for_controller(self) -> None:
+        current = self.swbt_key_store.currentText().strip()
+        defaults = {
+            str(model.default_key_store_path()).replace("\\", "/")
+            for model in supported_controller_models()
+        }
+        if not current or current in defaults:
+            self.swbt_key_store.setCurrentText(self._default_swbt_key_store_path())
+
     def _capture_source_type(self) -> str:
         value = self.capture_source_type.currentData()
         return str(value or "camera")
@@ -503,12 +542,23 @@ class DeviceSettingsTab(QWidget):
         is_swbt = self._controller_backend() == "swbt"
         settings_enabled = self.swbt_actions_enabled and not self._swbt_busy
         self.controller_backend.setEnabled(self.swbt_actions_enabled and not self._swbt_busy)
-        self.ser_group.setEnabled(not is_swbt and settings_enabled)
-        self.swbt_group.setEnabled(is_swbt and settings_enabled)
+        self.ser_group.setVisible(not is_swbt)
+        self.ser_group.setEnabled(settings_enabled)
+        self.swbt_group.setVisible(is_swbt)
+        self.swbt_group.setEnabled(self.swbt_actions_enabled)
+        self.swbt_controller_type.setEnabled(settings_enabled)
+        self.swbt_adapter.setEnabled(settings_enabled)
+        self.swbt_key_store.setEnabled(settings_enabled)
         adapter_selected = bool(_editable_combo_value(self.swbt_adapter))
         connect_enabled = is_swbt and settings_enabled and adapter_selected
-        self.swbt_pair_btn.setEnabled(connect_enabled)
-        self.swbt_reconnect_btn.setEnabled(connect_enabled)
+        cancelling_pair = (
+            self._cancel_swbt_connect is not None and self._swbt_connect_operation == "pair"
+        )
+        cancelling_reconnect = (
+            self._cancel_swbt_connect is not None and self._swbt_connect_operation == "reconnect"
+        )
+        self.swbt_pair_btn.setEnabled(cancelling_pair or connect_enabled)
+        self.swbt_reconnect_btn.setEnabled(cancelling_reconnect or connect_enabled)
         self.swbt_disconnect_btn.setEnabled(is_swbt and settings_enabled and self._swbt_connected)
         self.refresh_swbt_btn.setEnabled(is_swbt and settings_enabled)
 
@@ -523,11 +573,30 @@ class DeviceSettingsTab(QWidget):
 
     def _pair_swbt(self) -> None:
         self._save_swbt_settings(select_backend=True)
-        self._run_swbt_lifecycle(self.swbt_pair)
+        self._start_or_cancel_swbt_connect("pair", self.swbt_pair)
 
     def _reconnect_swbt(self) -> None:
         self._save_swbt_settings(select_backend=True)
-        self._run_swbt_lifecycle(self.swbt_reconnect)
+        self._start_or_cancel_swbt_connect("reconnect", self.swbt_reconnect)
+
+    def _start_or_cancel_swbt_connect(
+        self,
+        operation: str,
+        action: SwbtLifecycleAction | None,
+    ) -> None:
+        if self._cancel_swbt_connect is not None and self._swbt_connect_operation == operation:
+            self._cancel_swbt_connect()
+            self._cancel_swbt_connect = None
+            button = self.swbt_pair_btn if operation == "pair" else self.swbt_reconnect_btn
+            button.setText("Cancelling...")
+            button.setEnabled(False)
+            self.swbt_status_label.setText(
+                "pairing をキャンセル中..."
+                if operation == "pair"
+                else "reconnect をキャンセル中..."
+            )
+            return
+        self._run_swbt_lifecycle(action, connect_operation=operation)
 
     def _disconnect_swbt(self) -> None:
         self._run_swbt_lifecycle(self.swbt_disconnect, disconnect=True)
@@ -537,6 +606,7 @@ class DeviceSettingsTab(QWidget):
         action: SwbtLifecycleAction | None,
         *,
         disconnect: bool = False,
+        connect_operation: str | None = None,
     ) -> None:
         if action is None:
             self.swbt_status_label.setText("swbt lifecycle is unavailable")
@@ -554,21 +624,48 @@ class DeviceSettingsTab(QWidget):
             else:
                 self._set_swbt_status(status)
             self._swbt_lifecycle_running = False
+            self._reset_swbt_connect_action()
             self._set_swbt_busy(False)
 
         def failed(error: BaseException) -> None:
             if not isValid(self):
                 return
             self._swbt_connected = False
-            operation = "disconnect" if disconnect else "connection"
-            self.swbt_status_label.setText(f"{operation} failed: {error}")
+            if connect_operation is not None and is_swbt_connect_cancelled(error):
+                self.swbt_status_label.setText(
+                    "再接続をキャンセルしました"
+                    if swbt_connect_cancel_code(error) == "NYX_SWBT_RECONNECT_CANCELLED"
+                    else "ペアリングをキャンセルしました"
+                )
+            else:
+                operation = "disconnect" if disconnect else "connection"
+                self.swbt_status_label.setText(f"{operation} failed: {error}")
             self._swbt_lifecycle_running = False
+            self._reset_swbt_connect_action()
             self._set_swbt_busy(False)
 
         try:
-            action(succeeded, failed)
+            cancel = action(succeeded, failed)
+            if (
+                connect_operation is not None
+                and self._swbt_lifecycle_running
+                and cancel is not None
+            ):
+                self._cancel_swbt_connect = cancel
+                self._swbt_connect_operation = connect_operation
+                button = (
+                    self.swbt_pair_btn if connect_operation == "pair" else self.swbt_reconnect_btn
+                )
+                button.setText("Cancel")
+                self._update_controller_field_state()
         except Exception as exc:
             failed(exc)
+
+    def _reset_swbt_connect_action(self) -> None:
+        self._cancel_swbt_connect = None
+        self._swbt_connect_operation = None
+        self.swbt_pair_btn.setText("Pair")
+        self.swbt_reconnect_btn.setText("Reconnect")
 
     def _refresh_swbt_status(self) -> None:
         if self.swbt_status is None:

--- a/src/nyxpy/gui/main_window.py
+++ b/src/nyxpy/gui/main_window.py
@@ -2,6 +2,7 @@
 
 from dataclasses import dataclass
 from pathlib import Path
+from threading import Event
 
 from PySide6.QtCore import Qt, QTimer
 from PySide6.QtGui import QAction, QActionGroup
@@ -27,6 +28,10 @@ from nyxpy.framework.core.hardware.device_discovery import (
     WindowDiscoveryResult,
 )
 from nyxpy.framework.core.hardware.protocol_factory import ProtocolFactory
+from nyxpy.framework.core.hardware.swbt.errors import (
+    is_swbt_connect_cancelled,
+    swbt_connect_cancel_code,
+)
 from nyxpy.framework.core.hardware.window_discovery import WindowInfo, resolve_window
 from nyxpy.framework.core.io.ports import ControllerOutputPort
 from nyxpy.framework.core.macro.exceptions import ConfigurationError
@@ -687,11 +692,11 @@ class MainWindow(QMainWindow):
         self._update_connection_status()
         return status
 
-    def _pair_swbt_controller_async(self, succeeded=None, failed=None) -> None:
-        self._start_swbt_connect_task("pair", succeeded, failed)
+    def _pair_swbt_controller_async(self, succeeded=None, failed=None):
+        return self._start_swbt_connect_task("pair", succeeded, failed)
 
-    def _reconnect_swbt_controller_async(self, succeeded=None, failed=None) -> None:
-        self._start_swbt_connect_task("reconnect", succeeded, failed)
+    def _reconnect_swbt_controller_async(self, succeeded=None, failed=None):
+        return self._start_swbt_connect_task("reconnect", succeeded, failed)
 
     def _disconnect_swbt_controller_async(self, succeeded=None, failed=None) -> None:
         prepared, previous = self._prepare_swbt_lifecycle(failed, operation="disconnect")
@@ -714,12 +719,17 @@ class MainWindow(QMainWindow):
         self._track_background_task(task)
         task.start()
 
-    def _start_swbt_connect_task(self, operation: str, succeeded, failed) -> None:
+    def _start_swbt_connect_task(self, operation: str, succeeded, failed):
         prepared, previous = self._prepare_swbt_lifecycle(failed, operation="connect")
         if not prepared:
-            return
+            return None
+        cancellation_event = Event()
         task = BackgroundTask(
-            lambda: self._execute_swbt_connect(operation, previous),
+            lambda: self._execute_swbt_connect(
+                operation,
+                previous,
+                cancellation_event=cancellation_event,
+            ),
             parent=self,
         )
         task.succeeded.connect(lambda result: self._finish_swbt_connect(result, succeeded, failed))
@@ -728,6 +738,7 @@ class MainWindow(QMainWindow):
         )
         self._track_background_task(task)
         task.start()
+        return cancellation_event.set
 
     def _prepare_swbt_lifecycle(
         self,
@@ -763,13 +774,19 @@ class MainWindow(QMainWindow):
         self,
         operation: str,
         previous: ControllerOutputPort | None,
+        *,
+        cancellation_event: Event | None = None,
     ) -> _SwbtLifecycleResult:
         try:
             self._close_detached_manual_controller(previous)
             canonicalize = getattr(self.services, "canonicalize_swbt_adapter", None)
             config = canonicalize() if callable(canonicalize) else None
             outcome = self.services.apply_settings(is_run_active=False)
-            status = self._call_swbt_lifecycle(operation, config)
+            status = self._call_swbt_lifecycle(
+                operation,
+                config,
+                cancellation_event=cancellation_event,
+            )
             builder = self.services.create_runtime_builder()
             manual_controller = builder.controller_output_for_manual_input()
             if manual_controller is None:
@@ -785,9 +802,17 @@ class MainWindow(QMainWindow):
                 ) from exc
             raise
 
-    def _call_swbt_lifecycle(self, operation: str, config: object | None) -> object:
+    def _call_swbt_lifecycle(
+        self,
+        operation: str,
+        config: object | None,
+        *,
+        cancellation_event: Event | None = None,
+    ) -> object:
         prepared = getattr(self.services, f"{operation}_swbt_prepared", None)
         if callable(prepared) and config is not None:
+            if operation in {"pair", "reconnect"}:
+                return prepared(config, cancellation_event=cancellation_event)
             return prepared(config)
         return getattr(self.services, f"{operation}_swbt")()
 
@@ -854,6 +879,21 @@ class MainWindow(QMainWindow):
         self._notify_async_callback(succeeded, None)
 
     def _fail_swbt_lifecycle(self, error: BaseException, failed, *, operation: str) -> None:
+        if operation == "connect" and is_swbt_connect_cancelled(error):
+            self.manual_controller_error = None
+            self.virtual_controller.model.set_controller(None)
+            self._swbt_lifecycle_busy = False
+            error_code = swbt_connect_cancel_code(error)
+            self.status_label.setText(
+                "swbt 再接続をキャンセルしました"
+                if error_code == "NYX_SWBT_RECONNECT_CANCELLED"
+                else "swbt ペアリングをキャンセルしました"
+            )
+            self._sync_manual_input_state()
+            self._update_connection_status()
+            self._refresh_connection_menu()
+            self._notify_async_callback(failed, error)
+            return
         self.manual_controller_error = error
         self.virtual_controller.model.set_controller(None)
         self._swbt_lifecycle_busy = False
@@ -1520,9 +1560,7 @@ class MainWindow(QMainWindow):
         self._manual_controller_restoring = False
         self._manual_controller_restore_backend = None
         if not isinstance(controller, ControllerOutputPort):
-            self._fail_manual_controller_restore(
-                RuntimeError("manual controller was not created")
-            )
+            self._fail_manual_controller_restore(RuntimeError("manual controller was not created"))
             return
         stale = (
             restore_backend != self.global_settings.get("controller.backend", "serial")

--- a/src/nyxpy/gui/main_window.py
+++ b/src/nyxpy/gui/main_window.py
@@ -28,6 +28,8 @@ from nyxpy.framework.core.hardware.device_discovery import (
     WindowDiscoveryResult,
 )
 from nyxpy.framework.core.hardware.protocol_factory import ProtocolFactory
+from nyxpy.framework.core.hardware.swbt.config import supported_controller_models
+from nyxpy.framework.core.hardware.swbt.discovery import SwbtAdapterView
 from nyxpy.framework.core.hardware.swbt.errors import (
     is_swbt_connect_cancelled,
     swbt_connect_cancel_code,
@@ -191,6 +193,8 @@ class MainWindow(QMainWindow):
         self._manual_controller_restore_backend: str | None = None
         self._close_pending = False
         self._background_tasks: set[BackgroundTask] = set()
+        self._swbt_adapter_views: tuple[SwbtAdapterView, ...] = ()
+        self._swbt_adapter_refreshing = False
         self.window_size_actions: dict[str, QAction] = {}
         self.window_size_action_group: QActionGroup | None = None
         self.connection_menu: QMenu | None = None
@@ -198,6 +202,8 @@ class MainWindow(QMainWindow):
         self.capture_input_menu: QMenu | None = None
         self.serial_device_menu: QMenu | None = None
         self.protocol_menu: QMenu | None = None
+        self.swbt_device_menu: QMenu | None = None
+        self.swbt_type_menu: QMenu | None = None
         self.capture_source_type_menu: QMenu | None = None
         self.camera_source_menu: QMenu | None = None
         self.window_source_menu: QMenu | None = None
@@ -208,6 +214,7 @@ class MainWindow(QMainWindow):
         self.capture_fps_menu: QMenu | None = None
         self.serial_baud_menu: QMenu | None = None
         self.capture_device_action_group: QActionGroup | None = None
+        self.window_source_action_group: QActionGroup | None = None
         self.capture_profile_action_group: QActionGroup | None = None
         self.ponkan_backend_action_group: QActionGroup | None = None
         self.capture_fps_action_group: QActionGroup | None = None
@@ -215,6 +222,8 @@ class MainWindow(QMainWindow):
         self.serial_device_action_group: QActionGroup | None = None
         self.serial_baud_action_group: QActionGroup | None = None
         self.protocol_action_group: QActionGroup | None = None
+        self.swbt_device_action_group: QActionGroup | None = None
+        self.swbt_type_action_group: QActionGroup | None = None
         self.current_window_size_preset_key = normalize_window_size_preset_key(
             self.global_settings.get(
                 "gui.window_size_preset",
@@ -240,8 +249,6 @@ class MainWindow(QMainWindow):
         self.connection_menu = self.menuBar().addMenu("接続")
         self.capture_input_menu = self.connection_menu.addMenu("キャプチャ入力")
         self.controller_backend_menu = self.connection_menu.addMenu("コントローラー")
-        self.serial_device_menu = self.connection_menu.addMenu("シリアルデバイス")
-        self.protocol_menu = self.connection_menu.addMenu("プロトコル")
         self.connection_menu.aboutToShow.connect(
             lambda: self._refresh_connection_menu(refresh_discovery=True)
         )
@@ -277,16 +284,12 @@ class MainWindow(QMainWindow):
                 windows,
             )
         if self.controller_backend_menu is not None:
-            self._populate_controller_backend_menu(self.controller_backend_menu)
-        if self.serial_device_menu is not None:
-            self._populate_serial_device_menu(self.serial_device_menu, snapshot.serial_devices)
-        if self.protocol_menu is not None:
-            self._populate_protocol_menu(self.protocol_menu)
-        is_serial = self.global_settings.get("controller.backend", "serial") == "serial"
-        if self.serial_device_menu is not None:
-            self.serial_device_menu.setEnabled(is_serial)
-        if self.protocol_menu is not None:
-            self.protocol_menu.setEnabled(is_serial)
+            self._populate_controller_backend_menu(
+                self.controller_backend_menu,
+                snapshot.serial_devices,
+            )
+        if refresh_discovery and self.global_settings.get("controller.backend", "serial") == "swbt":
+            self._refresh_swbt_adapters_async()
 
     def _ponkan_capture_available(self) -> bool:
         value = getattr(self.services, "ponkan_capture_available", False)
@@ -294,13 +297,19 @@ class MainWindow(QMainWindow):
             return bool(value())
         return bool(value)
 
-    def _populate_controller_backend_menu(self, menu: QMenu) -> None:
+    def _populate_controller_backend_menu(
+        self,
+        menu: QMenu,
+        serial_devices: tuple[DeviceInfo, ...],
+    ) -> None:
+        self._dispose_controller_submenus()
         menu.clear()
-        self.controller_backend_action_group = QActionGroup(self)
+        if self.controller_backend_action_group is None:
+            self.controller_backend_action_group = QActionGroup(menu)
         self.controller_backend_action_group.setExclusive(True)
         current = str(self.global_settings.get("controller.backend", "serial") or "serial")
-        for label, backend in (("Serial", "serial"), ("swbt", "swbt")):
-            action = QAction(label, self)
+        for label, backend in (("serial", "serial"), ("swbt", "swbt")):
+            action = QAction(label, menu)
             action.setCheckable(True)
             action.setData(backend)
             action.setChecked(current == backend)
@@ -317,18 +326,37 @@ class MainWindow(QMainWindow):
             self.controller_backend_action_group.addAction(action)
             menu.addAction(action)
         menu.addSeparator()
-        adapter_selected = bool(self.global_settings.get("controller.swbt.adapter"))
+        self.serial_device_menu = None
+        self.protocol_menu = None
+        self.serial_baud_menu = None
+        self.swbt_device_menu = None
+        self.swbt_type_menu = None
+        if current == "serial":
+            self.serial_device_menu = menu.addMenu("デバイス")
+            self._populate_serial_device_menu(self.serial_device_menu, serial_devices)
+            self.protocol_menu = menu.addMenu("プロトコル")
+            self._populate_protocol_menu(self.protocol_menu)
+            self.serial_baud_menu = menu.addMenu("ボーレート")
+            self._populate_serial_baud_menu(self.serial_baud_menu)
+            return
+
+        adapters = self._swbt_adapter_views
+        self.swbt_device_menu = menu.addMenu("デバイス")
+        adapter_available = self._populate_swbt_device_menu(self.swbt_device_menu, adapters)
+        self.swbt_type_menu = menu.addMenu("タイプ")
+        self._populate_swbt_type_menu(self.swbt_type_menu)
+        menu.addSeparator()
         lifecycle_enabled = (
             current == "swbt"
             and not self._is_run_active()
             and not self._swbt_lifecycle_busy
             and not self._manual_controller_restoring
         )
-        pair_action = QAction("Pair", self)
-        reconnect_action = QAction("Reconnect", self)
-        disconnect_action = QAction("Disconnect", self)
-        pair_action.setEnabled(lifecycle_enabled and adapter_selected)
-        reconnect_action.setEnabled(lifecycle_enabled and adapter_selected)
+        pair_action = QAction("Pair", menu)
+        reconnect_action = QAction("Reconnect", menu)
+        disconnect_action = QAction("Disconnect", menu)
+        pair_action.setEnabled(lifecycle_enabled and adapter_available)
+        reconnect_action.setEnabled(lifecycle_enabled and adapter_available)
         disconnect_action.setEnabled(lifecycle_enabled and self._swbt_is_connected())
         pair_action.triggered.connect(lambda _checked=False: self._invoke_swbt_action("pair"))
         reconnect_action.triggered.connect(
@@ -341,17 +369,154 @@ class MainWindow(QMainWindow):
         menu.addAction(reconnect_action)
         menu.addAction(disconnect_action)
 
+    def _dispose_controller_submenus(self) -> None:
+        for name in (
+            "serial_device_menu",
+            "protocol_menu",
+            "serial_baud_menu",
+            "swbt_device_menu",
+            "swbt_type_menu",
+        ):
+            submenu = getattr(self, name)
+            if submenu is not None:
+                submenu.deleteLater()
+                setattr(self, name, None)
+        self.serial_device_action_group = None
+        self.serial_baud_action_group = None
+        self.protocol_action_group = None
+        self.swbt_device_action_group = None
+        self.swbt_type_action_group = None
+
+    def _refresh_swbt_adapters_async(self) -> None:
+        if self._swbt_adapter_refreshing:
+            return
+        self._swbt_adapter_refreshing = True
+        self._refresh_connection_menu()
+        task = BackgroundTask(self.services.refresh_swbt_adapters, parent=self)
+        task.succeeded.connect(self._finish_swbt_adapter_refresh)
+        task.failed.connect(self._fail_swbt_adapter_refresh)
+        self._track_background_task(task)
+        task.start()
+
+    def _finish_swbt_adapter_refresh(
+        self,
+        adapters: tuple[SwbtAdapterView, ...],
+    ) -> None:
+        self._swbt_adapter_views = adapters
+        self._swbt_adapter_refreshing = False
+        self._refresh_connection_menu()
+
+    def _fail_swbt_adapter_refresh(self, error: BaseException) -> None:
+        self._swbt_adapter_refreshing = False
+        self.logger.technical(
+            "WARNING",
+            "swbt adapter refresh failed while building connection menu.",
+            component="MainWindow",
+            event="swbt.adapter_refresh_failed",
+            exc=error,
+        )
+        self._refresh_connection_menu()
+
+    def _populate_swbt_device_menu(
+        self,
+        menu: QMenu,
+        adapters: tuple[SwbtAdapterView, ...],
+    ) -> bool:
+        self.swbt_device_action_group = QActionGroup(menu)
+        self.swbt_device_action_group.setExclusive(True)
+        current = str(self.global_settings.get("controller.swbt.adapter", "") or "")
+        selected = next(
+            (
+                adapter.name
+                for adapter in adapters
+                if current == adapter.name or current in adapter.aliases
+            ),
+            current,
+        )
+        adapter_available = bool(selected) and any(adapter.name == selected for adapter in adapters)
+        if current and not adapter_available:
+            missing_action = QAction(f"{current} (未検出)", menu)
+            missing_action.setCheckable(True)
+            missing_action.setChecked(True)
+            missing_action.setData(current)
+            missing_action.setEnabled(False)
+            menu.addAction(missing_action)
+        elif not adapters:
+            empty_action = QAction("利用可能な swbt デバイスなし", menu)
+            empty_action.setEnabled(False)
+            menu.addAction(empty_action)
+        for adapter in adapters:
+            action = QAction(adapter.display_name, menu)
+            action.setCheckable(True)
+            action.setData(adapter.name)
+            action.setChecked(adapter.name == selected)
+            action.triggered.connect(
+                lambda _checked=False, name=adapter.name: self._apply_connection_settings(
+                    {"controller.backend": "swbt", "controller.swbt.adapter": name}
+                )
+            )
+            self.swbt_device_action_group.addAction(action)
+            menu.addAction(action)
+        menu.addSeparator()
+        refresh_action = QAction(
+            "再検索中..." if self._swbt_adapter_refreshing else "再検索",
+            menu,
+        )
+        refresh_action.setEnabled(not self._swbt_adapter_refreshing)
+        refresh_action.triggered.connect(lambda _checked=False: self._refresh_swbt_adapters_async())
+        menu.addAction(refresh_action)
+        return adapter_available
+
+    def _populate_swbt_type_menu(self, menu: QMenu) -> None:
+        self.swbt_type_action_group = QActionGroup(menu)
+        self.swbt_type_action_group.setExclusive(True)
+        current = str(
+            self.global_settings.get("controller.swbt.controller_type", "pro-controller")
+            or "pro-controller"
+        )
+        for model in supported_controller_models():
+            action = QAction(model.display_name, menu)
+            action.setCheckable(True)
+            action.setData(model.settings_value)
+            action.setChecked(model.settings_value == current)
+            action.triggered.connect(
+                lambda _checked=False, selected=model.settings_value: (
+                    self._apply_connection_settings(self._swbt_type_updates(selected))
+                )
+            )
+            self.swbt_type_action_group.addAction(action)
+            menu.addAction(action)
+
+    def _swbt_type_updates(self, controller_type: str) -> dict[str, SettingValue]:
+        updates: dict[str, SettingValue] = {
+            "controller.backend": "swbt",
+            "controller.swbt.controller_type": controller_type,
+        }
+        current_key_store = str(
+            self.global_settings.get("controller.swbt.key_store_path", "") or ""
+        ).replace("\\", "/")
+        models = supported_controller_models()
+        defaults = {str(model.default_key_store_path()).replace("\\", "/") for model in models}
+        if not current_key_store or current_key_store in defaults:
+            selected_model = next(
+                model for model in models if model.settings_value == controller_type
+            )
+            updates["controller.swbt.key_store_path"] = str(
+                selected_model.default_key_store_path()
+            ).replace("\\", "/")
+        return updates
+
     def _populate_capture_input_menu(
         self,
         menu: QMenu,
         devices: tuple[DeviceInfo, ...],
         windows: tuple[WindowInfo, ...],
     ) -> None:
+        self._dispose_capture_submenus()
         menu.clear()
-        self.capture_source_type_menu = QMenu("入力ソース", menu)
-        menu.addMenu(self.capture_source_type_menu)
+        self.capture_source_type_menu = None
         self._populate_capture_source_type_menu(
-            self.capture_source_type_menu,
+            menu,
             devices,
             windows,
         )
@@ -364,11 +529,11 @@ class MainWindow(QMainWindow):
             self.global_settings.get("capture_source_type", "camera") != "capture"
         )
         menu.addMenu(self.capture_fps_menu)
-        self.capture_fps_action_group = QActionGroup(self)
+        self.capture_fps_action_group = QActionGroup(self.capture_fps_menu)
         self.capture_fps_action_group.setExclusive(True)
         current_fps = self.global_settings.get("capture_fps", None)
         for label, value in _CAPTURE_FPS_OPTIONS:
-            action = QAction(label, self)
+            action = QAction(label, self.capture_fps_menu)
             action.setCheckable(True)
             action.setData(value)
             action.setChecked(_same_number_or_none(current_fps, value))
@@ -379,6 +544,27 @@ class MainWindow(QMainWindow):
             )
             self.capture_fps_action_group.addAction(action)
             self.capture_fps_menu.addAction(action)
+
+    def _dispose_capture_submenus(self) -> None:
+        for name in (
+            "capture_source_type_menu",
+            "camera_source_menu",
+            "window_source_menu",
+            "capture_source_menu",
+            "capture_provider_menu",
+            "capture_settings_menu",
+            "ponkan_backend_menu",
+            "capture_fps_menu",
+        ):
+            submenu = getattr(self, name)
+            if submenu is not None:
+                submenu.deleteLater()
+                setattr(self, name, None)
+        self.capture_device_action_group = None
+        self.window_source_action_group = None
+        self.capture_profile_action_group = None
+        self.ponkan_backend_action_group = None
+        self.capture_fps_action_group = None
 
     def _populate_capture_source_type_menu(
         self,
@@ -403,9 +589,9 @@ class MainWindow(QMainWindow):
 
     def _populate_direct_capture_source_menu(self, menu: QMenu) -> None:
         menu.clear()
-        self.capture_profile_action_group = QActionGroup(self)
+        self.capture_profile_action_group = QActionGroup(menu)
         self.capture_profile_action_group.setExclusive(True)
-        action = QAction("N3DSXL (ponkan-python)", self)
+        action = QAction("N3DSXL (ponkan-python)", menu)
         action.setCheckable(True)
         action.setData("n3dsxl")
         action.setChecked(
@@ -431,14 +617,14 @@ class MainWindow(QMainWindow):
         devices: tuple[DeviceInfo, ...],
     ) -> None:
         menu.clear()
-        self.capture_device_action_group = QActionGroup(self)
+        self.capture_device_action_group = QActionGroup(menu)
         self.capture_device_action_group.setExclusive(True)
         current = str(self.global_settings.get("capture_device", "") or "")
         selection = select_capture_target(
             ConnectionRequest(kind="capture", requested=current, allow_dummy=True),
             DeviceDiscoveryResult(capture_devices=devices),
         )
-        dummy_action = QAction(DUMMY_DEVICE_NAME, self)
+        dummy_action = QAction(DUMMY_DEVICE_NAME, menu)
         dummy_action.setCheckable(True)
         dummy_action.setData(DUMMY_DEVICE_NAME)
         dummy_action.setChecked(
@@ -451,13 +637,13 @@ class MainWindow(QMainWindow):
         )
         self.capture_device_action_group.addAction(dummy_action)
         menu.addAction(dummy_action)
-        _add_auto_dummy_status_action(menu, selection, self)
+        _add_auto_dummy_status_action(menu, selection)
         if not devices:
-            empty_action = QAction("利用可能なキャプチャ入力なし", self)
+            empty_action = QAction("利用可能なキャプチャ入力なし", menu)
             empty_action.setEnabled(False)
             menu.addAction(empty_action)
         for device in devices:
-            action = QAction(device.display_name, self)
+            action = QAction(device.display_name, menu)
             action.setCheckable(True)
             action.setData(device.name)
             action.setChecked(selection.selected == device)
@@ -474,18 +660,18 @@ class MainWindow(QMainWindow):
         menu: QMenu,
         windows: tuple[WindowInfo, ...],
     ) -> None:
-        group = QActionGroup(self)
-        group.setExclusive(True)
+        self.window_source_action_group = QActionGroup(menu)
+        self.window_source_action_group.setExclusive(True)
         selection = _select_window_connection_status(self.global_settings, windows)
-        _add_auto_dummy_status_action(menu, selection, self)
+        _add_auto_dummy_status_action(menu, selection)
         if not windows:
-            empty_action = QAction("利用可能なウィンドウなし", self)
+            empty_action = QAction("利用可能なウィンドウなし", menu)
             empty_action.setEnabled(False)
             menu.addAction(empty_action)
             return
         for window in windows:
             identifier = str(window.identifier)
-            action = QAction(window.display_name, self)
+            action = QAction(window.display_name, menu)
             action.setCheckable(True)
             action.setData(identifier)
             action.setChecked(selection.selected == window)
@@ -498,7 +684,7 @@ class MainWindow(QMainWindow):
                     }
                 )
             )
-            group.addAction(action)
+            self.window_source_action_group.addAction(action)
             menu.addAction(action)
 
     def _populate_serial_device_menu(
@@ -507,14 +693,14 @@ class MainWindow(QMainWindow):
         devices: tuple[DeviceInfo, ...],
     ) -> None:
         menu.clear()
-        self.serial_device_action_group = QActionGroup(self)
+        self.serial_device_action_group = QActionGroup(menu)
         self.serial_device_action_group.setExclusive(True)
         current = str(self.global_settings.get("controller.serial.device", "") or "")
         selection = select_serial_target(
             ConnectionRequest(kind="serial", requested=current, allow_dummy=True),
             DeviceDiscoveryResult(serial_devices=devices),
         )
-        dummy_action = QAction(DUMMY_DEVICE_NAME, self)
+        dummy_action = QAction(DUMMY_DEVICE_NAME, menu)
         dummy_action.setCheckable(True)
         dummy_action.setData(DUMMY_DEVICE_NAME)
         dummy_action.setChecked(
@@ -530,14 +716,14 @@ class MainWindow(QMainWindow):
         )
         self.serial_device_action_group.addAction(dummy_action)
         menu.addAction(dummy_action)
-        _add_auto_dummy_status_action(menu, selection, self)
+        _add_auto_dummy_status_action(menu, selection)
         if not devices:
-            empty_action = QAction("利用可能なシリアルデバイスなし", self)
+            empty_action = QAction("利用可能なシリアルデバイスなし", menu)
             empty_action.setEnabled(False)
             menu.addAction(empty_action)
         for device in devices:
             identifier = str(device.identifier)
-            action = QAction(device.display_name, self)
+            action = QAction(device.display_name, menu)
             action.setCheckable(True)
             action.setData(identifier)
             action.setChecked(selection.selected == device)
@@ -551,10 +737,9 @@ class MainWindow(QMainWindow):
             )
             self.serial_device_action_group.addAction(action)
             menu.addAction(action)
-        menu.addSeparator()
-        self.serial_baud_menu = QMenu("ボーレート", menu)
-        menu.addMenu(self.serial_baud_menu)
-        self.serial_baud_action_group = QActionGroup(self)
+
+    def _populate_serial_baud_menu(self, menu: QMenu) -> None:
+        self.serial_baud_action_group = QActionGroup(menu)
         self.serial_baud_action_group.setExclusive(True)
         current_baud = str(self.global_settings.get("controller.serial.baudrate", 9600))
         protocol_name = str(
@@ -564,7 +749,7 @@ class MainWindow(QMainWindow):
         if current_baud not in baud_options:
             baud_options.append(current_baud)
         for baud in baud_options:
-            action = QAction(baud, self)
+            action = QAction(baud, menu)
             action.setCheckable(True)
             action.setData(int(baud))
             action.setChecked(baud == current_baud)
@@ -577,15 +762,15 @@ class MainWindow(QMainWindow):
                 )
             )
             self.serial_baud_action_group.addAction(action)
-            self.serial_baud_menu.addAction(action)
+            menu.addAction(action)
 
     def _populate_protocol_menu(self, menu: QMenu) -> None:
         menu.clear()
-        self.protocol_action_group = QActionGroup(self)
+        self.protocol_action_group = QActionGroup(menu)
         self.protocol_action_group.setExclusive(True)
         current = str(self.global_settings.get("controller.serial.protocol", "CH552") or "CH552")
         for protocol_name in ProtocolFactory.get_protocol_names():
-            action = QAction(protocol_name, self)
+            action = QAction(protocol_name, menu)
             action.setCheckable(True)
             action.setData(protocol_name)
             action.setChecked(protocol_name == current)
@@ -1756,14 +1941,13 @@ def _format_connection_status(label: str, selection: ResolvedConnection) -> str:
 def _add_auto_dummy_status_action(
     menu: QMenu,
     selection: ResolvedConnection,
-    parent: QMainWindow,
 ) -> None:
     if selection.uses_dummy and selection.fallback_reason not in {
         ConnectionFallbackReason.NOT_SELECTED,
         ConnectionFallbackReason.USER_SELECTED_DUMMY,
     }:
         requested = selection.requested or "未選択"
-        action = QAction(f"自動フォールバック中: {requested} 未検出", parent)
+        action = QAction(f"自動フォールバック中: {requested} 未検出", menu)
         action.setEnabled(False)
         menu.addAction(action)
 

--- a/tests/gui/test_device_settings_tab.py
+++ b/tests/gui/test_device_settings_tab.py
@@ -342,17 +342,19 @@ def test_device_settings_tab_saves_serial_identifier(qtbot):
     assert settings.data["controller.serial.device"] == "COM1"
 
 
-def test_device_tab_switches_serial_and_swbt_fields(qtbot):
+def test_device_tab_switches_serial_and_swbt_field_visibility(qtbot):
     settings = FakeSettings()
     tab = DeviceSettingsTab(settings, None, device_discovery=FakeDiscovery())
     qtbot.addWidget(tab)
 
+    assert not tab.ser_group.isHidden()
     assert tab.ser_group.isEnabled()
-    assert not tab.swbt_group.isEnabled()
+    assert tab.swbt_group.isHidden()
 
     tab.controller_backend.setCurrentIndex(tab.controller_backend.findData("swbt"))
 
-    assert not tab.ser_group.isEnabled()
+    assert tab.ser_group.isHidden()
+    assert not tab.swbt_group.isHidden()
     assert tab.swbt_group.isEnabled()
 
 
@@ -415,6 +417,47 @@ def test_device_settings_tab_applies_swbt_settings(qtbot):
     assert settings.data["controller.swbt.key_store_path"] == ".nyxpy/swbt/joy-con-l-bond.json"
 
 
+def test_key_store_lists_model_defaults_and_selects_current_model_default(qtbot) -> None:
+    tab = DeviceSettingsTab(FakeSettings(), None, device_discovery=FakeDiscovery())
+    qtbot.addWidget(tab)
+
+    assert tab.swbt_key_store.currentText() == ".nyxpy/swbt/pro-controller-bond.json"
+    assert {tab.swbt_key_store.itemText(index) for index in range(tab.swbt_key_store.count())} >= {
+        ".nyxpy/swbt/pro-controller-bond.json",
+        ".nyxpy/swbt/joy-con-l-bond.json",
+        ".nyxpy/swbt/joy-con-r-bond.json",
+    }
+
+
+def test_key_store_model_change_updates_default_but_preserves_custom_path(qtbot) -> None:
+    tab = DeviceSettingsTab(FakeSettings(), None, device_discovery=FakeDiscovery())
+    qtbot.addWidget(tab)
+
+    tab.swbt_controller_type.setCurrentIndex(tab.swbt_controller_type.findData("joy-con-l"))
+    assert tab.swbt_key_store.currentText() == ".nyxpy/swbt/joy-con-l-bond.json"
+
+    tab.swbt_key_store.setEditText("keys/custom.json")
+    tab.swbt_controller_type.setCurrentIndex(tab.swbt_controller_type.findData("joy-con-r"))
+    assert tab.swbt_key_store.currentText() == "keys/custom.json"
+
+
+def test_key_store_lists_existing_workspace_json_files(qtbot, tmp_path) -> None:
+    class SettingsWithConfigDir(FakeSettings):
+        config_dir = tmp_path / ".nyxpy"
+
+    key_store_dir = SettingsWithConfigDir.config_dir / "swbt"
+    key_store_dir.mkdir(parents=True)
+    (key_store_dir / "paired-switch.json").write_text("{}", encoding="utf-8")
+    (key_store_dir / "ignore.txt").write_text("", encoding="utf-8")
+
+    tab = DeviceSettingsTab(SettingsWithConfigDir(), None, device_discovery=FakeDiscovery())
+    qtbot.addWidget(tab)
+
+    choices = [tab.swbt_key_store.itemText(index) for index in range(tab.swbt_key_store.count())]
+    assert ".nyxpy/swbt/paired-switch.json" in choices
+    assert ".nyxpy/swbt/ignore.txt" not in choices
+
+
 def test_device_tab_preserves_edited_adapter_text(qtbot) -> None:
     settings = FakeSettings()
     provider = FakeSwbtAdapterProvider()
@@ -466,6 +509,95 @@ def test_pair_status_replaces_alias_with_canonical_adapter(qtbot) -> None:
 
     assert tab.swbt_adapter.currentText() == "hci0"
     assert settings.data["controller.swbt.adapter"] == "hci0"
+
+
+def test_pair_button_becomes_cancel_and_invokes_pair_cancellation(qtbot) -> None:
+    cancelled = Event()
+    callbacks = {}
+
+    def pair(_succeeded, failed):
+        callbacks["failed"] = failed
+        return cancelled.set
+
+    tab = DeviceSettingsTab(
+        FakeSettings(),
+        None,
+        device_discovery=FakeDiscovery(),
+        swbt_pair=pair,
+    )
+    qtbot.addWidget(tab)
+    tab.controller_backend.setCurrentIndex(tab.controller_backend.findData("swbt"))
+    tab.swbt_adapter.setEditText("usb-1")
+
+    tab.swbt_pair_btn.click()
+    assert tab.swbt_pair_btn.text() == "Cancel"
+    assert tab.swbt_pair_btn.isEnabled()
+
+    tab.swbt_pair_btn.click()
+    assert cancelled.is_set()
+    assert tab.swbt_pair_btn.text() == "Cancelling..."
+    assert not tab.swbt_pair_btn.isEnabled()
+
+    callbacks["failed"](
+        ExceptionGroup(
+            "pair cleanup",
+            [
+                type(
+                    "PairCancelled",
+                    (RuntimeError,),
+                    {"code": "NYX_SWBT_PAIR_CANCELLED"},
+                )()
+            ],
+        )
+    )
+
+    assert tab.swbt_status_label.text() == "ペアリングをキャンセルしました"
+    assert tab.swbt_pair_btn.text() == "Pair"
+
+
+def test_reconnect_button_becomes_cancel_and_restores_after_nested_cancellation(qtbot) -> None:
+    cancelled = Event()
+    callbacks = {}
+
+    def reconnect(_succeeded, failed):
+        callbacks["failed"] = failed
+        return cancelled.set
+
+    tab = DeviceSettingsTab(
+        FakeSettings(),
+        None,
+        device_discovery=FakeDiscovery(),
+        swbt_reconnect=reconnect,
+    )
+    qtbot.addWidget(tab)
+    tab.controller_backend.setCurrentIndex(tab.controller_backend.findData("swbt"))
+    tab.swbt_adapter.setEditText("usb-1")
+
+    tab.swbt_reconnect_btn.click()
+    assert tab.swbt_reconnect_btn.text() == "Cancel"
+    assert tab.swbt_reconnect_btn.isEnabled()
+    assert not tab.swbt_pair_btn.isEnabled()
+
+    tab.swbt_reconnect_btn.click()
+    assert cancelled.is_set()
+    assert tab.swbt_reconnect_btn.text() == "Cancelling..."
+    assert not tab.swbt_reconnect_btn.isEnabled()
+
+    callbacks["failed"](
+        ExceptionGroup(
+            "reconnect cleanup",
+            [
+                type(
+                    "ReconnectCancelled",
+                    (RuntimeError,),
+                    {"code": "NYX_SWBT_RECONNECT_CANCELLED"},
+                )()
+            ],
+        )
+    )
+
+    assert tab.swbt_status_label.text() == "再接続をキャンセルしました"
+    assert tab.swbt_reconnect_btn.text() == "Reconnect"
 
 
 def test_adapter_refresh_resolves_saved_alias_without_auto_selecting_other(qtbot) -> None:

--- a/tests/gui/test_device_settings_tab.py
+++ b/tests/gui/test_device_settings_tab.py
@@ -1,7 +1,7 @@
 from threading import Event
 
 import pytest
-from PySide6.QtWidgets import QLabel
+from PySide6.QtWidgets import QFormLayout, QLabel
 
 from nyxpy.framework.core.hardware.capture_source import CaptureRect
 from nyxpy.framework.core.hardware.device_discovery import DeviceInfo
@@ -120,6 +120,55 @@ def test_device_tab_protocol_options_include_3ds(qtbot):
 
     options = [tab.ser_protocol.itemText(i) for i in range(tab.ser_protocol.count())]
     assert "3DS" in options
+
+
+def test_device_tab_uses_consistent_controller_terms(qtbot):
+    tab = DeviceSettingsTab(FakeSettings(), None, device_discovery=FakeDiscovery())
+    qtbot.addWidget(tab)
+
+    labels = set(_label_texts(tab.controller_group))
+
+    assert tab.ser_group.title() == "serial"
+    assert tab.swbt_group.title() == "swbt"
+    assert [
+        tab.controller_backend.itemText(index) for index in range(tab.controller_backend.count())
+    ] == ["serial", "swbt"]
+    assert labels >= {
+        "方式:",
+        "デバイス:",
+        "プロトコル:",
+        "ボーレート:",
+        "タイプ:",
+        "キーストア:",
+        "接続:",
+        "状態:",
+    }
+    assert labels.isdisjoint(
+        {
+            "Backend:",
+            "Device:",
+            "Protocol:",
+            "Baud Rate:",
+            "Controller:",
+            "Adapter:",
+            "Key Store:",
+            "Connection:",
+            "Status:",
+        }
+    )
+
+
+def test_device_tab_orders_swbt_fields_like_controller_menu(qtbot):
+    tab = DeviceSettingsTab(FakeSettings(), None, device_discovery=FakeDiscovery())
+    qtbot.addWidget(tab)
+
+    form = tab.swbt_group.layout().itemAt(0).layout()
+
+    assert isinstance(form, QFormLayout)
+    assert [
+        form.itemAt(row, QFormLayout.ItemRole.LabelRole).widget().text()
+        for row in range(form.rowCount())
+    ] == ["デバイス:", "タイプ:", "キーストア:", "接続:", "状態:"]
 
 
 def test_device_tab_selects_3ds_default_baudrate(qtbot):

--- a/tests/gui/test_main_window.py
+++ b/tests/gui/test_main_window.py
@@ -20,7 +20,7 @@ from nyxpy.framework.core.hardware.device_discovery import (
 )
 from nyxpy.framework.core.hardware.window_discovery import WindowInfo
 from nyxpy.framework.core.logger import LogSanitizer, LogSinkDispatcher
-from nyxpy.framework.core.macro.exceptions import ErrorInfo, ErrorKind
+from nyxpy.framework.core.macro.exceptions import DeviceError, ErrorInfo, ErrorKind
 from nyxpy.framework.core.runtime.result import RunResult, RunStatus
 from nyxpy.gui.app_services import SettingsApplyOutcome
 from nyxpy.gui.layout import LEFT_PANE_CONTENT_MARGIN
@@ -1274,6 +1274,104 @@ def test_pair_and_close_wait_for_background_operation(qtbot, services: FakeServi
 
     release.set()
     qtbot.waitUntil(lambda: services.closed)
+
+
+def test_pair_cancel_callable_sets_event_passed_to_prepared_service(
+    qtbot,
+    services: FakeServices,
+) -> None:
+    started = Event()
+    received_events: list[Event] = []
+    config = object()
+
+    services.canonicalize_swbt_adapter = lambda: config
+
+    def pair_prepared(received_config, *, cancellation_event: Event) -> None:
+        assert received_config is config
+        received_events.append(cancellation_event)
+        started.set()
+        cancellation_event.wait(2.0)
+        raise ExceptionGroup(
+            "pair cleanup",
+            [
+                DeviceError(
+                    "cancelled",
+                    code="NYX_SWBT_PAIR_CANCELLED",
+                    component="test",
+                )
+            ],
+        )
+
+    services.pair_swbt_prepared = pair_prepared
+    services.global_settings.set("controller.backend", "swbt")
+    services.global_settings.set("controller.swbt.adapter", "hci0")
+    window = MainWindow(services=services)
+    qtbot.addWidget(window)
+    window.deferred_init()
+
+    cancel = window._pair_swbt_controller_async()
+
+    assert callable(cancel)
+    qtbot.waitUntil(started.is_set)
+    assert len(received_events) == 1
+    assert not received_events[0].is_set()
+
+    cancel()
+
+    assert received_events[0].is_set()
+    qtbot.waitUntil(lambda: not window._swbt_lifecycle_busy)
+    assert window.manual_controller_error is None
+    assert window.status_label.text() == "swbt ペアリングをキャンセルしました"
+    assert not any(
+        event[3] == "swbt.lifecycle_failed" for event in services.logger.technical_events
+    )
+
+
+def test_reconnect_cancel_event_is_forwarded_and_not_reported_as_failure(
+    qtbot,
+    services: FakeServices,
+) -> None:
+    started = Event()
+    received_events: list[Event] = []
+    config = object()
+    services.canonicalize_swbt_adapter = lambda: config
+
+    def reconnect_prepared(received_config, *, cancellation_event: Event) -> None:
+        assert received_config is config
+        received_events.append(cancellation_event)
+        started.set()
+        cancellation_event.wait(2.0)
+        raise ExceptionGroup(
+            "reconnect cleanup",
+            [
+                DeviceError(
+                    "cancelled",
+                    code="NYX_SWBT_RECONNECT_CANCELLED",
+                    component="test",
+                )
+            ],
+        )
+
+    services.reconnect_swbt_prepared = reconnect_prepared
+    services.global_settings.set("controller.backend", "swbt")
+    services.global_settings.set("controller.swbt.adapter", "hci0")
+    window = MainWindow(services=services)
+    qtbot.addWidget(window)
+    window.deferred_init()
+
+    cancel = window._reconnect_swbt_controller_async()
+    assert callable(cancel)
+    qtbot.waitUntil(started.is_set)
+    assert not received_events[0].is_set()
+    cancel()
+
+    assert received_events[0].is_set()
+    qtbot.waitUntil(lambda: not window._swbt_lifecycle_busy)
+    assert window.manual_controller_error is None
+    assert window.status_label.text() == "swbt 再接続をキャンセルしました"
+    assert not any(
+        event[3] == "swbt.lifecycle_failed" for event in services.logger.technical_events
+    )
 
 
 def test_manual_send_failure_is_visible_and_closes_port_in_worker(

--- a/tests/gui/test_main_window.py
+++ b/tests/gui/test_main_window.py
@@ -7,8 +7,8 @@ from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import pytest
-from PySide6.QtCore import QPoint
-from PySide6.QtGui import QCloseEvent
+from PySide6.QtCore import QCoreApplication, QEvent, QPoint
+from PySide6.QtGui import QAction, QActionGroup, QCloseEvent
 from PySide6.QtWidgets import QDialog
 
 from nyxpy.framework.core.constants import Button, Hat
@@ -18,6 +18,7 @@ from nyxpy.framework.core.hardware.device_discovery import (
     DeviceInfo,
     WindowDiscoveryResult,
 )
+from nyxpy.framework.core.hardware.swbt.discovery import SwbtAdapterView
 from nyxpy.framework.core.hardware.window_discovery import WindowInfo
 from nyxpy.framework.core.logger import LogSanitizer, LogSinkDispatcher
 from nyxpy.framework.core.macro.exceptions import DeviceError, ErrorInfo, ErrorKind
@@ -241,7 +242,22 @@ class FakeServices:
 
     def refresh_swbt_adapters(self):
         self.swbt_calls.append("refresh")
-        return ()
+        return (
+            SwbtAdapterView(
+                name="usb:0",
+                aliases=("usb:0A12:0001",),
+                display_name="CSR8510 A10 (usb:0)",
+                vendor_id=0x0A12,
+                product_id=0x0001,
+                manufacturer=None,
+                product="CSR8510 A10",
+                serial_number=None,
+                bus_number=1,
+                device_address=2,
+                port_numbers=(1,),
+                is_bluetooth_hci=True,
+            ),
+        )
 
     def pair_swbt(self):
         self.swbt_calls.append("pair")
@@ -389,19 +405,191 @@ def test_connection_menu_has_required_children(window: MainWindow) -> None:
         if action.menu() is not None
     ]
 
-    assert child_menus[:4] == ["キャプチャ入力", "コントローラー", "シリアルデバイス", "プロトコル"]
+    assert child_menus == ["キャプチャ入力", "コントローラー"]
 
 
-def test_capture_input_menu_nests_candidates_under_input_source(window: MainWindow) -> None:
-    assert window.capture_source_type_menu is not None
+def test_controller_menu_shows_only_serial_settings_for_serial_backend(
+    window: MainWindow,
+) -> None:
+    assert window.controller_backend_menu is not None
+
+    actions = window.controller_backend_menu.actions()
+    child_menus = [action.menu().title() for action in actions if action.menu() is not None]
+
+    assert [action.text() for action in actions[:2]] == ["serial", "swbt"]
+    assert child_menus == ["デバイス", "プロトコル", "ボーレート"]
+    assert window.serial_device_menu is not None
+    assert window.protocol_menu is not None
+    assert window.serial_baud_menu is not None
+    assert window.swbt_device_menu is None
+    assert window.swbt_type_menu is None
+
+
+def test_controller_menu_shows_only_swbt_settings_for_swbt_backend(
+    window: MainWindow,
+) -> None:
+    window.global_settings.set("controller.backend", "swbt")
+    window.global_settings.set("controller.swbt.adapter", "usb:0")
+
+    window._swbt_adapter_views = services_adapters = window.services.refresh_swbt_adapters()
+    assert services_adapters
+    window._refresh_connection_menu()
+
+    assert window.controller_backend_menu is not None
+    actions = window.controller_backend_menu.actions()
+    child_menus = [action.menu().title() for action in actions if action.menu() is not None]
+    assert child_menus == ["デバイス", "タイプ"]
+    assert [action.text() for action in actions[-3:]] == ["Pair", "Reconnect", "Disconnect"]
+    assert window.serial_device_menu is None
+    assert window.protocol_menu is None
+    assert window.serial_baud_menu is None
+    assert window.swbt_device_menu is not None
+    assert window.swbt_type_menu is not None
+
+
+def test_swbt_device_menu_canonicalizes_alias_selection(window: MainWindow) -> None:
+    window.global_settings.set("controller.backend", "swbt")
+    window.global_settings.set("controller.swbt.adapter", "usb:0A12:0001")
+    window._swbt_adapter_views = window.services.refresh_swbt_adapters()
+    window._refresh_connection_menu()
+    assert window.swbt_device_menu is not None
+    action = next(
+        action for action in window.swbt_device_menu.actions() if action.data() == "usb:0"
+    )
+
+    assert action.isChecked()
+    action.trigger()
+
+    assert window.global_settings.get("controller.swbt.adapter") == "usb:0"
+
+
+def test_swbt_type_menu_updates_default_key_store(window: MainWindow) -> None:
+    window.global_settings.set("controller.backend", "swbt")
+    window.global_settings.set(
+        "controller.swbt.key_store_path", ".nyxpy/swbt/pro-controller-bond.json"
+    )
+    window._refresh_connection_menu()
+    assert window.swbt_type_menu is not None
+    joy_con_l = next(
+        action for action in window.swbt_type_menu.actions() if action.data() == "joy-con-l"
+    )
+
+    joy_con_l.trigger()
+
+    assert window.global_settings.get("controller.swbt.controller_type") == "joy-con-l"
+    assert (
+        window.global_settings.get("controller.swbt.key_store_path")
+        == ".nyxpy/swbt/joy-con-l-bond.json"
+    )
+
+
+def test_swbt_type_menu_preserves_custom_key_store(window: MainWindow) -> None:
+    window.global_settings.set("controller.backend", "swbt")
+    window.global_settings.set("controller.swbt.key_store_path", "keys/custom.json")
+    window._refresh_connection_menu()
+    assert window.swbt_type_menu is not None
+    joy_con_r = next(
+        action for action in window.swbt_type_menu.actions() if action.data() == "joy-con-r"
+    )
+
+    joy_con_r.trigger()
+
+    assert window.global_settings.get("controller.swbt.controller_type") == "joy-con-r"
+    assert window.global_settings.get("controller.swbt.key_store_path") == "keys/custom.json"
+
+
+def test_swbt_device_menu_keeps_missing_saved_adapter_visible_and_disables_connect(
+    window: MainWindow,
+) -> None:
+    window.global_settings.set("controller.backend", "swbt")
+    window.global_settings.set("controller.swbt.adapter", "usb:missing")
+    window._swbt_adapter_views = ()
+
+    window._refresh_connection_menu()
+
+    assert window.swbt_device_menu is not None
+    missing = next(
+        action
+        for action in window.swbt_device_menu.actions()
+        if action.text() == "usb:missing (未検出)"
+    )
+    assert missing.isCheckable()
+    assert missing.isChecked()
+    assert not missing.isEnabled()
+    assert window.controller_backend_menu is not None
+    lifecycle = {action.text(): action for action in window.controller_backend_menu.actions()}
+    assert not lifecycle["Pair"].isEnabled()
+    assert not lifecycle["Reconnect"].isEnabled()
+
+
+def test_swbt_device_refresh_runs_in_background_and_updates_cached_menu(
+    qtbot,
+    services: FakeServices,
+) -> None:
+    started = Event()
+    release = Event()
+    adapters = services.refresh_swbt_adapters()
+
+    def slow_refresh():
+        started.set()
+        release.wait(2.0)
+        return adapters
+
+    services.refresh_swbt_adapters = slow_refresh
+    services.global_settings.set("controller.backend", "swbt")
+    services.global_settings.set("controller.swbt.adapter", "usb:0")
+    w = MainWindow(services=services)
+    qtbot.addWidget(w)
+    w._refresh_connection_menu()
+    assert w.swbt_device_menu is not None
+    refresh = next(action for action in w.swbt_device_menu.actions() if action.text() == "再検索")
+
+    refresh.trigger()
+
+    qtbot.waitUntil(started.is_set)
+    assert w._swbt_adapter_refreshing
+    assert w.swbt_device_menu is not None
+    assert any(
+        action.text() == "再検索中..." and not action.isEnabled()
+        for action in w.swbt_device_menu.actions()
+    )
+    release.set()
+    qtbot.waitUntil(lambda: not w._swbt_adapter_refreshing)
+    assert w.swbt_device_menu is not None
+    assert any(action.data() == "usb:0" for action in w.swbt_device_menu.actions())
+    w.preview_pane.timer.stop()
+
+
+def test_dynamic_menu_refresh_does_not_accumulate_qt_objects(
+    window: MainWindow,
+) -> None:
+    dynamic_children_before = (
+        len(window.findChildren(QAction)),
+        len(window.findChildren(QActionGroup)),
+    )
+
+    for _ in range(20):
+        window._refresh_connection_menu()
+    QCoreApplication.sendPostedEvents(None, QEvent.Type.DeferredDelete)
+
+    dynamic_children_after = (
+        len(window.findChildren(QAction)),
+        len(window.findChildren(QActionGroup)),
+    )
+    assert dynamic_children_after == dynamic_children_before
+
+
+def test_capture_input_menu_lists_source_candidates_directly(window: MainWindow) -> None:
+    assert window.capture_input_menu is not None
 
     source_menus = [
         action.menu().title()
-        for action in window.capture_source_type_menu.actions()
+        for action in window.capture_input_menu.actions()
         if action.menu() is not None
     ]
 
-    assert source_menus == ["カメラ", "ウィンドウ", "キャプチャ"]
+    assert source_menus == ["カメラ", "ウィンドウ", "キャプチャ", "FPS"]
+    assert window.capture_source_type_menu is None
 
 
 def test_connection_menu_hides_capture_when_ponkan_unavailable(
@@ -412,14 +600,14 @@ def test_connection_menu_hides_capture_when_ponkan_unavailable(
     w = MainWindow(services=services)
     qtbot.addWidget(w)
 
-    assert w.capture_source_type_menu is not None
+    assert w.capture_input_menu is not None
     source_menus = [
         action.menu().title()
-        for action in w.capture_source_type_menu.actions()
+        for action in w.capture_input_menu.actions()
         if action.menu() is not None
     ]
 
-    assert source_menus == ["カメラ", "ウィンドウ"]
+    assert source_menus == ["カメラ", "ウィンドウ", "FPS"]
     assert w.capture_source_menu is None
     w.preview_pane.timer.stop()
 
@@ -462,7 +650,7 @@ def test_connection_menu_removes_ponkan_backend_submenu(
         if action.menu() is not None
     ]
 
-    assert child_menus == ["入力ソース", "FPS"]
+    assert child_menus == ["カメラ", "ウィンドウ", "キャプチャ", "FPS"]
     assert window.capture_settings_menu is None
     assert window.ponkan_backend_menu is None
 

--- a/tests/unit/framework/hardware/swbt/test_session.py
+++ b/tests/unit/framework/hardware/swbt/test_session.py
@@ -92,6 +92,28 @@ class SlowAwaitableFakeSwbtController(AwaitableFakeSwbtController):
         self.connection_state = "connected"
 
 
+class HangingPairFakeSwbtController(AwaitableFakeSwbtController):
+    def __init__(self) -> None:
+        super().__init__()
+        self.pair_started = Event()
+
+    async def pair(self, *, timeout: float) -> None:
+        self.calls.append(("pair", timeout))
+        self.pair_started.set()
+        await asyncio.sleep(3600)
+
+
+class HangingReconnectFakeSwbtController(AwaitableFakeSwbtController):
+    def __init__(self) -> None:
+        super().__init__()
+        self.reconnect_started = Event()
+
+    async def reconnect(self, *, timeout: float) -> None:
+        self.calls.append(("reconnect", timeout))
+        self.reconnect_started.set()
+        await asyncio.sleep(3600)
+
+
 class CancellationAwareFakeSwbtController(AwaitableFakeSwbtController):
     async def apply(self, state) -> None:
         self.calls.append(("apply-start", state))
@@ -122,6 +144,54 @@ def test_session_open_does_not_pair_or_reconnect() -> None:
 
     assert fake.calls == [("open", None)]
     assert not session.connected
+
+
+def test_session_pair_cancels_pending_awaitable_without_waiting_for_timeout() -> None:
+    fake = HangingPairFakeSwbtController()
+    session = SwbtControllerSession(config(), controller_factory=lambda _config, _writer: fake)
+    cancellation_event = Event()
+    errors: list[BaseException] = []
+
+    def pair() -> None:
+        try:
+            session.pair(timeout_sec=30.0, cancellation_event=cancellation_event)
+        except BaseException as exc:
+            errors.append(exc)
+
+    thread = Thread(target=pair)
+    thread.start()
+    assert fake.pair_started.wait(1.0)
+
+    cancellation_event.set()
+    thread.join(1.0)
+
+    assert not thread.is_alive()
+    assert len(errors) == 1
+    assert getattr(errors[0], "code", None) == "NYX_SWBT_PAIR_CANCELLED"
+
+
+def test_session_reconnect_cancels_after_awaitable_started() -> None:
+    fake = HangingReconnectFakeSwbtController()
+    session = SwbtControllerSession(config(), controller_factory=lambda _config, _writer: fake)
+    cancellation_event = Event()
+    errors: list[BaseException] = []
+
+    def reconnect() -> None:
+        try:
+            session.reconnect(timeout_sec=30.0, cancellation_event=cancellation_event)
+        except BaseException as exc:
+            errors.append(exc)
+
+    thread = Thread(target=reconnect)
+    thread.start()
+    assert fake.reconnect_started.wait(1.0)
+
+    cancellation_event.set()
+    thread.join(1.0)
+
+    assert not thread.is_alive()
+    assert len(errors) == 1
+    assert getattr(errors[0], "code", None) == "NYX_SWBT_RECONNECT_CANCELLED"
 
 
 def test_session_pair_reconnect_apply_status_and_close() -> None:


### PR DESCRIPTION
## Summary

コントローラー設定の経路切替、swbt接続取消、キーストア選択、接続メニューの構造と用語を整理します。

## Related

- swbt実機検証で確認されたGUI操作性の改善

## Changes

- serial / swbt設定を無効表示ではなく表示切替へ変更
- Pair / Reconnectを同じボタンから即時キャンセル可能に変更
- キーストア候補と既存JSONを選択可能に変更
- 接続メニューをキャプチャ入力とコントローラーの責務で再構成
- serial / swbtのデバイス選択とタイプ・プロトコル設定を対称化
- swbtデバイス探索をバックグラウンド化し、未検出状態を明示
- 動的メニュー再構築時のQAction蓄積を解消
- 設定ダイアログの名称と順序をメニューへ統一

## Commit Log

`
ba19512 refactor(gui): 接続メニューの構造と用語を整理
0dd2d3f fix(gui): コントローラー設定と接続取消を改善
`

## Testing

`
uv run pytest
842 passed, 18 skipped

uv run ruff check src tests
All checks passed

uv run ruff format --check src tests
226 files already formatted

uv run ty check src/nyxpy --output-format concise --no-progress
All checks passed

git diff --check
passed
`

実機でPair / Reconnectのキャンセル、メニューツリー、設定ダイアログの表示を確認済みです。

## Checklist

- [x] lint / format チェック通過
- [x] 既存テスト通過
- [x] コミット prefix が変更の動機と一致
- [x] 新規・変更コードに対するテスト追加
- [x] 型チェック通過