### PR TITLE
feat(swbt): swbt-python 0.5.3のprofile移行を完了

### DIFF
--- a/docs/architecture/swbt-integration/configuration-cli-gui.md
+++ b/docs/architecture/swbt-integration/configuration-cli-gui.md
@@ -6,7 +6,7 @@
 
 ## 依存関係
 
-`swbt-python>=0.2.0,<0.3.0` は通常依存として追加する。`[project.optional-dependencies].swbt` は作らない。
+`swbt-python==0.5.3` は通常依存として固定する。`[project.optional-dependencies].swbt` は作らない。lockfile 上の Bumble は `0.0.233` とする。
 
 NyX はすでに serial backend のために PySerial を通常依存として持つ。swbt backend も controller backend の正式な選択肢として扱い、利用者に swbt 用の extra 指定や追加同期手順を要求しない。
 
@@ -33,7 +33,7 @@ backend = "swbt"
 [controller.swbt]
 controller_type = "pro-controller"
 adapter = "usb:0"
-key_store_path = ".nyxpy/swbt/pro-controller-bond.json"
+profile_path = ".nyxpy/swbt/pro-controller-profile.json"
 connect_timeout_sec = 30.0
 report_period_us = 8000
 ```
@@ -44,12 +44,12 @@ report_period_us = 8000
 
 `adapter` は swbt が開く USB Bluetooth adapter 名である。空文字または未指定のまま pair / reconnect / run を試みた場合は、候補数に関係なく `NYX_SWBT_ADAPTER_NOT_SELECTED` とする。adapter 候補が 1 件だけでも自動採用しない。
 
-`key_store_path` は pairing key file である。明示されない場合は controller type ごとに `.nyxpy/swbt/<controller>-bond.json` を使う。相対 path はコマンドを実行した子 directory ではなく workspace root を基準に解決する。
+`profile_path` は swbt-python schema v2 pairing profile である。明示されない場合は controller type ごとに `.nyxpy/swbt/<controller>-profile.json` を使う。相対 path はコマンドを実行した子 directory ではなく workspace root を基準に解決する。
 
 ```text
-.nyxpy/swbt/pro-controller-bond.json
-.nyxpy/swbt/joy-con-l-bond.json
-.nyxpy/swbt/joy-con-r-bond.json
+.nyxpy/swbt/pro-controller-profile.json
+.nyxpy/swbt/joy-con-l-profile.json
+.nyxpy/swbt/joy-con-r-profile.json
 ```
 
 `connect_timeout_sec` は接続操作ごとの timeout である。`report_period_us` は swbt report loop の周期で、既定値は `8000`、値は `None` または正の整数に限る。
@@ -62,11 +62,13 @@ report_period_us = 8000
 
 ```console
 nyxpy swbt adapters [--json]
-nyxpy swbt pair [--adapter usb:0] [--controller-type pro-controller] [--key-store .nyxpy/swbt/pro-controller-bond.json]
-nyxpy swbt reconnect [--adapter usb:0] [--controller-type pro-controller] [--key-store .nyxpy/swbt/pro-controller-bond.json]
+nyxpy swbt pair [--adapter usb:0] [--controller-type pro-controller] [--profile .nyxpy/swbt/pro-controller-profile.json]
+nyxpy swbt reconnect [--adapter usb:0] [--controller-type pro-controller] [--profile .nyxpy/swbt/pro-controller-profile.json]
 ```
 
-`pair` と `reconnect` は workspace settings を読み、CLI option が指定された場合だけ上書きする。解決後に adapter が空なら `NYX_SWBT_ADAPTER_NOT_SELECTED` とする。指定 adapter は discovery 結果の `name` / `aliases` から代表 `name` へ正規化する。不一致と曖昧 alias はそれぞれ `NYX_SWBT_ADAPTER_NOT_FOUND` / `NYX_SWBT_ADAPTER_AMBIGUOUS` とする。候補が 1 件でも未指定値を補わない。`key_store_path` が未指定なら controller type から既定値を補う。
+`pair` と `reconnect` は workspace settings を読み、CLI option が指定された場合だけ上書きする。解決後に adapter が空なら `NYX_SWBT_ADAPTER_NOT_SELECTED` とする。指定 adapter は discovery 結果の `name` / `aliases` から代表 `name` へ正規化する。不一致と曖昧 alias はそれぞれ `NYX_SWBT_ADAPTER_NOT_FOUND` / `NYX_SWBT_ADAPTER_AMBIGUOUS` とする。候補が 1 件でも未指定値を補わない。`profile_path` が未指定なら controller type から既定値を補う。
+
+旧設定を読み込んだ場合は旧 path を新 profile の path として流用せず、controller type ごとの既定 profile path へ切り替える。旧 JSON は変換・削除・上書きしない。schema v1 も読み込まず、利用者へ再ペアリングを要求する。
 
 run option:
 
@@ -94,7 +96,7 @@ GUI swbt panel に置く項目:
 | controller type | yes | Pro Controller / Joy-Con L / Joy-Con R |
 | adapter combo | yes | `list_adapters()` の結果 |
 | refresh adapters | yes | adapter 列挙だけ行う |
-| key store path | yes | pairing key JSON path |
+| pairing profile path | yes | pairing key JSON path |
 | pair button | yes | 明示 pairing |
 | reconnect button | yes | 保存済み key で reconnect |
 | disconnect button | yes | GUI lifetime port を release/close し、factory-managed session を disconnect |
@@ -119,8 +121,8 @@ GUI に置かない項目:
 | operation | enabled when | success | failure |
 |---|---|---|---|
 | Refresh adapters | macro 未実行中 | combo を更新。settings は変更しない | error 表示 |
-| Pair | backend `swbt`、adapter、controller type、key store が有効 | status connected、manual controller を注入 | controller `None`、error 表示 |
-| Reconnect | backend `swbt`、key store が存在 | status connected、manual controller を注入 | controller `None`、error 表示 |
+| Pair | backend `swbt`、adapter、controller type、pairing profile が有効 | status connected、manual controller を注入 | controller `None`、error 表示 |
+| Reconnect | backend `swbt`、pairing profile が存在 | status connected、manual controller を注入 | controller `None`、error 表示 |
 | Disconnect | connected | `release()` 後に `close()`、factory session を閉じ、controller `None` | error log、controller `None` |
 | Macro run start | not pairing/reconnecting | `VirtualControllerModel.set_controller(None)` 後に旧 manual port を release/close して runtime start | close 失敗時は実行を止める |
 
@@ -149,7 +151,7 @@ manual input widget は controller port が存在し、macro 非実行、lifecyc
 | `controller.backend` | `serial` or `swbt` |
 | `controller.swbt.controller_type` | `resolve_controller_model(...)` で解決できる |
 | `controller.swbt.adapter` | 保存時は空を許容する。接続操作時に空なら `NYX_SWBT_ADAPTER_NOT_SELECTED` |
-| `controller.swbt.key_store_path` | `Path | None`。`None` なら controller type から既定値を補う。親 directory は pair 前に作成 |
+| `controller.swbt.profile_path` | `Path | None`。`None` なら controller type から既定値を補う。親 directory は pair 前に作成 |
 | `connect_timeout_sec` | `> 0` |
 | `report_period_us` | `None` or `> 0` |
 
@@ -164,7 +166,12 @@ manual input widget は controller port が存在し、macro 非実行、lifecyc
 | `NYX_SWBT_ADAPTER_NOT_FOUND` | 選択 adapter が見つからない |
 | `NYX_SWBT_ADAPTER_AMBIGUOUS` | adapter alias が複数候補に一致している |
 | `NYX_SWBT_CONTROLLER_TYPE_UNSUPPORTED` | controller type を選択させる |
-| `NYX_SWBT_KEY_STORE_INVALID` | key store path を確認させる |
+| `NYX_SWBT_PROFILE_NOT_FOUND` | Pair で profile を新規作成させる |
+| `NYX_SWBT_PROFILE_ALREADY_EXISTS` | 既存 profile で Pair を再試行するか path を変更させる |
+| `NYX_SWBT_PROFILE_INVALID` | schema と profile path を確認させる |
+| `NYX_SWBT_PROFILE_CONTROLLER_MISMATCH` | controller type と profile の対応を確認させる |
+| `NYX_SWBT_PROFILE_KEY_DATA_INVALID` | 別 path で再ペアリングさせる |
+| `NYX_SWBT_ADAPTER_IDENTITY_RECOVERY_REQUIRED` | USB Bluetooth ドングルを抜き差しさせる |
 | `NYX_SWBT_CONNECTION_TIMED_OUT` | target device の pairing/reconnect 操作を確認させる |
 | `NYX_SWBT_CONNECTION_FAILED` | connection failed |
 | `NYX_SWBT_INPUT_UNSUPPORTED` | 選択 controller type ではその入力を扱えない |

--- a/docs/architecture/swbt-integration/controller-models.md
+++ b/docs/architecture/swbt-integration/controller-models.md
@@ -6,11 +6,11 @@ controller type は単なる文字列ではなく、domain object として扱�
 
 ## 永続化値
 
-| 値 | 表示名 | 既定 key store |
+| 値 | 表示名 | 既定 pairing profile |
 |---|---|---|
-| `pro-controller` | Pro Controller | `pro-controller-bond.json` |
-| `joy-con-l` | Joy-Con L | `joy-con-l-bond.json` |
-| `joy-con-r` | Joy-Con R | `joy-con-r-bond.json` |
+| `pro-controller` | Pro Controller | `pro-controller-profile.json` |
+| `joy-con-l` | Joy-Con L | `joy-con-l-profile.json` |
+| `joy-con-r` | Joy-Con R | `joy-con-r-profile.json` |
 
 TOML 例:
 
@@ -53,15 +53,15 @@ class SwbtInputCapabilities:
 class SwbtControllerModel:
     controller_type: SwbtControllerType
     display_name: str
-    default_key_store_name: str
+    default_profile_name: str
     capabilities: SwbtInputCapabilities
 
     @property
     def settings_value(self) -> str:
         return self.controller_type.value
 
-    def default_key_store_path(self, base_dir: Path = Path(".nyxpy/swbt")) -> Path:
-        return base_dir / self.default_key_store_name
+    def default_profile_path(self, base_dir: Path = Path(".nyxpy/swbt")) -> Path:
+        return base_dir / self.default_profile_name
 ```
 
 `SwbtControllerModel` は Project_NyX 側の controller 定義である。swbt の `ProController`、`JoyConL`、`JoyConR` などの runtime class は保持しない。session 作成時に `controller_type` から swbt controller class を解決する。
@@ -108,7 +108,7 @@ GUI choices と CLI choices は `supported_controller_models()` から作る。
 class SwbtControllerConfig:
     model: SwbtControllerModel
     adapter: str | None = None
-    key_store_path: Path | None = None
+    profile_path: Path
     connect_timeout_sec: float = 30.0
     report_period_us: int | None = 8000
 ```
@@ -117,7 +117,7 @@ class SwbtControllerConfig:
 
 `adapter` は settings 上では空を許容する。pair / reconnect / run の直前に空なら `NYX_SWBT_ADAPTER_NOT_SELECTED` にする。
 
-`key_store_path` が `None` の場合は、`model.default_key_store_path()` で `.nyxpy/swbt/<controller>-bond.json` を補う。
+`profile_path` が `None` の場合は、`model.default_profile_path()` で `.nyxpy/swbt/<controller>-profile.json` を補う。
 
 ## capability validation
 

--- a/docs/architecture/swbt-integration/controller-session.md
+++ b/docs/architecture/swbt-integration/controller-session.md
@@ -8,9 +8,9 @@
 
 ## なぜ session が必要か
 
-serial backend は `SerialControllerOutputPort` から `SerialComm.send(...)` を呼ぶ。swbt backend は controller class の選択、adapter 未指定の拒否、key store、diagnostics writer、swbt 例外の変換を同じ入力 port から扱う必要がある。
+serial backend は `SerialControllerOutputPort` から `SerialComm.send(...)` を呼ぶ。swbt backend は controller class の選択、adapter 未指定の拒否、pairing profile、diagnostics writer、swbt 例外の変換を同じ入力 port から扱う必要がある。
 
-`SwbtControllerSession` はこの lifecycle 差分を吸収する。swbt-python 0.2 系では `open()`、`pair()`、`reconnect()`、`apply()`、`neutral()`、`close()` が async API、`status()` が同期 API である。session は専用 event loop thread で async API の完了を待ち、上位には同期 method として見せる。
+`SwbtControllerSession` はこの lifecycle 差分を吸収する。swbt-python 0.5.3 では `create_profile()`、`open()`、`pair()`、`reconnect()`、`apply()`、`neutral()`、`close()` が async API、`status()` が同期 API である。session は専用 event loop thread で async API の完了を待ち、上位には同期 method として見せる。
 
 ```text
 SwbtControllerOutputPort  # sync ControllerOutputPort implementation
@@ -49,10 +49,10 @@ class SwbtControllerSession:
         """controller resource を開く。接続は開始しない。"""
 
     def pair(self, *, timeout_sec: float) -> None:
-        """pairing を実行し、status が connected であることを確認する。"""
+        """profile を作成または再利用してpairingし、connectedを確認する。"""
 
     def reconnect(self, *, timeout_sec: float) -> None:
-        """保存済み pairing key で reconnect し、status が connected であることを確認する。"""
+        """保存済み pairing profile で reconnect し、connectedを確認する。"""
 
     def apply(self, state: InputState) -> None:
         """現在入力全体を置き換える。"""
@@ -87,7 +87,7 @@ def create_swbt_controller(
         diagnostics = DiagnosticsConfig(trace_writer=diagnostics_writer)
     return controller_cls(
         adapter=config.adapter,
-        key_store_path=str(config.key_store_path),
+        profile_path=str(config.profile_path),
         report_period_us=config.report_period_us,
         diagnostics=diagnostics,
     )
@@ -95,7 +95,9 @@ def create_swbt_controller(
 
 diagnostics writer は NyX 内部 adapter で `LoggerPort.technical(...)` に流す。settings、GUI、CLI に diagnostics path は出さない。
 
-swbt の `pair()` / `reconnect()` 自体の戻り値は `None` である。session は操作完了後に同期 `status()` を取得し、`status.connection_state == "connected"` を接続成功条件として内部で確認する。上位へ返す値も `None` であり、戻り値の truthiness や存在しない `status.connected` / `status.message` は使わない。
+初回 Pair で profile が存在しない場合は `controller_cls.create_profile(adapter=..., profile_path=..., local_address=None, pair_timeout=...)` を呼び、返却された接続済み controller の lifetime を session が所有する。profile が存在する場合は通常 constructor と `pair()` を使う。これにより、キャンセルや接続失敗後に残った profile から Pair を再試行できる。factory は Pair 前に `session.open()` を呼ばず、分岐判断を session に集約する。
+
+swbt の `pair()` / `reconnect()` 自体の戻り値は `None` である。session は操作完了後に同期 `status()` を取得し、`status.connection_state == "connected"` を確認する。その後、公開 status の `report_counters[0x30]` が接続直後の値から増えるまで待つ。`0x30` は周期 input report であり、増加は Switch へ入力を送れる状態になった根拠である。タイムアウト時は `NYX_SWBT_INPUT_REPORT_NOT_READY` とする。上位へ返す値も `None` であり、戻り値の truthiness や存在しない `status.connected` / `status.message` は使わない。
 
 ## async bridge
 
@@ -136,7 +138,7 @@ session 内部には `RLock` を置き、connection operation と input apply �
 
 GUI lifetime port と macro runtime port が同一 session を同時に使わないよう、GUI 側は macro start 前に `VirtualControllerModel.set_controller(None)` を呼び、旧 manual port を release/close する。
 
-`SwbtControllerOutputPortFactory` は session key ごとに active port を 1 つだけ持つ。同一物理 adapter を別の controller model / key store で指定した場合も既存 port / session を先に閉じる。`create()` / `pair()` / `reconnect()` で旧 active port の neutral が失敗した場合は session close へ進み、終端 close に成功した場合だけ新しい session / port へ置き換える。`disconnect()` / `close()` / 接続失敗時の session 破棄も同じ cleanup 規則を使う。
+`SwbtControllerOutputPortFactory` は session key ごとに active port を 1 つだけ持つ。同一物理 adapter を別の controller model / pairing profile で指定した場合も既存 port / session を先に閉じる。`create()` / `pair()` / `reconnect()` で旧 active port の neutral が失敗した場合は session close へ進み、終端 close に成功した場合だけ新しい session / port へ置き換える。`disconnect()` / `close()` / 接続失敗時の session 破棄も同じ cleanup 規則を使う。
 
 session 自体は connection lifecycle と transport lock を持つ。manual / runtime の所有権は factory の active port 管理で扱い、`NYX_SWBT_ADAPTER_BUSY` のような busy error は追加しない。
 

--- a/docs/architecture/swbt-integration/index.md
+++ b/docs/architecture/swbt-integration/index.md
@@ -2,7 +2,7 @@
 
 この文書群は、Project_NyX から `swbt-python` を controller backend として利用するための設計方針を定義する。
 
-`swbt-python` は NX 互換の仮想 Bluetooth HID controller を Python から扱うための library である。Project_NyX では、Bluetooth adapter の列挙、pairing、保存済み pairing key に基づく reconnect、入力 report の送信を controller backend の実装として扱う。マクロ作者から見える通常 API は `Command`、GUI の仮想コントローラーから見える境界は既存の `ControllerOutputPort` に止める。
+`swbt-python` 0.5.3 は NX 互換の仮想 Bluetooth HID controller を Python から扱うための library である。Project_NyX では、Bluetooth adapter の列挙、schema v2 pairing profile の作成、保存済み profile に基づく reconnect、入力 report の送信を controller backend の実装として扱う。マクロ作者から見える通常 API は `Command`、GUI の仮想コントローラーから見える境界は既存の `ControllerOutputPort` に止める。
 
 ## 最小構成
 
@@ -13,7 +13,7 @@ backend = "swbt"
 [controller.swbt]
 controller_type = "pro-controller"
 adapter = "usb:0"
-key_store_path = ".nyxpy/swbt/pro-controller-bond.json"
+profile_path = ".nyxpy/swbt/pro-controller-profile.json"
 connect_timeout_sec = 30.0
 report_period_us = 8000
 ```
@@ -22,7 +22,7 @@ report_period_us = 8000
 
 `swbt-python` は通常依存である。利用者に swbt 用の extra 指定や追加同期手順を求めない。
 
-`adapter` が空文字または未指定のまま接続操作を行った場合は、候補が 1 件でも自動採用せず `NYX_SWBT_ADAPTER_NOT_SELECTED` とする。`key_store_path` が未指定なら `.nyxpy/swbt/<controller>-bond.json` を使う。
+`adapter` が空文字または未指定のまま接続操作を行った場合は、候補が 1 件でも自動採用せず `NYX_SWBT_ADAPTER_NOT_SELECTED` とする。`profile_path` が未指定なら `.nyxpy/swbt/<controller>-profile.json` を使う。
 
 ## 入力反映の基本方針
 
@@ -71,8 +71,8 @@ GUI の swbt 設定画面に置く機能は、実機運用に必要なものに�
 |---|---|
 | デバイス一覧取得 / 更新 | `list_adapters()` で利用可能な dedicated USB Bluetooth adapter 候補を表示する |
 | コントローラー種別指定 | Pro Controller / Joy-Con L / Joy-Con R を選ぶ |
-| ペアリング | 選択した adapter、controller type、key store path で pairing する |
-| pairing key に基づく reconnect | 保存済み key store を使って reconnect する |
+| ペアリング | 選択した adapter、controller type、pairing profile path で pairing する |
+| pairing key に基づく reconnect | 保存済み pairing profile を使って reconnect する |
 | 仮想コントローラー manual input | 既存 `VirtualControllerModel` から `ControllerOutputPort` へ button / D-pad / stick を送る |
 
 GUI と CLI の間で値を受け渡すための clipboard 機能、CLI command 生成、CLI 実行履歴との連携、diagnostics folder を開く導線、controller color editor は持たせない。
@@ -101,7 +101,7 @@ GUI manual input では IMU を直接操作しない。preset gesture、pose edi
 | controller type | `SwbtControllerType` / `SwbtControllerModel` で扱い、文字列は設定境界で解決する |
 | adapter refresh | Python API の `list_adapters()` を直接呼ぶ |
 | pairing | 明示操作として扱い、通常の macro run では勝手に pairing しない |
-| reconnect | key store に保存済み pairing 情報があることを前提にする |
+| reconnect | pairing profile に保存済み pairing 情報があることを前提にする |
 | disconnect | factory lifetime を維持する GUI から cached session を明示的に閉じる。fresh factory を作る CLI command は提供しない |
 | input | NyX state から `InputState` を構成し、`apply(state)` を使う |
 | manual input | 既存 `VirtualControllerModel` と `ControllerOutputPort` 経路を使う |
@@ -134,7 +134,7 @@ GUI manual input では IMU を直接操作しない。preset gesture、pose edi
 - swbt backend の controller 出力
 - dedicated USB Bluetooth adapter の列挙
 - Pro Controller / Joy-Con L / Joy-Con R の選択
-- pairing と key store への保存
+- pairing と pairing profile への保存
 - 保存済み pairing key に基づく reconnect
 - GUI が管理する cached session の disconnect
 - `ControllerOutputPort` からの button / D-pad / stick / IMU 入力

--- a/docs/architecture/swbt-integration/public-api.md
+++ b/docs/architecture/swbt-integration/public-api.md
@@ -6,14 +6,18 @@ Project_NyX は `swbt-python` の公開 API を `swbt` root module から import
 from swbt import (
     AdapterInfo,
     AdapterDiscoveryError,
+    AdapterIdentityRecoveryRequired,
     Button,
     DiagnosticsConfig,
     GamepadStatus,
     IMUFrame,
     InputState,
+    InvalidKeyStoreError,
+    InvalidProfileError,
     JoyConL,
     JoyConR,
     ProController,
+    ProfileControllerMismatchError,
     Stick,
     SwitchGamepad,
     list_adapters,
@@ -50,7 +54,7 @@ controller 実体は次の具象 class から生成する。
 ```python
 pad: SwitchGamepad = ProController(
     adapter="usb:0",
-    key_store_path=".nyxpy/swbt/pro-controller-bond.json",
+    profile_path=".nyxpy/swbt/pro-controller-profile.json",
     report_period_us=8000,
     diagnostics=None,
 )
@@ -60,8 +64,20 @@ pad: SwitchGamepad = ProController(
 
 `SwbtControllerSession` は `open()` と `close(neutral=True)` の scope を所有する。`open()` は transport と report loop の準備であり、pairing や reconnect を開始しない。
 
+新規 profile は constructor ではなく `create_profile()` で作成する。
+
 ```python
-pad = ProController(adapter="usb:0", key_store_path="switch-bond.json")
+pad = await ProController.create_profile(
+    adapter="usb:0",
+    profile_path="switch-profile.json",
+    local_address=None,
+    pair_timeout=30.0,
+    report_period_us=8000,
+)
+```
+
+```python
+pad = ProController(adapter="usb:0", profile_path="switch-profile.json")
 await pad.open()
 try:
     await pad.reconnect(timeout=30.0)
@@ -76,12 +92,13 @@ Project_NyX は connection operation を明示的に分ける。
 
 | operation | swbt API | 用途 |
 |---|---|---|
-| pair | `pair(timeout=...)` | 初回 pairing。key store に保存する |
+| profile作成と初回pair | `create_profile(..., pair_timeout=...)` | schema v2 profile を新規作成し、接続済み controller を返す |
+| pair再試行 | `pair(timeout=...)` | 作成済み profile から pairing を再試行する |
 | reconnect | `reconnect(timeout=...)` | 保存済み pairing key に基づく再接続 |
 | connect | `connect(timeout=..., allow_pairing=False)` | 原則使わない。pairing の暗黙実行を避ける |
 | connect result | `try_connect(timeout=..., allow_pairing=False)` | 原則使わない |
 
-macro 実行時は reconnect のみを行う。key store がないからといって暗黙に pairing しない。
+macro 実行時は reconnect のみを行う。pairing profile がないからといって暗黙に pairing しない。
 
 現行の Project_NyX 実装は `pair()` と `reconnect()` を使い、接続結果を返す別 API には依存しない。失敗理由は swbt 例外を NyX の framework error に変換して扱う。
 
@@ -129,7 +146,12 @@ swbt 例外は Project_NyX の framework error へ変換し、macro / GUI へ `S
 | `TransportOpenError` | `ConfigurationError(code="NYX_SWBT_TRANSPORT_OPEN_FAILED")` |
 | `ConnectionTimeoutError` | `ConfigurationError(code="NYX_SWBT_CONNECTION_TIMED_OUT")` |
 | `ConnectionFailedError` | `ConfigurationError(code="NYX_SWBT_CONNECTION_FAILED")` |
-| `InvalidKeyStoreError` | `ConfigurationError(code="NYX_SWBT_KEY_STORE_INVALID")` |
+| `FileNotFoundError` | `ConfigurationError(code="NYX_SWBT_PROFILE_NOT_FOUND")` |
+| `FileExistsError` | `ConfigurationError(code="NYX_SWBT_PROFILE_ALREADY_EXISTS")` |
+| `InvalidProfileError` | `ConfigurationError(code="NYX_SWBT_PROFILE_INVALID")` |
+| `ProfileControllerMismatchError` | `ConfigurationError(code="NYX_SWBT_PROFILE_CONTROLLER_MISMATCH")` |
+| `InvalidKeyStoreError` | `ConfigurationError(code="NYX_SWBT_PROFILE_KEY_DATA_INVALID")` |
+| `AdapterIdentityRecoveryRequired` | `ConfigurationError(code="NYX_SWBT_ADAPTER_IDENTITY_RECOVERY_REQUIRED")` |
 | `UnsupportedInputError` | `DeviceError(code="NYX_SWBT_INPUT_UNSUPPORTED")` |
 | `InvalidInputError` | `DeviceError(code="NYX_SWBT_INPUT_INVALID")` |
 | `ClosedError` | `DeviceError(code="NYX_SWBT_NOT_CONNECTED")` |

--- a/docs/architecture/swbt-integration/runtime-composition.md
+++ b/docs/architecture/swbt-integration/runtime-composition.md
@@ -46,7 +46,7 @@ class SerialControllerConfig:
 class SwbtControllerConfig:
     model: SwbtControllerModel
     adapter: str | None = None
-    key_store_path: Path | None = None
+    profile_path: Path | None = None
     connect_timeout_sec: float = 30.0
     report_period_us: int | None = 8000
 
@@ -56,7 +56,7 @@ ControllerConfig = SerialControllerConfig | SwbtControllerConfig
 
 `SwbtControllerConfig` は `controller_type` 文字列を持たない。設定正規化の時点で `SwbtControllerModel` へ解決する。
 
-`key_store_path` が `None` の場合は、session 作成前に `.nyxpy/swbt/<controller>-bond.json` へ補完する。相対 path は現在の shell directory ではなく workspace root を基準に解決する。`adapter` が `None` または空文字の場合、接続操作は `NYX_SWBT_ADAPTER_NOT_SELECTED` で失敗させる。
+`profile_path` が `None` の場合は、session 作成前に `.nyxpy/swbt/<controller>-profile.json` へ補完する。相対 path は現在の shell directory ではなく workspace root を基準に解決する。`adapter` が `None` または空文字の場合、接続操作は `NYX_SWBT_ADAPTER_NOT_SELECTED` で失敗させる。
 
 `operation_timeout_sec` は settings / config に出さず、session / factory の内部既定値として扱う。diagnostics は config path ではなく writer を session へ渡す。
 
@@ -80,6 +80,7 @@ def make_controller_port_factory(
 ) -> PortFactory[ControllerOutputPort]:
     match config:
         case SerialControllerConfig():
+
             def create_serial(request: RuntimeBuildRequest, _definition) -> ControllerOutputPort:
                 return serial_factory.create(
                     name=config.device,
@@ -87,15 +88,18 @@ def make_controller_port_factory(
                     allow_dummy=allow_dummy(request),
                     timeout_sec=detection_timeout_sec,
                 )
+
             return create_serial
 
         case SwbtControllerConfig():
+
             def create_swbt(request: RuntimeBuildRequest, _definition) -> ControllerOutputPort:
                 return swbt_factory.create(
                     config=config,
                     allow_dummy=allow_dummy(request),
                     timeout_sec=config.connect_timeout_sec,
                 )
+
             return create_swbt
 ```
 
@@ -123,7 +127,7 @@ VirtualControllerModel
 
 ## SwbtControllerOutputPortFactory
 
-swbt factory は session と active port を cache する。同じ adapter / controller model / key store / report period の transport resource は `SwbtControllerSession` に集約する。同一物理 adapter は controller model や key store が違っても同時に開かず、有効な `SwbtControllerOutputPort` を 1 つだけにする。
+swbt factory は session と active port を cache する。同じ adapter / controller model / pairing profile / report period の transport resource は `SwbtControllerSession` に集約する。同一物理 adapter は controller model や pairing profile が違っても同時に開かず、有効な `SwbtControllerOutputPort` を 1 つだけにする。
 
 ```text
 SwbtControllerOutputPortFactory
@@ -146,7 +150,7 @@ session key に含める値:
 ```text
 model.controller_type
 adapter
-key_store_path
+profile_path
 report_period_us
 ```
 
@@ -195,7 +199,7 @@ class SwbtControllerOutputPortFactory:
 
 `SwbtControllerSession.start()` は作らない。`factory.create()` が `open()` と `reconnect()` を順に呼ぶ。
 
-key store がない場合に pairing へ fallback しない。key store がない場合や不正な場合は `ConfigurationError` に変換する。
+runtime と Reconnect は pairing profile がない場合に pairing へ fallback しない。明示 Pair だけが `create_profile()` を呼ぶ。pairing profile がない場合や不正な場合は個別の `ConfigurationError` に変換する。
 
 port 作成時は `SwbtControllerOutputPort` が neutral を常に試みる。`reset_on_port_create` という設定や引数は持たない。
 

--- a/docs/architecture/swbt-integration/testing-rollout.md
+++ b/docs/architecture/swbt-integration/testing-rollout.md
@@ -4,7 +4,7 @@ swbt backend は、設定 model、adapter discovery、session、port、runtime i
 
 ## 導入順序
 
-1. `swbt-python>=0.2.0,<0.3.0` を通常依存として追加する。
+1. `swbt-python==0.5.3` を通常依存として固定する。
 2. `nyxpy.framework.core.hardware.swbt` package を追加する。
 3. `SwbtControllerType` / `SwbtControllerModel` / capabilities / `SwbtControllerConfig` を `config.py` に定義する。
 4. `ControllerOutputPort.imu(...)` と `Command.imu(...)` を既定 unsupported として追加する。
@@ -46,8 +46,8 @@ swbt backend は、設定 model、adapter discovery、session、port、runtime i
 [ ] close 時に neutral を試みる
 [ ] swbt が通常依存であり、`[project.optional-dependencies].swbt` がない
 [ ] adapter 未指定時に自動採用せず `NYX_SWBT_ADAPTER_NOT_SELECTED` になる
-[ ] key store 未指定時に `.nyxpy/swbt/<controller>-bond.json` を使う
-[ ] 相対 key store path が workspace root 基準で解決される
+[ ] pairing profile 未指定時に `.nyxpy/swbt/<controller>-profile.json` を使う
+[ ] 相対 pairing profile path が workspace root 基準で解決される
 [ ] pair / reconnect 後の接続判定が `GamepadStatus.connection_state` に基づく
 [ ] GUI の swbt lifecycle と macro start が worker thread で実行される
 [ ] GUI manual input が port なし、macro 実行中、lifecycle 操作中に無効になる
@@ -61,7 +61,7 @@ swbt backend は、設定 model、adapter discovery、session、port、runtime i
 | リスク | 対策 |
 |---|---|
 | adapter 名が接続状態で変わる | `list_adapters()` の結果で `aliases` と VID/PID も表示する |
-| key store に複数候補が入る | controller type と対象機器ごとに file を分け、`InvalidKeyStoreError` を明示表示する |
+| pairing profile に複数候補が入る | controller type と対象機器ごとに file を分け、`InvalidKeyStoreError` を明示表示する |
 | GUI manual input と macro runtime が競合する | macro start 前に GUI lifetime port を release/close する |
 | IMU command が非対応 backend で silent no-op になる | 共通 default を `NotImplementedError` にする |
 | Joy-Con type で存在しない入力を送る | `SwbtControllerModel.capabilities` で mapper が拒否する |
@@ -77,20 +77,20 @@ Adapter discovery
   [ ] refresh だけでは pairing 待ち受けが開始されない
 
 Pair / reconnect
-  [ ] Pro Controller で pair 成功
-  [ ] 同じ key store で reconnect 成功
-  [ ] Joy-Con L で pair/reconnect 成功
-  [ ] Joy-Con R で pair/reconnect 成功
-  [ ] invalid key store が明確に表示される
+  [x] Pro Controller で pair 成功
+  [x] 同じ pairing profile で reconnect 成功
+  [x] Joy-Con L で pair/reconnect 成功
+  [x] Joy-Con R で pair/reconnect 成功
+  [ ] invalid pairing profile が明確に表示される
   [ ] GUI Disconnect が factory-managed cached session を閉じる
 
 Macro input
-  [ ] Button.A press/release
-  [ ] 16ms / 33ms / 50ms の短い押下を確認
-  [ ] D-pad diagonal
-  [ ] left stick / right stick
-  [ ] Command.imu(...) による IMU neutral / gyro frame
-  [ ] release all / close neutral
+  [x] Button.A press/release
+  [x] 16ms / 33ms / 50ms の短い押下を確認
+  [x] D-pad input を確認（観察画面は斜め方向を上として表示するため、右上の方向区別は未確認）
+  [x] left stick / right stick
+  [x] Command.imu(...) による IMU neutral / gyro frame を送信し、切断・想定外入力がないことを確認（gyro 値自体の画面上の反映は未確認）
+  [x] release all / close neutral
 
 GUI manual input
   [ ] reconnect 後に virtual controller が有効になる
@@ -106,12 +106,12 @@ GUI manual input
 unit、CLI、GUI の非実機 gate では mapping と lifecycle 境界を確認できる。次の項目は Switch、専用 USB Bluetooth adapter、operator がそろった環境で確定するまで未検証として扱う。
 
 ```text
-[ ] Pro Controller / Joy-Con L / Joy-Con R の pair / reconnect
+[x] Pro Controller / Joy-Con L / Joy-Con R の pair / reconnect
 [ ] NyX `0..255`、Y-down から `Stick.normalized`、Y-up への変換が実機で期待方向に反映されること
-[ ] 16ms / 33ms / 50ms short press の安定性
+[x] 16ms / 33ms / 50ms short press の反映
 [ ] public flush / send_current 相当 API が必要かどうか
 ```
 
-座標変換規則自体は単体テストで固定する。Switch 画面上の方向は実機未検証であり、完了扱いにしない。
+座標変換規則自体は単体テストで固定する。Switch 画面では左右 stick の上方向を確認した。D-pad の `UPRIGHT` は上として反映されたが、観察画面が斜め方向を区別しないため、右成分を含むことは未確認である。
 
 実機で short press が取りこぼされる場合、この文書と利用者向け docs に最小推奨 duration を反映する。実機確認前の段階では、NyX は swbt backend 固有の最小押下時間を保証しない。

--- a/docs/architecture/swbt-integration/testing.md
+++ b/docs/architecture/swbt-integration/testing.md
@@ -10,7 +10,7 @@ swbt 連携は unit test、session test、CLI test、GUI model test、port contr
 |---|---|
 | `parse_controller_type("pro-controller")` | `SwbtControllerType.PRO_CONTROLLER` |
 | unsupported value | `NYX_SWBT_CONTROLLER_TYPE_UNSUPPORTED` |
-| resolve model | `controller_cls`、表示名、default key store が得られる |
+| resolve model | `controller_cls`、表示名、default pairing profile が得られる |
 | capabilities | Pro Controller と Joy-Con L/R が IMU を supported として持つ |
 | config normalization | `controller_type` 文字列が `SwbtControllerModel` に変換される |
 
@@ -70,7 +70,9 @@ class FakeGamepad:
 - `close()` が `close(neutral=True)` を呼び、複数回呼んでも安全。
 - transport error が `NYX_SWBT_TRANSPORT_OPEN_FAILED` になる。
 - connection timeout が `NYX_SWBT_CONNECTION_TIMED_OUT` になる。
-- invalid key store が `NYX_SWBT_KEY_STORE_INVALID` になる。
+- profile未作成、既存、schema不正、controller type不一致、内部key不正がそれぞれ固有の `NYX_SWBT_PROFILE_*` code になる。
+- profile未作成時のPairだけが `create_profile()` を呼び、返却controllerをsessionが所有する。
+- Pairキャンセル後に残ったprofileからPairを再試行できる。
 - close 後の apply が `DeviceError` になる。
 
 ## port contract test
@@ -142,7 +144,7 @@ $env:NYX_REALDEVICE = "1"
 $env:NYX_SWBT = "1"
 $env:NYX_SWBT_ADAPTER = "usb:0"
 $env:NYX_SWBT_CONTROLLER_TYPE = "pro-controller"
-$env:NYX_SWBT_KEY_STORE = ".nyxpy/swbt/pro-controller-bond.json"
+$env:NYX_SWBT_PROFILE = ".nyxpy/swbt/pro-controller-profile.json"
 $env:NYX_SWBT_OPERATOR_CONFIRMATION = "1"
 $env:NYX_SWBT_OPERATOR_RESULT = "pass"
 uv run pytest tests/hardware/ -m realdevice

--- a/docs/user-guide/cli.md
+++ b/docs/user-guide/cli.md
@@ -39,7 +39,7 @@ uv run nyxpy run sample_macro --serial <serial-device> --capture "Capture Device
 | `--controller` | controller backend。`serial` または `swbt` |
 | `--swbt-adapter` | swbt 用 USB Bluetooth adapter 名。候補が 1 件でも自動採用しない |
 | `--swbt-controller-type` | `pro-controller`、`joy-con-l`、`joy-con-r` |
-| `--swbt-key-store` | pairing key store の path |
+| `--swbt-profile` | pairing profile の path |
 | `--swbt-timeout` | pair / reconnect の timeout 秒 |
 | `--define` | マクロへ渡す `key=value` 形式の引数 |
 | `--verbose` | 詳細ログを出す |
@@ -54,29 +54,33 @@ nyxpy swbt adapters
 nyxpy swbt adapters --json
 ```
 
-初回は pairing を行い、controller type ごとに key store を分けます。
+初回は pairing を行い、controller type ごとに pairing profile を分けます。
 
 ```console
-nyxpy swbt pair --adapter usb:0 --controller-type pro-controller --key-store .nyxpy/swbt/pro-controller-bond.json
+nyxpy swbt pair --adapter usb:0 --controller-type pro-controller --profile .nyxpy/swbt/pro-controller-profile.json
 ```
 
-保存済み key store で reconnect します。
+`pair` は profile がなければ `create_profile()` で schema v2 profile を作成します。キャンセルや接続失敗後に profile が残った場合、同じコマンドを再実行すると既存 profile から pairing を再試行します。
+
+保存済み pairing profile で reconnect します。
 
 ```console
-nyxpy swbt reconnect --adapter usb:0 --controller-type pro-controller --key-store .nyxpy/swbt/pro-controller-bond.json
+nyxpy swbt reconnect --adapter usb:0 --controller-type pro-controller --profile .nyxpy/swbt/pro-controller-profile.json
 ```
 
 `--adapter` には一覧の代表名または alias を指定できます。alias は接続前に代表名へ正規化されます。候補が 1 件でも未指定値を自動補完しません。不一致または曖昧な alias は `NYX_SWBT_ADAPTER_NOT_FOUND` / `NYX_SWBT_ADAPTER_AMBIGUOUS` で失敗します。
 
-相対 key store path は、コマンドを実行した子ディレクトリではなく workspace root を基準に解決されます。
+相対 pairing profile path は、コマンドを実行した子ディレクトリではなく workspace root を基準に解決されます。
 
 CLI の各操作は別プロセスで新しい factory を作るため、以前のプロセスが持っていた session を閉じる subcommand はありません。継続中の GUI session は GUI の `Disconnect` で閉じてください。
 
-マクロ実行では `--controller swbt` を指定します。key store がない場合でも暗黙の pairing は行いません。
+マクロ実行では `--controller swbt` を指定します。pairing profile がない場合でも暗黙の pairing は行いません。
 
 ```console
-nyxpy run sample_macro --controller swbt --swbt-adapter usb:0 --swbt-controller-type pro-controller --swbt-key-store .nyxpy/swbt/pro-controller-bond.json --capture "Capture Device"
+nyxpy run sample_macro --controller swbt --swbt-adapter usb:0 --swbt-controller-type pro-controller --swbt-profile .nyxpy/swbt/pro-controller-profile.json --capture "Capture Device"
 ```
+
+旧オプションは受け付けません。swbt-python 0.2 系の旧キーストアや schema v1 profile を指定しても変換せず、profile error で終了します。
 
 ## 終了時の見方
 

--- a/docs/user-guide/device-setup.md
+++ b/docs/user-guide/device-setup.md
@@ -35,13 +35,15 @@ nyxpy gui
 | Baud Rate | protocol の既定値を使う。CH552 の既定値は `9600` |
 | swbt Controller | `Pro Controller`、`Joy-Con L`、`Joy-Con R` から選ぶ |
 | swbt Adapter | `リロード` で候補を取得し、使う adapter を明示的に選ぶ。候補が 1 件でも自動選択しない |
-| swbt Key Store | pairing key の保存先。未指定時は `.nyxpy/swbt/<controller>-bond.json`。相対 path は workspace root 基準 |
+| swbt Pairing Profile | swbt-python 0.5.3 の pairing profile 保存先。未指定時は `.nyxpy/swbt/<controller>-profile.json`。相対 path は workspace root 基準 |
 | swbt Connection | `Pair`、`Reconnect`、`Disconnect` を実行する |
 | Preview FPS | GUI プレビューの更新頻度 |
 
 設定は workspace の `.nyxpy/global.toml` に保存されます。
 
-`Pair` は初回 pairing で key store を作ります。2 回目以降は `Reconnect` を使います。接続状態は操作後の実際の status で判定されます。`Disconnect` は GUI と同じプロセスが管理している swbt session を閉じる操作で、Switch 側や別プロセスの接続状態までは保証しません。
+`Pair` は初回 pairing で pairing profile を作ります。2 回目以降は `Reconnect` を使います。接続状態は操作後の実際の status で判定されます。`Disconnect` は GUI と同じプロセスが管理している swbt session を閉じる操作で、Switch 側や別プロセスの接続状態までは保証しません。
+
+swbt-python 0.2 系の旧キーストアと schema v1 profile は読み込めません。NyX は旧ファイルを変換・削除・上書きせず、新しい既定 path へ切り替えます。更新後は `Pair` を実行して schema v2 profile を作成してください。
 
 ## CLI で指定する
 
@@ -69,16 +71,16 @@ nyxpy run sample_macro --serial <serial-device> --capture "Capture Device" --pro
 
 ```console
 nyxpy swbt adapters
-nyxpy swbt pair --adapter usb:0 --controller-type pro-controller --key-store .nyxpy/swbt/pro-controller-bond.json
-nyxpy swbt reconnect --adapter usb:0 --controller-type pro-controller --key-store .nyxpy/swbt/pro-controller-bond.json
+nyxpy swbt pair --adapter usb:0 --controller-type pro-controller --profile .nyxpy/swbt/pro-controller-profile.json
+nyxpy swbt reconnect --adapter usb:0 --controller-type pro-controller --profile .nyxpy/swbt/pro-controller-profile.json
 ```
 
 一覧に表示された alias も指定できますが、接続時には代表名へ正規化されます。候補が 1 件でも adapter を省略できません。CLI は操作ごとに別プロセスを起動するため、前回の cached session を閉じる subcommand はありません。
 
-マクロ実行時は controller backend を明示します。`swbt` は保存済み key store に基づいて reconnect し、暗黙の pairing は行いません。
+マクロ実行時は controller backend を明示します。`swbt` は保存済み pairing profile に基づいて reconnect し、暗黙の pairing は行いません。
 
 ```console
-nyxpy run sample_macro --controller swbt --swbt-adapter usb:0 --swbt-controller-type pro-controller --swbt-key-store .nyxpy/swbt/pro-controller-bond.json --capture "Capture Device"
+nyxpy run sample_macro --controller swbt --swbt-adapter usb:0 --swbt-controller-type pro-controller --swbt-profile .nyxpy/swbt/pro-controller-profile.json --capture "Capture Device"
 ```
 
 ## 主な設定ファイル

--- a/docs/user-guide/gui.md
+++ b/docs/user-guide/gui.md
@@ -60,13 +60,15 @@ uv run nyxpy gui
 |------|------|
 | Controller | `Pro Controller`、`Joy-Con L`、`Joy-Con R` |
 | Adapter | `リロード` で候補を取得し、使う adapter を選ぶ |
-| Key Store | pairing key の保存先 |
+| Pairing Profile | swbt-python 0.5.3 schema v2 profile の保存先 |
 | Pair | 初回 pairing を実行する |
-| Reconnect | 保存済み key store で再接続する |
+| Reconnect | 保存済み pairing profile で再接続する |
 | Disconnect | GUI が管理する swbt session を閉じる |
 | Status | `GamepadStatus.connection_state` に基づく GUI session の状態 |
 
 adapter は候補が 1 件でも自動採用されません。`Pair` と `Reconnect` の前に明示的に選んでください。保存済み alias が候補に一致した場合は代表名へ正規化されます。候補の更新に失敗した場合、保存済み値と更新前の選択は消去されません。
+
+`Reconnect` は指定した profile file が存在するときだけ有効です。旧キーストア設定を検出した場合は旧ファイルを残したまま新しい profile path へ切り替え、再ペアリングが必要であることをツールログへ表示します。schema 不正や controller type 不一致は個別の `NYX_SWBT_PROFILE_*` error として表示します。
 
 adapter 更新、`Pair`、`Reconnect`、`Disconnect`、マクロ開始は background worker で処理されます。処理中は対象操作が無効になり、GUI の表示更新は処理完了後に行われます。
 

--- a/docs/user-guide/troubleshooting.md
+++ b/docs/user-guide/troubleshooting.md
@@ -58,22 +58,33 @@ nyxpy swbt adapters --json
 
 - pair が timeout する。
 - reconnect が失敗する。
-- `NYX_SWBT_KEY_STORE_INVALID` または key store 関連のエラーが出る。
+- `NYX_SWBT_PROFILE_INVALID` または pairing profile 関連のエラーが出る。
 
 確認するもの:
 
 - Switch 側が controller の pairing を受け付ける画面になっている。
 - `--swbt-controller-type` と実機が一致している。
-- controller type ごとに別の key store を使っている。
-- key store を手で編集していない。
+- controller type ごとに別の pairing profile を使っている。
+- pairing profile を手で編集していない。
 - 初回は `nyxpy swbt pair`、2 回目以降は `nyxpy swbt reconnect` を使っている。
 
 ```console
-nyxpy swbt pair --adapter usb:0 --controller-type pro-controller --key-store .nyxpy/swbt/pro-controller-bond.json
-nyxpy swbt reconnect --adapter usb:0 --controller-type pro-controller --key-store .nyxpy/swbt/pro-controller-bond.json
+nyxpy swbt pair --adapter usb:0 --controller-type pro-controller --profile .nyxpy/swbt/pro-controller-profile.json
+nyxpy swbt reconnect --adapter usb:0 --controller-type pro-controller --profile .nyxpy/swbt/pro-controller-profile.json
 ```
 
-`nyxpy run --controller swbt` は暗黙に pairing しません。key store がない場合は、先に pair を実行してください。
+`nyxpy run --controller swbt` は暗黙に pairing しません。pairing profile がない場合は、先に pair を実行してください。
+
+| error code | 対応 |
+|------------|------|
+| `NYX_SWBT_PROFILE_NOT_FOUND` | `Pair` で新しい schema v2 profile を作成する |
+| `NYX_SWBT_PROFILE_ALREADY_EXISTS` | 指定 path を確認する。失敗後に残った profile なら同じ `Pair` を再試行する |
+| `NYX_SWBT_PROFILE_INVALID` | schema v1、旧キーストア、破損 file を使わず、別 path で再ペアリングする |
+| `NYX_SWBT_PROFILE_CONTROLLER_MISMATCH` | profile を作成した controller type を選ぶか、controller type ごとに別 profile を作る |
+| `NYX_SWBT_PROFILE_KEY_DATA_INVALID` | profile 内の key 情報が不正である。file を手で直さず、別 path で再ペアリングする |
+| `NYX_SWBT_ADAPTER_IDENTITY_RECOVERY_REQUIRED` | USB Bluetooth ドングルを抜き差ししてから再試行する |
+
+NyX は旧キーストア、schema v1 profile、破損 profile を自動変換・削除・上書きしません。必要なら別の場所へ保管したまま、新しい `*-profile.json` を指定してください。
 
 ## swbt 入力が反映されない
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
     "paddleocr>=3.5.0,<3.6.0",
     "numpy>=2.3.5,<2.4.0",
     "mss>=10.2.0",
-    "swbt-python>=0.2.0,<0.3.0",
+    "swbt-python==0.5.3",
 ]
 
 [dependency-groups]

--- a/spec/agent/complete/local_027/SWBT_PYTHON_0_5_3_PROFILE_MIGRATION.md
+++ b/spec/agent/complete/local_027/SWBT_PYTHON_0_5_3_PROFILE_MIGRATION.md
@@ -1,0 +1,204 @@
+# swbt-python 0.5.3 ペアリングプロファイル移行仕様書
+
+> **対象モジュール**: `src/nyxpy/framework/core/hardware/swbt/`
+> **目的**: swbt-python 0.5.3 の schema v2 pairing profile 契約へ移行する
+> **関連ドキュメント**: [swbt integration](../../../../docs/architecture/swbt-integration/index.md)、[実機検証仕様](../../local_026/SWBT_REALDEVICE_DOCS_CLOSEOUT.md)
+> **既存ソース**: `src/nyxpy/framework/core/hardware/swbt/`
+> **破壊的変更**: あり
+
+## 1. 概要
+
+### 1.1 目的
+
+Project_NyX の swbt backend を `swbt-python==0.5.3` に固定し、初回 Pair、再Pair、Reconnect、runtime 入力を schema v2 pairing profile で動作させる。旧キーストアと schema v1 profile は変換せず、新しい path での再ペアリングを利用者へ要求する。
+
+### 1.2 用語定義
+
+| 用語 | 定義 |
+|------|------|
+| pairing profile | swbt-python 0.5.3 が controller 種別、adapter identity、bond key を保持する schema v2 JSON |
+| 初回 Pair | profile が存在しない path に `controller_cls.create_profile(...)` を実行する操作 |
+| 再Pair | Pair 失敗またはキャンセル後に残った profile を constructor へ渡し、`pair()` を再実行する操作 |
+| Reconnect | 保存済み profile を constructor へ渡し、`reconnect()` する操作 |
+| session | swbt controller と専用 asyncio event loop の lifetime を所有し、同期 `ControllerOutputPort` と橋渡しする部品 |
+| 旧キーストア | swbt-python 0.2 系で使っていた JSON。schema v2 profile へ変換しない |
+
+### 1.3 背景・問題
+
+現行実装は `swbt-python>=0.2.0,<0.3.0` と旧キーストア引数を前提にしている。0.5.3 では constructor が `profile_path` を受け取り、初回作成は非同期 class method `create_profile()` が接続済み controller を返す。旧 JSON と schema v1 profile に互換読込はない。
+
+### 1.4 期待効果
+
+| 指標 | 現状 | 目標 |
+|------|------|------|
+| swbt-python | `>=0.2.0,<0.3.0` | `==0.5.3` |
+| Bumble | `0.0.230` | `0.0.233` |
+| 新規 profile schema | 旧キーストア | schema v2 |
+| profile failure | 汎用 code 中心 | 原因別 `NYX_SWBT_PROFILE_*` code |
+| Reconnect UI | adapter 選択だけで有効 | profile file が存在するときだけ有効 |
+
+### 1.5 着手条件
+
+- GitHub Issue #195 の実装項目と完了条件を正本とする。
+- swbt-python 0.5.3 の公開 signature と例外を導入済み package から確認する。
+- 実機操作は `@pytest.mark.realdevice` と `@pytest.mark.swbt` を付け、通常 gate と分離する。
+
+## 2. 対象ファイル
+
+| ファイル | 変更種別 | 変更内容 |
+|----------|----------|----------|
+| `pyproject.toml` / `uv.lock` | 変更 | swbt-python 0.5.3 と Bumble 0.0.233 を固定 |
+| `src/nyxpy/framework/core/hardware/swbt/config.py` | 変更 | profile 名、path、config を正 API に変更 |
+| `src/nyxpy/framework/core/hardware/swbt/session.py` | 変更 | `create_profile()` と既存 profile の分岐、controller 所有権 |
+| `src/nyxpy/framework/core/hardware/swbt/factory.py` | 変更 | profile path cache key、Pair 前 open の削除 |
+| `src/nyxpy/framework/core/hardware/swbt/errors.py` | 変更 | profile と adapter recovery の個別 error code |
+| `src/nyxpy/framework/core/io/controller_config.py` | 変更 | workspace root 基準の profile path 解決 |
+| `src/nyxpy/framework/core/settings/global_settings.py` | 変更 | 旧設定 key の除去と新しい既定 path への移行 |
+| `src/nyxpy/cli/` | 変更 | `--profile` / `--swbt-profile` |
+| `src/nyxpy/gui/` | 変更 | 表示名、保存先、既定候補、Reconnect 有効条件 |
+| `tests/unit/` / `tests/integration/` / `tests/gui/` | 変更 | profile 契約と既存 mapper / port 回帰 |
+| `tests/hardware/` | 変更 | schema v2 profile と diagnostics evidence |
+| `docs/user-guide/` | 変更 | 操作、移行、error 対応 |
+| `docs/architecture/swbt-integration/` | 変更 | 0.5.3 の設計契約 |
+| `spec/agent/wip/local_026/SWBT_REALDEVICE_DOCS_CLOSEOUT.md` | 変更 | 実機環境変数と evidence を profile 名へ更新 |
+
+## 3. 設計方針
+
+### アーキテクチャ上の位置づけ
+
+swbt-python の非同期 lifecycle は `SwbtControllerSession` 内へ閉じる。CLI、GUI、runtime は同期 factory と `ControllerOutputPort` だけを使い、swbt controller を直接所有しない。
+
+### 公開 API 方針
+
+Project_NyX の設定と CLI は `profile` に統一する。旧 CLI option と旧 Python 属性の alias は追加しない。設定ファイルの旧 key だけは一度読み取り、新 profile の既定 path を設定して除去する。
+
+### 後方互換性
+
+破壊的変更である。旧キーストアと schema v1 profile は読み込まず、自動変換・削除・上書きもしない。移行後は別名の schema v2 profile を作成する。
+
+### レイヤー構成
+
+`framework.core.hardware.swbt` は swbt-python に依存する。GUI と CLI は framework の config、factory、error を使う。framework から GUI / CLI への逆依存は作らない。新規 global singleton は追加しない。
+
+### 性能要件
+
+| 指標 | 目標値 |
+|------|--------|
+| report period 既定値 | `8000us` を維持 |
+| 同期 bridge timeout | swbt 接続 timeout より 1 秒以上長い |
+| active session | 同一 adapter につき最大 1 |
+
+### 並行性・スレッド安全性
+
+session の `RLock` と専用 asyncio event loop thread を維持する。Pair / Reconnect のキャンセル時は coroutine の終了処理を待ち、close と loop stop の例外を失わない。GUI は lifecycle 操作を background worker で実行する。
+
+swbt-python 0.5.3 の `apply()` は送信済み入力を保証しない。Pair / Reconnect 成功後は `GamepadStatus.report_counters[0x30]` が増えるまで待ち、周期 input report の送信開始を確認してから入力を許可する。接続直後の subcommand reply holdoff 中に押下・解放を完了すると Switch へ入力が届かないためである。
+
+## 4. 実装仕様
+
+### 公開インターフェース
+
+```python
+@dataclass(frozen=True, slots=True)
+class SwbtControllerConfig:
+    model: SwbtControllerModel
+    adapter: str | None
+    profile_path: Path
+    connect_timeout_sec: float = 30.0
+    report_period_us: int | None = 8000
+
+
+class SwbtControllerSession:
+    def pair(self, *, timeout_sec: float, cancellation_event: Event | None = None) -> None: ...
+    def reconnect(
+        self,
+        *,
+        timeout_sec: float,
+        cancellation_event: Event | None = None,
+    ) -> None: ...
+```
+
+### Pair 状態遷移
+
+```text
+profileなし
+  -> controller_cls.create_profile(...)
+  -> 接続済みcontrollerをsessionが所有
+
+profileあり
+  -> controller_cls(profile_path=...)
+  -> open()
+  -> pair()
+
+Reconnect
+  -> controller_cls(profile_path=...)
+  -> open()
+  -> reconnect()
+```
+
+### 設定パラメータ
+
+| パラメータ | 型 | デフォルト | 説明 |
+|------------|-----|-----------|------|
+| `controller.swbt.profile_path` | `str | None` | controller type 別 path | schema v2 profile |
+| `controller.swbt.connect_timeout_sec` | `float` | `30.0` | Pair / Reconnect timeout |
+| `controller.swbt.report_period_us` | `int | None` | `8000` | 周期 report 間隔 |
+| `--profile` | `Path | None` | settings | swbt lifecycle command override |
+| `--swbt-profile` | `Path | None` | settings | macro run override |
+
+### エラーハンドリング
+
+| 例外クラス | NyX code |
+|------------|----------|
+| `FileNotFoundError` | `NYX_SWBT_PROFILE_NOT_FOUND` |
+| `FileExistsError` | `NYX_SWBT_PROFILE_ALREADY_EXISTS` |
+| `InvalidProfileError` | `NYX_SWBT_PROFILE_INVALID` |
+| `ProfileControllerMismatchError` | `NYX_SWBT_PROFILE_CONTROLLER_MISMATCH` |
+| `InvalidKeyStoreError` | `NYX_SWBT_PROFILE_KEY_DATA_INVALID` |
+| `AdapterIdentityRecoveryRequired` | `NYX_SWBT_ADAPTER_IDENTITY_RECOVERY_REQUIRED` |
+| input report readiness timeout | `NYX_SWBT_INPUT_REPORT_NOT_READY` |
+
+adapter identity recovery の利用者向け本文には、USB Bluetooth ドングルを抜き差ししてから再試行する手順を含める。
+
+### シングルトン管理
+
+該当なし。session と factory の lifetime は runtime builder、GUI services、CLI command が所有する。
+
+## 5. テスト方針
+
+| テスト種別 | テスト名 | 検証内容 |
+|------------|----------|----------|
+| ユニット | `test_session_pair_creates_profile_and_owns_returned_controller` | 初回作成と所有権 |
+| ユニット | `test_session_waits_for_periodic_input_report_after_reconnect` | 接続後に `0x30` 周期 input report の開始を待つ |
+| ユニット | `test_profile_errors_map_to_individual_nyx_codes` | error code の個別変換 |
+| ユニット | `test_settings_store_migrates_legacy_swbt_key_without_touching_old_file` | 旧設定除去と旧file保持 |
+| ユニット | `test_factory_*` | cache key、競合 adapter、close retry |
+| 結合 | `test_swbt_runtime_cli_integration.py` | runtime Reconnect と入力 |
+| GUI | `test_reconnect_requires_existing_profile_file` | profile file による有効条件 |
+| ハードウェア | `test_swbt_pair_realdevice` | schema v2 profile 作成と初回 Pair |
+| ハードウェア | `test_swbt_reconnect_realdevice` | active reconnect |
+| ハードウェア | `test_swbt_macro_reconnect_realdevice` | runtime factory のReconnectとマクロ入力 |
+| ハードウェア | `test_swbt_gui_lifecycle_realdevice` | GUI service のPair / Reconnect / Disconnect |
+| ハードウェア | `test_swbt_*_manual_realdevice` | Button、D-pad、stick、IMU、neutral、Joy-Con |
+
+## 6. 実装チェックリスト
+
+- [x] swbt-python 0.5.3 と Bumble 0.0.233 の依存解決
+- [x] profile 設定 model と CLI surface
+- [x] 初回 `create_profile()` と既存 profile 再Pair
+- [x] profile / adapter recovery error 変換
+- [x] 旧設定 key の除去と旧file保持
+- [x] GUI 表示名、候補、Reconnect 有効条件
+- [x] 利用者向け文書と architecture 文書
+- [x] unit / integration / GUI 全 gate
+- [x] ruff / ty / MkDocs strict gate
+- [x] Pro Controller の新規 Pair / active Reconnect / 入力 / neutral
+- [x] GUI Pair / Reconnect / Disconnect と macro Reconnect
+- [x] Joy-Con L/R の Pair / Reconnect
+- [x] diagnostics evidence と未確認範囲の記録
+
+## 7. 実機検証結果
+
+2026-07-26 に `usb:0`（CSR8510 A10）で実施した。Pro Controller は Pair、Reconnect、macro 経路の A 入力、Button、D-pad、left/right stick、16/33/50 ms short press、close 後 neutral、GUI Pair/Disconnect/Reconnect/Disconnect を確認した。Joy-Con (L)/(R) は個別 schema v2 profile の Pair と Reconnect を確認した。
+
+修正前の macro trace は protocol ready 後の periodic `0x30` report が 0 件で、close 時の neutral report だけだった。修正後は periodic report が 15 件記録され、Switch 画面で A 入力による遷移を確認した。D-pad `UPRIGHT` は観察画面で上として反映され、斜めの右成分は未確認である。IMU gyro 値自体の画面上の反映も未確認だが、送信中に切断・想定外入力は発生しなかった。

--- a/spec/agent/wip/local_026/SWBT_REALDEVICE_DOCS_CLOSEOUT.md
+++ b/spec/agent/wip/local_026/SWBT_REALDEVICE_DOCS_CLOSEOUT.md
@@ -19,7 +19,7 @@ swbt backend の実機検証、利用者向け docs 反映、完了記録を定�
 
 ### 1.3 背景・問題
 
-単体テストと dummy session では、Bluetooth adapter、pairing key、Switch 側接続状態、Joy-Con capability、stick の画面上の方向、short press の取りこぼし、close 後の入力残留を確認できない。利用者 docs では、専用 adapter、key store、CLI pair/reconnect、GUI disconnect、GUI 操作、トラブル対応を説明する必要がある。
+単体テストと dummy session では、Bluetooth adapter、pairing key、Switch 側接続状態、Joy-Con capability、stick の画面上の方向、short press の取りこぼし、close 後の入力残留を確認できない。利用者 docs では、専用 adapter、pairing profile、CLI pair/reconnect、GUI disconnect、GUI 操作、トラブル対応を説明する必要がある。
 
 ### 1.4 期待効果
 
@@ -52,7 +52,7 @@ swbt backend の実機検証、利用者向け docs 反映、完了記録を定�
 | `tests/unit/framework/hardware/swbt/test_realdevice_support.py` | 新規 | 実機テスト設定と evidence writer を単体テストする |
 | `tests/integration/test_swbt_docs_examples.py` | 新規 | docs に記載した swbt CLI 例が parser と一致することを確認する |
 | `docs/user-guide/installation.md` | 変更 | swbt が通常依存である前提へ整える。extra 導入手順は追加しない |
-| `docs/user-guide/device-setup.md` | 変更 | swbt adapter、key store、CLI pair/reconnect、GUI disconnect 手順を追加する |
+| `docs/user-guide/device-setup.md` | 変更 | swbt adapter、pairing profile、CLI pair/reconnect、GUI disconnect 手順を追加する |
 | `docs/user-guide/cli.md` | 変更 | `nyxpy swbt adapters/pair/reconnect` と `nyxpy run --controller swbt` を追加する |
 | `docs/user-guide/gui.md` | 変更 | backend selector、adapter refresh、pair、reconnect、disconnect を追加する |
 | `docs/user-guide/troubleshooting.md` | 変更 | adapter 未選択、不検出、pair timeout、reconnect 失敗、unsupported input、disconnect の限界、short press を追加する |
@@ -75,7 +75,7 @@ swbt backend の実機検証、利用者向け docs 反映、完了記録を定�
 
 | ファイル | 内容 | commit 対象 |
 |----------|------|-------------|
-| `run-metadata.json` | OS、NyX commit、swbt-python version、controller type、adapter、key store、test command | 原則 commit しない |
+| `run-metadata.json` | OS、NyX commit、swbt-python version、controller type、adapter、pairing profile、test command | 原則 commit しない |
 | `swbt-trace.jsonl` | diagnostics writer 由来の pair/reconnect/report/neutral/disconnect trace | 原則 commit しない |
 | `operator-confirmation.jsonl` | 画面観察の `pass` / `fail` / `skip` | 原則 commit しない |
 | `summary.md` | 検証結果、失敗条件、docs 反映先 | 必要な要約だけ complete 仕様へ転記 |
@@ -84,7 +84,7 @@ swbt backend の実機検証、利用者向け docs 反映、完了記録を定�
 
 ### controller type 別確認
 
-Pro Controller、Joy-Con L、Joy-Con R は別 key store を使う。Joy-Con L は right stick、Joy-Con R は left stick を unsupported として明確に失敗させる。unsupported input は実機確認の前に単体テストで固定し、実機では選択 controller type に存在する入力だけを確認する。
+Pro Controller、Joy-Con L、Joy-Con R は別 pairing profile を使う。Joy-Con L は right stick、Joy-Con R は left stick を unsupported として明確に失敗させる。unsupported input は実機確認の前に単体テストで固定し、実機では選択 controller type に存在する入力だけを確認する。
 
 ### stick Y 軸と short press
 
@@ -109,7 +109,7 @@ serial backend を置き換えず、serial と swbt を並列に説明する。s
 class SwbtRealDeviceOptions:
     adapter: str
     controller_type: str
-    key_store_path: Path
+    profile_path: Path
     evidence_dir: Path
     timeout_sec: float = 30.0
     operator_confirmation: bool = False
@@ -124,7 +124,7 @@ class SwbtRealDeviceOptions:
 | `NYX_SWBT` | `str` | なし | `1` のとき swbt 実機テストを実行可能 |
 | `NYX_SWBT_ADAPTER` | `str` | なし | adapter 名 |
 | `NYX_SWBT_CONTROLLER_TYPE` | `str` | `"pro-controller"` | controller type |
-| `NYX_SWBT_KEY_STORE` | `Path` | `.nyxpy/swbt/<controller>-test-bond.json` | 実機テスト用 key store |
+| `NYX_SWBT_PROFILE` | `Path` | `.nyxpy/swbt/<controller>-test-profile.json` | 実機テスト用 pairing profile |
 | `NYX_SWBT_TIMEOUT` | `float` | `30.0` | pair/reconnect timeout |
 | `NYX_SWBT_EVIDENCE_DIR` | `Path | None` | `tmp/hardware/swbt/<日時>/` | 証跡保存先 |
 | `NYX_SWBT_OPERATOR_CONFIRMATION` | `str` | なし | `1` のとき画面観察を要するテストを実行 |
@@ -137,8 +137,10 @@ class SwbtRealDeviceOptions:
 | テスト | 自動判定 | operator confirmation | 検証内容 |
 |--------|----------|-----------------------|----------|
 | `test_swbt_adapter_discovery_realdevice` | あり | 不要 | adapter が `list_adapters()` で見える |
-| `test_swbt_pair_realdevice` | あり | 必須 | pairing 成功と key store 作成 |
-| `test_swbt_reconnect_realdevice` | あり | 不要 | 保存済み key store で reconnect |
+| `test_swbt_pair_realdevice` | あり | 必須 | pairing 成功、pairing profile 作成、`schema_version == 2` |
+| `test_swbt_reconnect_realdevice` | あり | 不要 | 保存済み pairing profile で reconnect |
+| `test_swbt_macro_reconnect_realdevice` | あり | 必須 | runtime factory と `DefaultCommand` を通した reconnect / input |
+| `test_swbt_gui_lifecycle_realdevice` | あり | 必須 | GUI service の Pair / Disconnect / Reconnect / Disconnect |
 | `test_swbt_button_dpad_manual_realdevice` | trace は自動 | 必須 | Button、D-pad の反映 |
 | `test_swbt_stick_manual_realdevice` | trace は自動 | 必須 | left / right stick と Y 軸 |
 | `test_swbt_imu_realdevice` | trace は自動 | 必要に応じて必須 | `Command.imu(IMUFrame.neutral())` と gyro frame |
@@ -162,7 +164,7 @@ $env:NYX_REALDEVICE = "1"
 $env:NYX_SWBT = "1"
 $env:NYX_SWBT_ADAPTER = "usb:0"
 $env:NYX_SWBT_CONTROLLER_TYPE = "pro-controller"
-$env:NYX_SWBT_KEY_STORE = ".nyxpy/swbt/pro-controller-test-bond.json"
+$env:NYX_SWBT_PROFILE = ".nyxpy/swbt/pro-controller-test-profile.json"
 uv run pytest tests/hardware -m "realdevice and swbt"
 ```
 
@@ -181,15 +183,15 @@ $env:NYX_SWBT_OPERATOR_RESULTS = '{"test_swbt_pair_realdevice":"pass","test_swbt
 uv run pytest tests/hardware -m "realdevice and swbt" -s
 ```
 
-Joy-Con は key store を分ける。
+Joy-Con は pairing profile を分ける。
 
 ```console
 $env:NYX_SWBT_CONTROLLER_TYPE = "joy-con-l"
-$env:NYX_SWBT_KEY_STORE = ".nyxpy/swbt/joy-con-l-test-bond.json"
+$env:NYX_SWBT_PROFILE = ".nyxpy/swbt/joy-con-l-test-profile.json"
 uv run pytest tests/hardware -m "realdevice and swbt" -s
 
 $env:NYX_SWBT_CONTROLLER_TYPE = "joy-con-r"
-$env:NYX_SWBT_KEY_STORE = ".nyxpy/swbt/joy-con-r-test-bond.json"
+$env:NYX_SWBT_PROFILE = ".nyxpy/swbt/joy-con-r-test-profile.json"
 uv run pytest tests/hardware -m "realdevice and swbt" -s
 ```
 
@@ -198,10 +200,10 @@ uv run pytest tests/hardware -m "realdevice and swbt" -s
 | docs | 追加内容 |
 |------|----------|
 | `installation.md` | swbt は通常依存であるため extra 導入手順を書かない |
-| `device-setup.md` | 専用 adapter、adapter discovery、key store、CLI pair/reconnect、GUI disconnect |
+| `device-setup.md` | 専用 adapter、adapter discovery、pairing profile、CLI pair/reconnect、GUI disconnect |
 | `cli.md` | `nyxpy swbt adapters/pair/reconnect`、`nyxpy run --controller swbt` |
 | `gui.md` | backend selector、Refresh adapters、Pair、Reconnect、Disconnect |
-| `troubleshooting.md` | adapter 未選択、不検出、timeout、key store 不正、unsupported input、disconnect の限界、short press |
+| `troubleshooting.md` | adapter 未選択、不検出、timeout、pairing profile 不正、unsupported input、disconnect の限界、short press |
 | `command-api.md` | `Command.imu(...)`、IMU frame 数、非対応 backend |
 | `docs/architecture/swbt-integration/` | optional dependency、adapter 自動採用、session start、button 名、diagnostics path 前提を修正 |
 | `testing-rollout.md` | stick Y 軸、short press、public flush 要否 |
@@ -211,8 +213,8 @@ uv run pytest tests/hardware -m "realdevice and swbt" -s
 | 条件 | 記録 |
 |------|------|
 | adapter 不検出 | adapter 名、aliases、VID/PID の有無 |
-| pair timeout | Switch 側状態、controller type、key store path |
-| reconnect 失敗 | key store の有無、不正判定、controller type 不一致 |
+| pair timeout | Switch 側状態、controller type、pairing profile path |
+| reconnect 失敗 | pairing profile の有無、不正判定、controller type 不一致 |
 | unsupported input | controller type、入力名、error code |
 | short press 失敗 | duration、pressed report 有無、neutral report 有無、画面観察 |
 
@@ -232,7 +234,7 @@ uv run pytest tests/hardware -m "realdevice and swbt" -s
 | 結合 | `test_swbt_docs_examples_match_cli_parser` | docs の CLI 例が parser と一致 |
 | 結合 | `test_mkdocs_build_includes_swbt_pages` | swbt docs 追加後の `mkdocs build --strict` |
 | ハードウェア | `test_swbt_adapter_discovery_realdevice` | adapter discovery |
-| ハードウェア | `test_swbt_pair_realdevice` | pairing と key store 作成 |
+| ハードウェア | `test_swbt_pair_realdevice` | pairing と pairing profile 作成 |
 | ハードウェア | `test_swbt_reconnect_realdevice` | reconnect |
 | ハードウェア | `test_swbt_button_dpad_manual_realdevice` | Button / D-pad |
 | ハードウェア | `test_swbt_stick_manual_realdevice` | stick と Y 軸 |
@@ -279,7 +281,7 @@ uv run mkdocs build --strict
 - `tests/hardware/swbt_realdevice_support.py`: 環境変数から `SwbtRealDeviceOptions` を構築し、`run-metadata.json`、`swbt-trace.jsonl`、`operator-confirmation.jsonl`、`summary.md` を evidence directory に出力する。
 - `tests/hardware/test_swbt_controller_backend_realdevice.py`: adapter discovery、pair、reconnect、button / D-pad、stick、`Command.imu(...)`、close neutral、`Command.press(..., dur=...)` short press を分けて検証する。
 - `conftest.py`: swbt 実機テストだけは `NYX_REALDEVICE=1` と `NYX_SWBT=1` で `--realdevice` なしでも環境変数 gate へ進める。
-- `src/nyxpy/framework/core/hardware/swbt/session.py`: swbt-python 0.2 系の lifecycle / input API は async、status は同期 API として扱い、session 内部の event loop thread で完了待ちする。
+- `src/nyxpy/framework/core/hardware/swbt/session.py`: swbt-python 0.5.3 の `create_profile()` と lifecycle / input API は async、status は同期 API として扱い、session 内部の event loop thread で完了待ちする。
 - 利用者 docs: installation、device setup、CLI、GUI、troubleshooting に swbt backend を追加した。
 - macro development docs: `Command.imu(...)` と swbt 非対応入力を追加した。
 - architecture docs: swbt 通常依存、adapter 自動採用なし、diagnostics path 非公開、現行 public API 前提へ更新した。
@@ -288,7 +290,7 @@ uv run mkdocs build --strict
 
 ## 8. 2026-07-10 統合監査追補
 
-非実機監査で stick 座標変換、status 判定、GUI worker、adapter 正規化、relative key store、production diagnostics、CLI surface、operator result を修正した。`uv run mkdocs build --strict` と docs integration test は非実機環境で実行するが、これらを実機検証の代替にはしない。
+非実機監査で stick 座標変換、status 判定、GUI worker、adapter 正規化、relative pairing profile、production diagnostics、CLI surface、operator result を修正した。`uv run mkdocs build --strict` と docs integration test は非実機環境で実行するが、これらを実機検証の代替にはしない。
 
 未検証のまま残す項目:
 

--- a/src/nyxpy/cli/run_cli.py
+++ b/src/nyxpy/cli/run_cli.py
@@ -293,6 +293,13 @@ def cli_main(
         logger = logging.logger
 
         settings = SettingsStore(config_dir=paths.config_dir, strict_load=False)
+        for notice in settings.migration_notices:
+            logger.user(
+                "WARNING",
+                notice,
+                component="CLI",
+                event="configuration.migrated",
+            )
         controller_config = _controller_config_from_args(
             args,
             settings_snapshot=settings.snapshot(),
@@ -405,10 +412,10 @@ def add_run_arguments(parser: argparse.ArgumentParser) -> None:
         help="swbt controller type override",
     )
     parser.add_argument(
-        "--swbt-key-store",
+        "--swbt-profile",
         type=pathlib.Path,
         default=None,
-        help="swbt pairing key store path override",
+        help="swbt pairing profile path override",
     )
     parser.add_argument(
         "--swbt-timeout",
@@ -441,7 +448,7 @@ def _controller_config_from_args(
         serial_baudrate=getattr(args, "baud", None),
         swbt_adapter=getattr(args, "swbt_adapter", None),
         swbt_controller_type=getattr(args, "swbt_controller_type", None),
-        swbt_key_store_path=getattr(args, "swbt_key_store", None),
+        swbt_profile_path=getattr(args, "swbt_profile", None),
         swbt_connect_timeout_sec=getattr(args, "swbt_timeout", None),
     )
     if isinstance(config, SerialControllerConfig):

--- a/src/nyxpy/cli/swbt_cli.py
+++ b/src/nyxpy/cli/swbt_cli.py
@@ -73,6 +73,7 @@ def cli_main(
                 args,
                 settings_store=settings_store,
                 project_root=project_root,
+                output=output,
             )
             config = canonicalize_swbt_adapter(
                 config,
@@ -128,10 +129,10 @@ def _add_lifecycle_options(parser: argparse.ArgumentParser) -> None:
         help="swbt controller type override",
     )
     parser.add_argument(
-        "--key-store",
+        "--profile",
         type=Path,
         default=None,
-        help="swbt pairing key store path override",
+        help="swbt pairing profile path override",
     )
     parser.add_argument(
         "--timeout",
@@ -146,6 +147,7 @@ def _controller_config_from_args(
     *,
     settings_store: SettingsStore | None,
     project_root: Path | None,
+    output: TextIO,
 ) -> SwbtControllerConfig:
     resolved_root = resolve_project_root(
         explicit_root=project_root,
@@ -153,13 +155,15 @@ def _controller_config_from_args(
     )
     paths = ensure_workspace(resolved_root)
     settings = settings_store or SettingsStore(config_dir=paths.config_dir, strict_load=False)
+    for notice in settings.migration_notices:
+        print(f"WARNING: {notice}", file=output)
     config = controller_config_from_overrides(
         settings.snapshot(),
         workspace_root=paths.project_root,
         backend="swbt",
         swbt_adapter=getattr(args, "adapter", None),
         swbt_controller_type=getattr(args, "controller_type", None),
-        swbt_key_store_path=getattr(args, "key_store", None),
+        swbt_profile_path=getattr(args, "profile", None),
         swbt_connect_timeout_sec=getattr(args, "timeout", None),
     )
     if not isinstance(config, SwbtControllerConfig):

--- a/src/nyxpy/framework/core/hardware/swbt/config.py
+++ b/src/nyxpy/framework/core/hardware/swbt/config.py
@@ -32,7 +32,7 @@ class SwbtControllerModel:
 
     controller_type: SwbtControllerType
     display_name: str
-    default_key_store_name: str
+    default_profile_name: str
     capabilities: SwbtInputCapabilities
 
     @property
@@ -40,9 +40,9 @@ class SwbtControllerModel:
         """Settings / CLI に保存する文字列表現。"""
         return self.controller_type.value
 
-    def default_key_store_path(self, base_dir: Path = Path(".nyxpy/swbt")) -> Path:
-        """Controller type ごとの既定 pairing key path を返す。"""
-        return base_dir / self.default_key_store_name
+    def default_profile_path(self, base_dir: Path = Path(".nyxpy/swbt")) -> Path:
+        """Controller type ごとの既定 pairing profile path を返す。"""
+        return base_dir / self.default_profile_name
 
 
 @dataclass(frozen=True, slots=True)
@@ -51,7 +51,7 @@ class SwbtControllerConfig:
 
     model: SwbtControllerModel
     adapter: str | None
-    key_store_path: Path
+    profile_path: Path
     connect_timeout_sec: float = 30.0
     report_period_us: int | None = 8000
 
@@ -84,7 +84,7 @@ SUPPORTED_CONTROLLER_MODELS: dict[SwbtControllerType, SwbtControllerModel] = {
     SwbtControllerType.PRO_CONTROLLER: SwbtControllerModel(
         controller_type=SwbtControllerType.PRO_CONTROLLER,
         display_name="Pro Controller",
-        default_key_store_name="pro-controller-bond.json",
+        default_profile_name="pro-controller-profile.json",
         capabilities=SwbtInputCapabilities(
             buttons=_PRO_BUTTONS,
             left_stick=True,
@@ -95,7 +95,7 @@ SUPPORTED_CONTROLLER_MODELS: dict[SwbtControllerType, SwbtControllerModel] = {
     SwbtControllerType.JOY_CON_L: SwbtControllerModel(
         controller_type=SwbtControllerType.JOY_CON_L,
         display_name="Joy-Con L",
-        default_key_store_name="joy-con-l-bond.json",
+        default_profile_name="joy-con-l-profile.json",
         capabilities=SwbtInputCapabilities(
             buttons=_JOY_CON_L_BUTTONS,
             left_stick=True,
@@ -106,7 +106,7 @@ SUPPORTED_CONTROLLER_MODELS: dict[SwbtControllerType, SwbtControllerModel] = {
     SwbtControllerType.JOY_CON_R: SwbtControllerModel(
         controller_type=SwbtControllerType.JOY_CON_R,
         display_name="Joy-Con R",
-        default_key_store_name="joy-con-r-bond.json",
+        default_profile_name="joy-con-r-profile.json",
         capabilities=SwbtInputCapabilities(
             buttons=_JOY_CON_R_BUTTONS,
             left_stick=False,

--- a/src/nyxpy/framework/core/hardware/swbt/errors.py
+++ b/src/nyxpy/framework/core/hardware/swbt/errors.py
@@ -27,6 +27,27 @@ def swbt_connect_cancel_code(error: BaseException) -> str | None:
     return None
 
 
+def swbt_user_error_message(error: BaseException) -> str:
+    """利用者が原因を特定できる swbt error code と本文を返す。"""
+    coded_error = _first_swbt_coded_error(error)
+    if coded_error is None:
+        return str(error)
+    code, cause = coded_error
+    return f"{code}: {cause}"
+
+
+def _first_swbt_coded_error(error: BaseException) -> tuple[str, BaseException] | None:
+    code = getattr(error, "code", None)
+    if isinstance(code, str) and code.startswith("NYX_SWBT_"):
+        return code, error
+    if isinstance(error, BaseExceptionGroup):
+        for nested in error.exceptions:
+            coded_error = _first_swbt_coded_error(nested)
+            if coded_error is not None:
+                return coded_error
+    return None
+
+
 def is_swbt_pair_cancelled(error: BaseException) -> bool:
     """Pair cancellation の後方互換 helper。"""
     return getattr(error, "code", None) == "NYX_SWBT_PAIR_CANCELLED" or (
@@ -127,6 +148,49 @@ def swbt_input_invalid(message: str, *, component: str = "NyxSwbtInputMapper") -
 def map_swbt_exception(exc: BaseException, *, component: str) -> ConfigurationError | DeviceError:
     """swbt-python の公開例外を framework error に変換する。"""
     name = type(exc).__name__
+    if isinstance(exc, FileNotFoundError):
+        return ConfigurationError(
+            "swbt pairing profile was not found; run Pair to create it",
+            code="NYX_SWBT_PROFILE_NOT_FOUND",
+            component=component,
+            cause=exc,
+        )
+    if isinstance(exc, FileExistsError):
+        return ConfigurationError(
+            "swbt pairing profile already exists",
+            code="NYX_SWBT_PROFILE_ALREADY_EXISTS",
+            component=component,
+            cause=exc,
+        )
+    if name == "ProfileControllerMismatchError":
+        return ConfigurationError(
+            "swbt pairing profile belongs to a different controller type",
+            code="NYX_SWBT_PROFILE_CONTROLLER_MISMATCH",
+            component=component,
+            details={
+                "expected_controller_kind": str(getattr(exc, "expected_controller_kind", "")),
+                "actual_controller_kind": str(getattr(exc, "actual_controller_kind", "")),
+            },
+            cause=exc,
+        )
+    if name == "InvalidProfileError":
+        return ConfigurationError(
+            "swbt pairing profile is invalid or uses an unsupported schema",
+            code="NYX_SWBT_PROFILE_INVALID",
+            component=component,
+            cause=exc,
+        )
+    if name == "AdapterIdentityRecoveryRequired":
+        return ConfigurationError(
+            "swbt adapter identity recovery is required; unplug and reconnect the USB Bluetooth dongle before retrying",
+            code="NYX_SWBT_ADAPTER_IDENTITY_RECOVERY_REQUIRED",
+            component=component,
+            details={
+                "target_address": str(getattr(exc, "target_address", "")),
+                "stage": str(getattr(exc, "stage", "")),
+            },
+            cause=exc,
+        )
     if name == "TransportOpenError":
         return ConfigurationError(
             "swbt transport open failed",
@@ -150,8 +214,8 @@ def map_swbt_exception(exc: BaseException, *, component: str) -> ConfigurationEr
         )
     if name == "InvalidKeyStoreError":
         return ConfigurationError(
-            "swbt key store is invalid",
-            code="NYX_SWBT_KEY_STORE_INVALID",
+            "swbt pairing profile contains invalid key data",
+            code="NYX_SWBT_PROFILE_KEY_DATA_INVALID",
             component=component,
             cause=exc,
         )

--- a/src/nyxpy/framework/core/hardware/swbt/factory.py
+++ b/src/nyxpy/framework/core/hardware/swbt/factory.py
@@ -27,7 +27,7 @@ class SwbtSessionKey:
 
     controller_type: SwbtControllerType
     adapter: str | None
-    key_store_path: Path
+    profile_path: Path
     report_period_us: int | None
 
 
@@ -109,7 +109,6 @@ class SwbtControllerOutputPortFactory:
             self._prepare_active_port_replacement(key)
             session = self._session_for(config)
             try:
-                session.open()
                 effective_timeout = timeout_sec or config.connect_timeout_sec
                 if cancellation_event is None:
                     session.pair(timeout_sec=effective_timeout)
@@ -360,7 +359,7 @@ def session_key(config: SwbtControllerConfig) -> SwbtSessionKey:
     return SwbtSessionKey(
         controller_type=config.model.controller_type,
         adapter=config.adapter,
-        key_store_path=config.key_store_path,
+        profile_path=config.profile_path,
         report_period_us=config.report_period_us,
     )
 

--- a/src/nyxpy/framework/core/hardware/swbt/session.py
+++ b/src/nyxpy/framework/core/hardware/swbt/session.py
@@ -21,6 +21,13 @@ from nyxpy.framework.core.hardware.swbt.errors import (
 from nyxpy.framework.core.macro.exceptions import ConfigurationError, DeviceError
 
 type SwbtControllerFactory = Callable[[SwbtControllerConfig, DiagnosticsWriter | None], object]
+type SwbtProfileCreator = Callable[
+    [SwbtControllerConfig, DiagnosticsWriter | None, float],
+    object,
+]
+
+_INPUT_REPORT_ID = 0x30
+_DEFAULT_REPORT_PERIOD_US = 8000
 
 
 class SwbtControllerSessionProtocol(Protocol):
@@ -68,11 +75,13 @@ class SwbtControllerSession:
         config: SwbtControllerConfig,
         *,
         controller_factory: SwbtControllerFactory | None = None,
+        profile_creator: SwbtProfileCreator | None = None,
         diagnostics_writer: DiagnosticsWriter | None = None,
     ) -> None:
         """config、controller factory、diagnostics writer を保持する。"""
         self.config = config
         self._controller_factory = controller_factory or create_swbt_controller
+        self._profile_creator = profile_creator or create_swbt_profile
         self._diagnostics_writer = diagnostics_writer
         self._controller: object | None = None
         self._lock = RLock()
@@ -130,17 +139,27 @@ class SwbtControllerSession:
     def pair(self, *, timeout_sec: float, cancellation_event: Event | None = None) -> None:
         """明示 pairing を実行する。"""
         with self._lock:
-            self.open()
-            controller = self._require_controller()
             try:
-                self._call_controller(
-                    controller,
-                    "pair",
-                    timeout=timeout_sec,
-                    _wait_timeout_sec=self._connection_wait_timeout(timeout_sec),
-                    _cancellation_event=cancellation_event,
-                    _cancellation_code="NYX_SWBT_PAIR_CANCELLED",
-                )
+                if self._profile_exists():
+                    self.open()
+                    controller = self._require_controller()
+                    self._call_controller(
+                        controller,
+                        "pair",
+                        timeout=timeout_sec,
+                        _wait_timeout_sec=self._connection_wait_timeout(timeout_sec),
+                        _cancellation_event=cancellation_event,
+                        _cancellation_code="NYX_SWBT_PAIR_CANCELLED",
+                    )
+                else:
+                    self._require_adapter()
+                    controller = self._create_profile_controller(
+                        timeout_sec=timeout_sec,
+                        cancellation_event=cancellation_event,
+                    )
+                    self._controller = controller
+                    self._opened = True
+                    self._closed = False
                 status = self._call_controller(controller, "status")
             except (ConfigurationError, DeviceError):
                 raise
@@ -149,9 +168,16 @@ class SwbtControllerSession:
             self._connected = is_swbt_status_connected(status)
             if not self._connected:
                 raise swbt_not_connected(type(self).__name__)
+            self._wait_for_input_reporting(
+                controller,
+                status,
+                timeout_sec=timeout_sec,
+                cancellation_event=cancellation_event,
+                cancellation_code="NYX_SWBT_PAIR_CANCELLED",
+            )
 
     def reconnect(self, *, timeout_sec: float, cancellation_event: Event | None = None) -> None:
-        """保存済み pairing key に基づく reconnect を実行する。"""
+        """保存済み pairing profile に基づく reconnect を実行する。"""
         with self._lock:
             self.open()
             controller = self._require_controller()
@@ -172,6 +198,13 @@ class SwbtControllerSession:
             self._connected = is_swbt_status_connected(status)
             if not self._connected:
                 raise swbt_not_connected(type(self).__name__)
+            self._wait_for_input_reporting(
+                controller,
+                status,
+                timeout_sec=timeout_sec,
+                cancellation_event=cancellation_event,
+                cancellation_code="NYX_SWBT_RECONNECT_CANCELLED",
+            )
 
     def apply(self, state: object) -> None:
         """完全な swbt InputState を controller へ適用する。"""
@@ -252,6 +285,81 @@ class SwbtControllerSession:
         if self._controller is None:
             raise swbt_not_connected(type(self).__name__)
         return self._controller
+
+    def _require_adapter(self) -> str:
+        if not self.config.adapter:
+            raise swbt_configuration_error(
+                "swbt adapter is not selected",
+                code="NYX_SWBT_ADAPTER_NOT_SELECTED",
+                component=type(self).__name__,
+            )
+        return self.config.adapter
+
+    def _profile_exists(self) -> bool:
+        return self.config.profile_path.is_file()
+
+    def _create_profile_controller(
+        self,
+        *,
+        timeout_sec: float,
+        cancellation_event: Event | None,
+    ) -> object:
+        result = self._profile_creator(
+            self.config,
+            self._diagnostics_writer,
+            timeout_sec,
+        )
+        if not inspect.isawaitable(result):
+            return result
+        self._ensure_loop_locked()
+        return self._run_awaitable(
+            result,
+            timeout_sec=self._connection_wait_timeout(timeout_sec),
+            cancellation_event=cancellation_event,
+            cancellation_code="NYX_SWBT_PAIR_CANCELLED",
+        )
+
+    def _wait_for_input_reporting(
+        self,
+        controller: object,
+        status: object,
+        *,
+        timeout_sec: float,
+        cancellation_event: Event | None,
+        cancellation_code: str,
+    ) -> None:
+        """接続完了後に最初の周期 input report が送信されるまで待つ。"""
+        initial_count = _input_report_count(status)
+        if initial_count is None:
+            return
+        period_sec = (self.config.report_period_us or _DEFAULT_REPORT_PERIOD_US) / 1_000_000
+        readiness_timeout_sec = min(
+            max(1.0, period_sec * 4),
+            max(1.0, timeout_sec),
+        )
+        deadline = time.monotonic() + readiness_timeout_sec
+        poll_interval_sec = min(max(period_sec, 0.001), 0.05)
+        while time.monotonic() < deadline:
+            if cancellation_event is not None and cancellation_event.is_set():
+                raise DeviceError(
+                    "swbt connection operation was cancelled",
+                    code=cancellation_code,
+                    component=type(self).__name__,
+                    recoverable=True,
+                )
+            time.sleep(poll_interval_sec)
+            current_status = self._call_controller(controller, "status")
+            if not is_swbt_status_connected(current_status):
+                self._connected = False
+                raise swbt_not_connected(type(self).__name__)
+            current_count = _input_report_count(current_status)
+            if current_count is not None and current_count > initial_count:
+                return
+        raise swbt_configuration_error(
+            "swbt periodic input reporting did not become ready",
+            code="NYX_SWBT_INPUT_REPORT_NOT_READY",
+            component=type(self).__name__,
+        )
 
     def _require_connected_controller(self) -> object:
         if not self.connected:
@@ -430,6 +538,14 @@ async def _await_result(awaitable: Awaitable[object], completed: Event) -> objec
         completed.set()
 
 
+def _input_report_count(status: object) -> int | None:
+    counters = getattr(status, "report_counters", None)
+    if not isinstance(counters, dict):
+        return None
+    count = counters.get(_INPUT_REPORT_ID)
+    return count if isinstance(count, int) else None
+
+
 class DummySwbtControllerSession:
     """実機なしテストで InputState を記録する session double。"""
 
@@ -490,17 +606,43 @@ def create_swbt_controller(
 ) -> object:
     """SwbtControllerConfig から swbt controller instance を作る。"""
     controller_cls = resolve_swbt_controller_class(config.model.controller_type)
-    diagnostics = None
-    if diagnostics_writer is not None:
-        from swbt import DiagnosticsConfig
-
-        diagnostics = DiagnosticsConfig(trace_writer=cast(TextIO, diagnostics_writer))
     return controller_cls(
         adapter=config.adapter,
-        key_store_path=str(config.key_store_path),
+        profile_path=str(config.profile_path),
         report_period_us=config.report_period_us,
-        diagnostics=diagnostics,
+        diagnostics=_create_diagnostics_config(diagnostics_writer),
     )
+
+
+def create_swbt_profile(
+    config: SwbtControllerConfig,
+    diagnostics_writer: DiagnosticsWriter | None,
+    timeout_sec: float,
+) -> object:
+    """新しい v2 profile を作成し、接続済み controller を返す。"""
+    if not config.adapter:
+        raise swbt_configuration_error(
+            "swbt adapter is not selected",
+            code="NYX_SWBT_ADAPTER_NOT_SELECTED",
+            component="SwbtControllerSession",
+        )
+    controller_cls = resolve_swbt_controller_class(config.model.controller_type)
+    return controller_cls.create_profile(
+        adapter=config.adapter,
+        profile_path=str(config.profile_path),
+        local_address=None,
+        pair_timeout=timeout_sec,
+        report_period_us=config.report_period_us,
+        diagnostics=_create_diagnostics_config(diagnostics_writer),
+    )
+
+
+def _create_diagnostics_config(diagnostics_writer: DiagnosticsWriter | None) -> object | None:
+    if diagnostics_writer is None:
+        return None
+    from swbt import DiagnosticsConfig
+
+    return DiagnosticsConfig(trace_writer=cast(TextIO, diagnostics_writer))
 
 
 def resolve_swbt_controller_class(controller_type: SwbtControllerType):

--- a/src/nyxpy/framework/core/io/controller_config.py
+++ b/src/nyxpy/framework/core/io/controller_config.py
@@ -58,15 +58,15 @@ def controller_config_from_settings(
     model = resolve_controller_model(
         str(dotted_get(settings, "controller.swbt.controller_type", "pro-controller"))
     )
-    key_store = _key_store_path(
-        dotted_get(settings, "controller.swbt.key_store_path", None),
-        default=model.default_key_store_path(_default_swbt_key_store_dir(workspace_root)),
+    profile_path = _profile_path(
+        dotted_get(settings, "controller.swbt.profile_path", None),
+        default=model.default_profile_path(_default_swbt_profile_dir(workspace_root)),
         workspace_root=workspace_root,
     )
     return SwbtControllerConfig(
         model=model,
         adapter=_optional_name(dotted_get(settings, "controller.swbt.adapter", None)),
-        key_store_path=key_store,
+        profile_path=profile_path,
         connect_timeout_sec=_positive_float(
             dotted_get(settings, "controller.swbt.connect_timeout_sec", 30.0),
             key="controller.swbt.connect_timeout_sec",
@@ -88,7 +88,7 @@ def controller_config_from_overrides(
     serial_baudrate: int | None = None,
     swbt_adapter: str | None = None,
     swbt_controller_type: str | None = None,
-    swbt_key_store_path: Path | str | None = None,
+    swbt_profile_path: Path | str | None = None,
     swbt_connect_timeout_sec: float | None = None,
 ) -> ControllerConfig:
     """Settings の copy に CLI override を重ねて ControllerConfig を作る。"""
@@ -105,8 +105,8 @@ def controller_config_from_overrides(
         dotted_set(data, "controller.swbt.adapter", swbt_adapter)
     if swbt_controller_type is not None:
         dotted_set(data, "controller.swbt.controller_type", swbt_controller_type)
-    if swbt_key_store_path is not None:
-        dotted_set(data, "controller.swbt.key_store_path", str(swbt_key_store_path))
+    if swbt_profile_path is not None:
+        dotted_set(data, "controller.swbt.profile_path", str(swbt_profile_path))
     if swbt_connect_timeout_sec is not None:
         dotted_set(data, "controller.swbt.connect_timeout_sec", swbt_connect_timeout_sec)
     return controller_config_from_settings(data, workspace_root=workspace_root)
@@ -138,13 +138,13 @@ def _reject_legacy_serial_keys(settings: Mapping[str, Any]) -> None:
     )
 
 
-def _default_swbt_key_store_dir(workspace_root: Path | None) -> Path:
+def _default_swbt_profile_dir(workspace_root: Path | None) -> Path:
     if workspace_root is None:
         return Path(".nyxpy") / "swbt"
     return Path(workspace_root) / ".nyxpy" / "swbt"
 
 
-def _key_store_path(
+def _profile_path(
     value: object,
     *,
     default: Path,

--- a/src/nyxpy/framework/core/settings/global_settings.py
+++ b/src/nyxpy/framework/core/settings/global_settings.py
@@ -1,6 +1,6 @@
 """NyX workspace の global settings store。"""
 
-from collections.abc import Mapping
+from collections.abc import Mapping, MutableMapping
 from pathlib import Path
 from threading import RLock
 from typing import Any
@@ -102,8 +102,8 @@ GLOBAL_SETTINGS_SCHEMA = SettingsSchema(
             (str, type(None)),
             None,
         ),
-        "controller.swbt.key_store_path": SettingField(
-            "controller.swbt.key_store_path",
+        "controller.swbt.profile_path": SettingField(
+            "controller.swbt.profile_path",
             (str, type(None)),
             None,
         ),
@@ -171,6 +171,7 @@ class SettingsStore:
         self.strict_load = strict_load
         self._lock = RLock()
         self.data: dict[str, SettingValue] = {}
+        self.migration_notices: tuple[str, ...] = ()
         self.load()
 
     def load(self) -> None:
@@ -178,9 +179,18 @@ class SettingsStore:
             try:
                 if self.config_path.exists():
                     loaded = tomlkit.loads(self.config_path.read_text(encoding="utf-8"))
+                    migrated = _migrate_swbt_profile_settings(loaded)
                     self.data = self.schema.validate(loaded)
+                    if migrated:
+                        self.migration_notices = (
+                            "旧 swbt キーストア設定を削除しました。新しいペアリングプロファイルで再ペアリングしてください。",
+                        )
+                        self.save()
+                    else:
+                        self.migration_notices = ()
                 else:
                     self.data = self.schema.defaults()
+                    self.migration_notices = ()
                     self.save()
             except TOMLKitError as exc:
                 if self.strict_load:
@@ -195,10 +205,12 @@ class SettingsStore:
                         cause=exc,
                     ) from exc
                 self.data = self.schema.defaults()
+                self.migration_notices = ()
             except ConfigurationError:
                 if self.strict_load:
                     raise
                 self.data = self.schema.defaults()
+                self.migration_notices = ()
 
     def save(self) -> None:
         with self._lock:
@@ -239,3 +251,25 @@ def _drop_none(value: Any) -> Any:
     if isinstance(value, list):
         return [_drop_none(item) for item in value]
     return value
+
+
+def _migrate_swbt_profile_settings(data: MutableMapping[str, Any]) -> bool:
+    """旧 key_store_path を除去し、新しい既定 profile path を設定する。"""
+    controller = data.get("controller")
+    if not isinstance(controller, MutableMapping):
+        return False
+    swbt = controller.get("swbt")
+    if not isinstance(swbt, MutableMapping) or "key_store_path" not in swbt:
+        return False
+
+    swbt.pop("key_store_path")
+    if swbt.get("profile_path") in (None, ""):
+        controller_type = str(swbt.get("controller_type", "pro-controller"))
+        profile_names = {
+            "pro-controller": "pro-controller-profile.json",
+            "joy-con-l": "joy-con-l-profile.json",
+            "joy-con-r": "joy-con-r-profile.json",
+        }
+        profile_name = profile_names.get(controller_type, "pro-controller-profile.json")
+        swbt["profile_path"] = f".nyxpy/swbt/{profile_name}"
+    return True

--- a/src/nyxpy/gui/app_services.py
+++ b/src/nyxpy/gui/app_services.py
@@ -111,7 +111,7 @@ CONTROLLER_SETTING_KEYS = frozenset(
         "controller.serial.protocol",
         "controller.swbt.adapter",
         "controller.swbt.controller_type",
-        "controller.swbt.key_store_path",
+        "controller.swbt.profile_path",
         "controller.swbt.connect_timeout_sec",
         "controller.swbt.report_period_us",
     }
@@ -150,6 +150,13 @@ class GuiAppServices:
             run_retention_days=int(self.global_settings.get("logging.run_retention_days", 30)),
         )
         self.logger = self.logging.logger
+        for notice in self.global_settings.migration_notices:
+            self.logger.user(
+                "WARNING",
+                notice,
+                component="GuiAppServices",
+                event="configuration.migrated",
+            )
         self.device_discovery = DeviceDiscoveryService(logger=self.logger)
         self.swbt_adapter_discovery = SwbtAdapterDiscoveryService()
         self.swbt_controller_factory = SwbtControllerOutputPortFactory(

--- a/src/nyxpy/gui/dialogs/settings/device_tab.py
+++ b/src/nyxpy/gui/dialogs/settings/device_tab.py
@@ -23,6 +23,7 @@ from nyxpy.framework.core.hardware.swbt.discovery import SwbtAdapterView
 from nyxpy.framework.core.hardware.swbt.errors import (
     is_swbt_connect_cancelled,
     swbt_connect_cancel_code,
+    swbt_user_error_message,
 )
 from nyxpy.framework.core.settings.global_settings import GlobalSettings
 from nyxpy.framework.core.settings.secrets_settings import SecretsSettings
@@ -261,16 +262,16 @@ class DeviceSettingsTab(QWidget):
         swbt_form.addRow(QLabel("デバイス:"), adapter_row)
         swbt_form.addRow(QLabel("タイプ:"), self.swbt_controller_type)
 
-        self.swbt_key_store = QComboBox()
-        self.swbt_key_store.setEditable(True)
-        current_key_store = str(self.settings.get("controller.swbt.key_store_path", "") or "")
-        for key_store_path in self._swbt_key_store_candidates(current_key_store):
-            self.swbt_key_store.addItem(key_store_path, key_store_path)
-        self.swbt_key_store.setCurrentText(current_key_store or self._default_swbt_key_store_path())
+        self.swbt_profile = QComboBox()
+        self.swbt_profile.setEditable(True)
+        current_profile = str(self.settings.get("controller.swbt.profile_path", "") or "")
+        for profile_path in self._swbt_profile_candidates(current_profile):
+            self.swbt_profile.addItem(profile_path, profile_path)
+        self.swbt_profile.setCurrentText(current_profile or self._default_swbt_profile_path())
         self.swbt_controller_type.currentIndexChanged.connect(
-            self._update_swbt_key_store_for_controller
+            self._update_swbt_profile_for_controller
         )
-        swbt_form.addRow(QLabel("キーストア:"), self.swbt_key_store)
+        swbt_form.addRow(QLabel("ペアリングプロファイル:"), self.swbt_profile)
 
         lifecycle_row = QHBoxLayout()
         self.swbt_pair_btn = QPushButton("Pair")
@@ -466,12 +467,12 @@ class DeviceSettingsTab(QWidget):
         )
         swbt_adapter = _editable_combo_value(self.swbt_adapter)
         self.settings.set("controller.swbt.adapter", swbt_adapter or None)
-        swbt_key_store = self.swbt_key_store.currentText().strip()
-        self.settings.set("controller.swbt.key_store_path", swbt_key_store or None)
+        swbt_profile = self.swbt_profile.currentText().strip()
+        self.settings.set("controller.swbt.profile_path", swbt_profile or None)
 
-    def _swbt_key_store_candidates(self, current: str) -> tuple[str, ...]:
+    def _swbt_profile_candidates(self, current: str) -> tuple[str, ...]:
         candidates = [
-            str(model.default_key_store_path()).replace("\\", "/")
+            str(model.default_profile_path()).replace("\\", "/")
             for model in supported_controller_models()
         ]
         config_dir = getattr(self.settings, "config_dir", None)
@@ -482,21 +483,21 @@ class DeviceSettingsTab(QWidget):
             candidates.append(current)
         return tuple(dict.fromkeys(candidates))
 
-    def _default_swbt_key_store_path(self) -> str:
+    def _default_swbt_profile_path(self) -> str:
         controller_type = self.swbt_controller_type.currentData()
         for model in supported_controller_models():
             if model.settings_value == controller_type:
-                return str(model.default_key_store_path()).replace("\\", "/")
+                return str(model.default_profile_path()).replace("\\", "/")
         return ""
 
-    def _update_swbt_key_store_for_controller(self) -> None:
-        current = self.swbt_key_store.currentText().strip()
+    def _update_swbt_profile_for_controller(self) -> None:
+        current = self.swbt_profile.currentText().strip()
         defaults = {
-            str(model.default_key_store_path()).replace("\\", "/")
+            str(model.default_profile_path()).replace("\\", "/")
             for model in supported_controller_models()
         }
         if not current or current in defaults:
-            self.swbt_key_store.setCurrentText(self._default_swbt_key_store_path())
+            self.swbt_profile.setCurrentText(self._default_swbt_profile_path())
 
     def _capture_source_type(self) -> str:
         value = self.capture_source_type.currentData()
@@ -548,7 +549,7 @@ class DeviceSettingsTab(QWidget):
         self.swbt_group.setEnabled(self.swbt_actions_enabled)
         self.swbt_controller_type.setEnabled(settings_enabled)
         self.swbt_adapter.setEnabled(settings_enabled)
-        self.swbt_key_store.setEnabled(settings_enabled)
+        self.swbt_profile.setEnabled(settings_enabled)
         adapter_selected = bool(_editable_combo_value(self.swbt_adapter))
         connect_enabled = is_swbt and settings_enabled and adapter_selected
         cancelling_pair = (
@@ -558,13 +559,26 @@ class DeviceSettingsTab(QWidget):
             self._cancel_swbt_connect is not None and self._swbt_connect_operation == "reconnect"
         )
         self.swbt_pair_btn.setEnabled(cancelling_pair or connect_enabled)
-        self.swbt_reconnect_btn.setEnabled(cancelling_reconnect or connect_enabled)
+        self.swbt_reconnect_btn.setEnabled(
+            cancelling_reconnect or (connect_enabled and self._swbt_profile_exists())
+        )
         self.swbt_disconnect_btn.setEnabled(is_swbt and settings_enabled and self._swbt_connected)
         self.refresh_swbt_btn.setEnabled(is_swbt and settings_enabled)
 
     def _set_swbt_busy(self, busy: bool) -> None:
         self._swbt_busy = bool(busy)
         self._update_controller_field_state()
+
+    def _swbt_profile_exists(self) -> bool:
+        value = self.swbt_profile.currentText().strip()
+        if not value:
+            return False
+        path = Path(value)
+        if not path.is_absolute():
+            config_dir = getattr(self.settings, "config_dir", None)
+            if config_dir is not None:
+                path = Path(config_dir).parent / path
+        return path.is_file()
 
     @property
     def swbt_lifecycle_busy(self) -> bool:
@@ -639,7 +653,9 @@ class DeviceSettingsTab(QWidget):
                 )
             else:
                 operation = "disconnect" if disconnect else "connection"
-                self.swbt_status_label.setText(f"{operation} failed: {error}")
+                self.swbt_status_label.setText(
+                    f"{operation} failed: {swbt_user_error_message(error)}"
+                )
             self._swbt_lifecycle_running = False
             self._reset_swbt_connect_action()
             self._set_swbt_busy(False)

--- a/src/nyxpy/gui/main_window.py
+++ b/src/nyxpy/gui/main_window.py
@@ -33,6 +33,7 @@ from nyxpy.framework.core.hardware.swbt.discovery import SwbtAdapterView
 from nyxpy.framework.core.hardware.swbt.errors import (
     is_swbt_connect_cancelled,
     swbt_connect_cancel_code,
+    swbt_user_error_message,
 )
 from nyxpy.framework.core.hardware.window_discovery import WindowInfo, resolve_window
 from nyxpy.framework.core.io.ports import ControllerOutputPort
@@ -356,7 +357,9 @@ class MainWindow(QMainWindow):
         reconnect_action = QAction("Reconnect", menu)
         disconnect_action = QAction("Disconnect", menu)
         pair_action.setEnabled(lifecycle_enabled and adapter_available)
-        reconnect_action.setEnabled(lifecycle_enabled and adapter_available)
+        reconnect_action.setEnabled(
+            lifecycle_enabled and adapter_available and self._swbt_profile_exists()
+        )
         disconnect_action.setEnabled(lifecycle_enabled and self._swbt_is_connected())
         pair_action.triggered.connect(lambda _checked=False: self._invoke_swbt_action("pair"))
         reconnect_action.triggered.connect(
@@ -492,17 +495,17 @@ class MainWindow(QMainWindow):
             "controller.backend": "swbt",
             "controller.swbt.controller_type": controller_type,
         }
-        current_key_store = str(
-            self.global_settings.get("controller.swbt.key_store_path", "") or ""
+        current_profile = str(
+            self.global_settings.get("controller.swbt.profile_path", "") or ""
         ).replace("\\", "/")
         models = supported_controller_models()
-        defaults = {str(model.default_key_store_path()).replace("\\", "/") for model in models}
-        if not current_key_store or current_key_store in defaults:
+        defaults = {str(model.default_profile_path()).replace("\\", "/") for model in models}
+        if not current_profile or current_profile in defaults:
             selected_model = next(
                 model for model in models if model.settings_value == controller_type
             )
-            updates["controller.swbt.key_store_path"] = str(
-                selected_model.default_key_store_path()
+            updates["controller.swbt.profile_path"] = str(
+                selected_model.default_profile_path()
             ).replace("\\", "/")
         return updates
 
@@ -1092,7 +1095,7 @@ class MainWindow(QMainWindow):
         self.status_label.setText(
             "エラー: swbt を切断できません"
             if operation == "disconnect"
-            else "エラー: swbt 接続操作に失敗しました"
+            else f"エラー: {swbt_user_error_message(error)}"
         )
         self._sync_manual_input_state()
         self._update_connection_status()
@@ -1124,6 +1127,31 @@ class MainWindow(QMainWindow):
         except Exception:
             return False
         return bool(status is not None and status.connected)
+
+    def _swbt_profile_exists(self) -> bool:
+        value = str(self.global_settings.get("controller.swbt.profile_path", "") or "").strip()
+        if not value:
+            controller_type = str(
+                self.global_settings.get(
+                    "controller.swbt.controller_type",
+                    "pro-controller",
+                )
+            )
+            model = next(
+                (
+                    candidate
+                    for candidate in supported_controller_models()
+                    if candidate.settings_value == controller_type
+                ),
+                None,
+            )
+            if model is None:
+                return False
+            value = str(model.default_profile_path())
+        path = Path(value)
+        if not path.is_absolute():
+            path = self.project_root / path
+        return path.is_file()
 
     def apply_window_size_preset(self, key: object, *, save: bool = True) -> None:
         preset_key = normalize_window_size_preset_key(key)

--- a/tests/gui/test_device_settings_tab.py
+++ b/tests/gui/test_device_settings_tab.py
@@ -7,6 +7,7 @@ from nyxpy.framework.core.hardware.capture_source import CaptureRect
 from nyxpy.framework.core.hardware.device_discovery import DeviceInfo
 from nyxpy.framework.core.hardware.swbt.discovery import SwbtAdapterView
 from nyxpy.framework.core.hardware.window_discovery import WindowInfo
+from nyxpy.framework.core.macro.exceptions import ConfigurationError
 from nyxpy.gui.dialogs.settings.device_tab import DeviceSettingsTab
 
 
@@ -38,7 +39,7 @@ class FakeSettings:
             "controller.serial.baudrate": 9600,
             "controller.swbt.controller_type": "pro-controller",
             "controller.swbt.adapter": None,
-            "controller.swbt.key_store_path": None,
+            "controller.swbt.profile_path": None,
             "gui.window_size_preset": "full_hd",
         }
 
@@ -139,7 +140,7 @@ def test_device_tab_uses_consistent_controller_terms(qtbot):
         "プロトコル:",
         "ボーレート:",
         "タイプ:",
-        "キーストア:",
+        "ペアリングプロファイル:",
         "接続:",
         "状態:",
     }
@@ -151,7 +152,7 @@ def test_device_tab_uses_consistent_controller_terms(qtbot):
             "Baud Rate:",
             "Controller:",
             "Adapter:",
-            "Key Store:",
+            "Pairing Profile:",
             "Connection:",
             "Status:",
         }
@@ -168,7 +169,7 @@ def test_device_tab_orders_swbt_fields_like_controller_menu(qtbot):
     assert [
         form.itemAt(row, QFormLayout.ItemRole.LabelRole).widget().text()
         for row in range(form.rowCount())
-    ] == ["デバイス:", "タイプ:", "キーストア:", "接続:", "状態:"]
+    ] == ["デバイス:", "タイプ:", "ペアリングプロファイル:", "接続:", "状態:"]
 
 
 def test_device_tab_selects_3ds_default_baudrate(qtbot):
@@ -457,52 +458,52 @@ def test_device_settings_tab_applies_swbt_settings(qtbot):
     tab.controller_backend.setCurrentIndex(tab.controller_backend.findData("swbt"))
     tab.swbt_controller_type.setCurrentIndex(tab.swbt_controller_type.findData("joy-con-l"))
     tab.swbt_adapter.setCurrentIndex(tab.swbt_adapter.findData("hci0"))
-    tab.swbt_key_store.setEditText(".nyxpy/swbt/joy-con-l-bond.json")
+    tab.swbt_profile.setEditText(".nyxpy/swbt/joy-con-l-profile.json")
     tab.apply()
 
     assert settings.data["controller.backend"] == "swbt"
     assert settings.data["controller.swbt.controller_type"] == "joy-con-l"
     assert settings.data["controller.swbt.adapter"] == "hci0"
-    assert settings.data["controller.swbt.key_store_path"] == ".nyxpy/swbt/joy-con-l-bond.json"
+    assert settings.data["controller.swbt.profile_path"] == ".nyxpy/swbt/joy-con-l-profile.json"
 
 
-def test_key_store_lists_model_defaults_and_selects_current_model_default(qtbot) -> None:
+def test_profile_lists_model_defaults_and_selects_current_model_default(qtbot) -> None:
     tab = DeviceSettingsTab(FakeSettings(), None, device_discovery=FakeDiscovery())
     qtbot.addWidget(tab)
 
-    assert tab.swbt_key_store.currentText() == ".nyxpy/swbt/pro-controller-bond.json"
-    assert {tab.swbt_key_store.itemText(index) for index in range(tab.swbt_key_store.count())} >= {
-        ".nyxpy/swbt/pro-controller-bond.json",
-        ".nyxpy/swbt/joy-con-l-bond.json",
-        ".nyxpy/swbt/joy-con-r-bond.json",
+    assert tab.swbt_profile.currentText() == ".nyxpy/swbt/pro-controller-profile.json"
+    assert {tab.swbt_profile.itemText(index) for index in range(tab.swbt_profile.count())} >= {
+        ".nyxpy/swbt/pro-controller-profile.json",
+        ".nyxpy/swbt/joy-con-l-profile.json",
+        ".nyxpy/swbt/joy-con-r-profile.json",
     }
 
 
-def test_key_store_model_change_updates_default_but_preserves_custom_path(qtbot) -> None:
+def test_profile_model_change_updates_default_but_preserves_custom_path(qtbot) -> None:
     tab = DeviceSettingsTab(FakeSettings(), None, device_discovery=FakeDiscovery())
     qtbot.addWidget(tab)
 
     tab.swbt_controller_type.setCurrentIndex(tab.swbt_controller_type.findData("joy-con-l"))
-    assert tab.swbt_key_store.currentText() == ".nyxpy/swbt/joy-con-l-bond.json"
+    assert tab.swbt_profile.currentText() == ".nyxpy/swbt/joy-con-l-profile.json"
 
-    tab.swbt_key_store.setEditText("keys/custom.json")
+    tab.swbt_profile.setEditText("keys/custom.json")
     tab.swbt_controller_type.setCurrentIndex(tab.swbt_controller_type.findData("joy-con-r"))
-    assert tab.swbt_key_store.currentText() == "keys/custom.json"
+    assert tab.swbt_profile.currentText() == "keys/custom.json"
 
 
-def test_key_store_lists_existing_workspace_json_files(qtbot, tmp_path) -> None:
+def test_profile_lists_existing_workspace_json_files(qtbot, tmp_path) -> None:
     class SettingsWithConfigDir(FakeSettings):
         config_dir = tmp_path / ".nyxpy"
 
-    key_store_dir = SettingsWithConfigDir.config_dir / "swbt"
-    key_store_dir.mkdir(parents=True)
-    (key_store_dir / "paired-switch.json").write_text("{}", encoding="utf-8")
-    (key_store_dir / "ignore.txt").write_text("", encoding="utf-8")
+    profile_dir = SettingsWithConfigDir.config_dir / "swbt"
+    profile_dir.mkdir(parents=True)
+    (profile_dir / "paired-switch.json").write_text("{}", encoding="utf-8")
+    (profile_dir / "ignore.txt").write_text("", encoding="utf-8")
 
     tab = DeviceSettingsTab(SettingsWithConfigDir(), None, device_discovery=FakeDiscovery())
     qtbot.addWidget(tab)
 
-    choices = [tab.swbt_key_store.itemText(index) for index in range(tab.swbt_key_store.count())]
+    choices = [tab.swbt_profile.itemText(index) for index in range(tab.swbt_profile.count())]
     assert ".nyxpy/swbt/paired-switch.json" in choices
     assert ".nyxpy/swbt/ignore.txt" not in choices
 
@@ -604,7 +605,37 @@ def test_pair_button_becomes_cancel_and_invokes_pair_cancellation(qtbot) -> None
     assert tab.swbt_pair_btn.text() == "Pair"
 
 
-def test_reconnect_button_becomes_cancel_and_restores_after_nested_cancellation(qtbot) -> None:
+def test_profile_error_displays_individual_code(qtbot) -> None:
+    def pair(_succeeded, failed) -> None:
+        failed(
+            ConfigurationError(
+                "pairing profile uses an unsupported schema",
+                code="NYX_SWBT_PROFILE_INVALID",
+                component="test",
+            )
+        )
+
+    tab = DeviceSettingsTab(
+        FakeSettings(),
+        None,
+        device_discovery=FakeDiscovery(),
+        swbt_pair=pair,
+    )
+    qtbot.addWidget(tab)
+    tab.controller_backend.setCurrentIndex(tab.controller_backend.findData("swbt"))
+    tab.swbt_adapter.setEditText("usb-1")
+
+    tab.swbt_pair_btn.click()
+
+    assert tab.swbt_status_label.text() == (
+        "connection failed: NYX_SWBT_PROFILE_INVALID: pairing profile uses an unsupported schema"
+    )
+
+
+def test_reconnect_button_becomes_cancel_and_restores_after_nested_cancellation(
+    qtbot,
+    tmp_path,
+) -> None:
     cancelled = Event()
     callbacks = {}
 
@@ -612,8 +643,12 @@ def test_reconnect_button_becomes_cancel_and_restores_after_nested_cancellation(
         callbacks["failed"] = failed
         return cancelled.set
 
+    settings = FakeSettings()
+    profile_path = tmp_path / "pro-controller-profile.json"
+    profile_path.touch()
+    settings.data["controller.swbt.profile_path"] = str(profile_path)
     tab = DeviceSettingsTab(
-        FakeSettings(),
+        settings,
         None,
         device_discovery=FakeDiscovery(),
         swbt_reconnect=reconnect,
@@ -644,9 +679,26 @@ def test_reconnect_button_becomes_cancel_and_restores_after_nested_cancellation(
             ],
         )
     )
-
     assert tab.swbt_status_label.text() == "再接続をキャンセルしました"
     assert tab.swbt_reconnect_btn.text() == "Reconnect"
+
+
+def test_reconnect_requires_existing_profile_file(qtbot, tmp_path) -> None:
+    settings = FakeSettings()
+    profile_path = tmp_path / "pro-controller-profile.json"
+    settings.data["controller.swbt.profile_path"] = str(profile_path)
+    tab = DeviceSettingsTab(settings, None, device_discovery=FakeDiscovery())
+    qtbot.addWidget(tab)
+    tab.controller_backend.setCurrentIndex(tab.controller_backend.findData("swbt"))
+    tab.swbt_adapter.setEditText("usb-1")
+
+    assert tab.swbt_pair_btn.isEnabled()
+    assert not tab.swbt_reconnect_btn.isEnabled()
+
+    profile_path.touch()
+    tab._update_controller_field_state()
+
+    assert tab.swbt_reconnect_btn.isEnabled()
 
 
 def test_adapter_refresh_resolves_saved_alias_without_auto_selecting_other(qtbot) -> None:

--- a/tests/gui/test_main_window.py
+++ b/tests/gui/test_main_window.py
@@ -21,7 +21,12 @@ from nyxpy.framework.core.hardware.device_discovery import (
 from nyxpy.framework.core.hardware.swbt.discovery import SwbtAdapterView
 from nyxpy.framework.core.hardware.window_discovery import WindowInfo
 from nyxpy.framework.core.logger import LogSanitizer, LogSinkDispatcher
-from nyxpy.framework.core.macro.exceptions import DeviceError, ErrorInfo, ErrorKind
+from nyxpy.framework.core.macro.exceptions import (
+    ConfigurationError,
+    DeviceError,
+    ErrorInfo,
+    ErrorKind,
+)
 from nyxpy.framework.core.runtime.result import RunResult, RunStatus
 from nyxpy.gui.app_services import SettingsApplyOutcome
 from nyxpy.gui.layout import LEFT_PANE_CONTENT_MARGIN
@@ -81,7 +86,7 @@ class FakeSettings:
                 "swbt": {
                     "controller_type": "pro-controller",
                     "adapter": None,
-                    "key_store_path": None,
+                    "profile_path": None,
                 },
             },
             "capture_fps": None,
@@ -447,6 +452,31 @@ def test_controller_menu_shows_only_swbt_settings_for_swbt_backend(
     assert window.swbt_type_menu is not None
 
 
+def test_swbt_reconnect_menu_requires_existing_profile(
+    window: MainWindow,
+    services: FakeServices,
+) -> None:
+    window.global_settings.set("controller.backend", "swbt")
+    window.global_settings.set("controller.swbt.adapter", "usb:0")
+    window._swbt_adapter_views = services.refresh_swbt_adapters()
+
+    window._refresh_connection_menu()
+
+    assert window.controller_backend_menu is not None
+    lifecycle = {action.text(): action for action in window.controller_backend_menu.actions()}
+    assert lifecycle["Pair"].isEnabled()
+    assert not lifecycle["Reconnect"].isEnabled()
+
+    profile_path = services.project_root / ".nyxpy" / "swbt" / "pro-controller-profile.json"
+    profile_path.parent.mkdir(parents=True)
+    profile_path.touch()
+    window._refresh_connection_menu()
+
+    assert window.controller_backend_menu is not None
+    lifecycle = {action.text(): action for action in window.controller_backend_menu.actions()}
+    assert lifecycle["Reconnect"].isEnabled()
+
+
 def test_swbt_device_menu_canonicalizes_alias_selection(window: MainWindow) -> None:
     window.global_settings.set("controller.backend", "swbt")
     window.global_settings.set("controller.swbt.adapter", "usb:0A12:0001")
@@ -463,10 +493,10 @@ def test_swbt_device_menu_canonicalizes_alias_selection(window: MainWindow) -> N
     assert window.global_settings.get("controller.swbt.adapter") == "usb:0"
 
 
-def test_swbt_type_menu_updates_default_key_store(window: MainWindow) -> None:
+def test_swbt_type_menu_updates_default_profile(window: MainWindow) -> None:
     window.global_settings.set("controller.backend", "swbt")
     window.global_settings.set(
-        "controller.swbt.key_store_path", ".nyxpy/swbt/pro-controller-bond.json"
+        "controller.swbt.profile_path", ".nyxpy/swbt/pro-controller-profile.json"
     )
     window._refresh_connection_menu()
     assert window.swbt_type_menu is not None
@@ -478,14 +508,14 @@ def test_swbt_type_menu_updates_default_key_store(window: MainWindow) -> None:
 
     assert window.global_settings.get("controller.swbt.controller_type") == "joy-con-l"
     assert (
-        window.global_settings.get("controller.swbt.key_store_path")
-        == ".nyxpy/swbt/joy-con-l-bond.json"
+        window.global_settings.get("controller.swbt.profile_path")
+        == ".nyxpy/swbt/joy-con-l-profile.json"
     )
 
 
-def test_swbt_type_menu_preserves_custom_key_store(window: MainWindow) -> None:
+def test_swbt_type_menu_preserves_custom_profile(window: MainWindow) -> None:
     window.global_settings.set("controller.backend", "swbt")
-    window.global_settings.set("controller.swbt.key_store_path", "keys/custom.json")
+    window.global_settings.set("controller.swbt.profile_path", "keys/custom.json")
     window._refresh_connection_menu()
     assert window.swbt_type_menu is not None
     joy_con_r = next(
@@ -495,7 +525,7 @@ def test_swbt_type_menu_preserves_custom_key_store(window: MainWindow) -> None:
     joy_con_r.trigger()
 
     assert window.global_settings.get("controller.swbt.controller_type") == "joy-con-r"
-    assert window.global_settings.get("controller.swbt.key_store_path") == "keys/custom.json"
+    assert window.global_settings.get("controller.swbt.profile_path") == "keys/custom.json"
 
 
 def test_swbt_device_menu_keeps_missing_saved_adapter_visible_and_disables_connect(
@@ -1345,6 +1375,27 @@ def test_reconnect_success_sets_manual_controller(window: MainWindow, services: 
 
     assert services.swbt_calls == ["reconnect"]
     assert window.virtual_controller.model.controller is services.builder.manual_controller
+
+
+def test_connect_failure_displays_profile_error_code(
+    window: MainWindow,
+    services: FakeServices,
+) -> None:
+    error = ConfigurationError(
+        "pairing profile belongs to a different controller type",
+        code="NYX_SWBT_PROFILE_CONTROLLER_MISMATCH",
+        component="test",
+    )
+    failed: list[BaseException] = []
+
+    window._fail_swbt_lifecycle(error, failed.append, operation="connect")
+
+    assert window.status_label.text() == (
+        "エラー: NYX_SWBT_PROFILE_CONTROLLER_MISMATCH: "
+        "pairing profile belongs to a different controller type"
+    )
+    assert failed == [error]
+    assert services.logger.technical_events[-1][3] == "swbt.lifecycle_failed"
 
 
 def test_disconnect_releases_and_clears_manual_controller(

--- a/tests/gui/test_settings_tabs.py
+++ b/tests/gui/test_settings_tabs.py
@@ -18,7 +18,7 @@ class FakeSettings:
             "controller.serial.baudrate": 9600,
             "controller.swbt.controller_type": "pro-controller",
             "controller.swbt.adapter": None,
-            "controller.swbt.key_store_path": None,
+            "controller.swbt.profile_path": None,
             "preview_fps": 60,
         }
 

--- a/tests/hardware/swbt_realdevice_support.py
+++ b/tests/hardware/swbt_realdevice_support.py
@@ -17,7 +17,7 @@ from typing import TextIO
 class SwbtRealDeviceOptions:
     adapter: str
     controller_type: str
-    key_store_path: Path
+    profile_path: Path
     evidence_dir: Path
     timeout_sec: float = 30.0
     operator_confirmation: bool = False
@@ -58,10 +58,10 @@ def load_swbt_realdevice_options(
         )
 
     controller_type = values.get("NYX_SWBT_CONTROLLER_TYPE", "pro-controller").strip()
-    key_store_path = Path(
+    profile_path = Path(
         values.get(
-            "NYX_SWBT_KEY_STORE",
-            f".nyxpy/swbt/{controller_type}-test-bond.json",
+            "NYX_SWBT_PROFILE",
+            f".nyxpy/swbt/{controller_type}-test-profile.json",
         )
     )
     timestamp = (now or datetime.now()).strftime("%Y%m%dT%H%M%S")
@@ -77,7 +77,7 @@ def load_swbt_realdevice_options(
     return SwbtRealDeviceOptions(
         adapter=adapter,
         controller_type=controller_type,
-        key_store_path=key_store_path,
+        profile_path=profile_path,
         evidence_dir=evidence_dir,
         timeout_sec=timeout_sec,
         operator_confirmation=values.get("NYX_SWBT_OPERATOR_CONFIRMATION") == "1",
@@ -163,7 +163,7 @@ class SwbtEvidenceWriter:
             "swbt_python_version": swbt_version,
             "controller_type": options.controller_type,
             "adapter": options.adapter,
-            "key_store_path": _display_path(options.key_store_path),
+            "profile_path": _display_path(options.profile_path),
             "timeout_sec": options.timeout_sec,
             "short_press_ms": list(options.short_press_ms),
             "operator_confirmation": options.operator_confirmation,
@@ -205,7 +205,7 @@ class SwbtEvidenceWriter:
             "",
             f"- controller_type: `{options.controller_type}`",
             f"- adapter: `{options.adapter}`",
-            f"- key_store_path: `{_display_path(options.key_store_path)}`",
+            f"- profile_path: `{_display_path(options.profile_path)}`",
             f"- trace: `{self.trace_path.name}`",
             f"- operator_confirmation: `{self.operator_confirmation_path.name}`",
             "",

--- a/tests/hardware/test_swbt_controller_backend_realdevice.py
+++ b/tests/hardware/test_swbt_controller_backend_realdevice.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import time
 from collections.abc import Iterator, Mapping
 from contextlib import contextmanager
@@ -19,8 +20,10 @@ from nyxpy.framework.core.hardware.swbt.discovery import (
     SwbtAdapterDiscoveryService,
     resolve_adapter,
 )
+from nyxpy.framework.core.hardware.swbt.factory import SwbtControllerOutputPortFactory
 from nyxpy.framework.core.hardware.swbt.session import SwbtControllerSession
 from nyxpy.framework.core.macro.command import DefaultCommand
+from nyxpy.gui.app_services import GuiAppServices
 from tests.hardware.swbt_realdevice_support import (
     SwbtEvidenceResult,
     SwbtEvidenceWriter,
@@ -50,7 +53,7 @@ class SwbtRealDeviceRun:
         return SwbtControllerConfig(
             model=self.model,
             adapter=self.options.adapter,
-            key_store_path=self.options.key_store_path,
+            profile_path=self.options.profile_path,
         )
 
     def record(self, test_name: str, status: str, **details: object) -> None:
@@ -102,27 +105,31 @@ def test_swbt_adapter_discovery_realdevice(swbt_run: SwbtRealDeviceRun) -> None:
 
 def test_swbt_pair_realdevice(swbt_run: SwbtRealDeviceRun) -> None:
     _require_operator_confirmation(swbt_run, "test_swbt_pair_realdevice")
-    swbt_run.options.key_store_path.parent.mkdir(parents=True, exist_ok=True)
+    swbt_run.options.profile_path.parent.mkdir(parents=True, exist_ok=True)
 
     with _session(swbt_run) as session:
         result = session.pair(timeout_sec=swbt_run.options.timeout_sec)
         assert session.connected is True
 
-    assert swbt_run.options.key_store_path.exists()
+    assert swbt_run.options.profile_path.exists()
+    profile_payload = json.loads(swbt_run.options.profile_path.read_text(encoding="utf-8"))
+    assert profile_payload["schema_version"] == 2
     _record_operator_result(
         swbt_run,
         "test_swbt_pair_realdevice",
         prompt="Switch 上で controller の接続が確認できたか (pass/fail/skip): ",
         details={
             "controller_type": swbt_run.options.controller_type,
-            "key_store_exists": True,
+            "profile_path": swbt_run.options.profile_path.name,
+            "profile_schema_version": profile_payload["schema_version"],
+            "initialization_result": "connected",
             "result_type": type(result).__name__,
         },
     )
 
 
 def test_swbt_reconnect_realdevice(swbt_run: SwbtRealDeviceRun) -> None:
-    _require_key_store(swbt_run, "test_swbt_reconnect_realdevice")
+    _require_profile(swbt_run, "test_swbt_reconnect_realdevice")
 
     with _session(swbt_run) as session:
         result = session.reconnect(timeout_sec=swbt_run.options.timeout_sec)
@@ -134,6 +141,76 @@ def test_swbt_reconnect_realdevice(swbt_run: SwbtRealDeviceRun) -> None:
         "pass",
         result_type=type(result).__name__,
         status_type=type(status).__name__,
+        profile_path=swbt_run.options.profile_path.name,
+        initialization_result="connected",
+    )
+
+
+def test_swbt_macro_reconnect_realdevice(
+    tmp_path: Path,
+    swbt_run: SwbtRealDeviceRun,
+) -> None:
+    _require_operator_confirmation(swbt_run, "test_swbt_macro_reconnect_realdevice")
+    _require_profile(swbt_run, "test_swbt_macro_reconnect_realdevice")
+    button = _supported_button(swbt_run.model)
+
+    with swbt_run.writer.open_trace() as trace:
+        factory = SwbtControllerOutputPortFactory(diagnostics_writer=trace)
+        try:
+            port = factory.create(
+                config=swbt_run.config(),
+                allow_dummy=False,
+                timeout_sec=swbt_run.options.timeout_sec,
+            )
+            command = DefaultCommand(context=make_fake_execution_context(tmp_path, controller=port))
+            command.press(button, dur=0.05)
+            status = factory.status(swbt_run.config())
+            assert status is not None
+            assert getattr(status, "connection_state", None) == "connected"
+        finally:
+            factory.close()
+
+    _record_operator_result(
+        swbt_run,
+        "test_swbt_macro_reconnect_realdevice",
+        prompt=f"macro経路のReconnect後に{button.name}が入力されたか (pass/fail/skip): ",
+        details={
+            "button": button.name,
+            "profile_path": swbt_run.options.profile_path.name,
+            "initialization_result": "connected",
+        },
+    )
+
+
+def test_swbt_gui_lifecycle_realdevice(
+    tmp_path: Path,
+    swbt_run: SwbtRealDeviceRun,
+) -> None:
+    _require_operator_confirmation(swbt_run, "test_swbt_gui_lifecycle_realdevice")
+    _require_profile(swbt_run, "test_swbt_gui_lifecycle_realdevice")
+
+    services = GuiAppServices(project_root=tmp_path)
+    with swbt_run.writer.open_trace() as trace:
+        services.swbt_controller_factory = SwbtControllerOutputPortFactory(diagnostics_writer=trace)
+        try:
+            paired = services.pair_swbt_prepared(swbt_run.config())
+            assert paired.connected
+            services.disconnect_swbt()
+            reconnected = services.reconnect_swbt_prepared(swbt_run.config())
+            assert reconnected.connected
+            services.disconnect_swbt()
+        finally:
+            services.close()
+
+    _record_operator_result(
+        swbt_run,
+        "test_swbt_gui_lifecycle_realdevice",
+        prompt="GUI Pair / Disconnect / Reconnect / DisconnectがSwitch上で完了したか (pass/fail/skip): ",
+        details={
+            "profile_path": swbt_run.options.profile_path.name,
+            "pair_result": paired.message,
+            "reconnect_result": reconnected.message,
+        },
     )
 
 
@@ -257,7 +334,7 @@ def _session(run: SwbtRealDeviceRun) -> Iterator[SwbtControllerSession]:
 def _connected_port(
     run: SwbtRealDeviceRun,
 ) -> Iterator[SwbtControllerOutputPort]:
-    _require_key_store(run, "connected_swbt_port")
+    _require_profile(run, "connected_swbt_port")
     with _session(run) as session:
         session.reconnect(timeout_sec=run.options.timeout_sec)
         port = SwbtControllerOutputPort(session=session, model=run.model)
@@ -301,16 +378,16 @@ def _record_operator_result(
         pytest.skip(f"operator skipped {test_name}")
 
 
-def _require_key_store(run: SwbtRealDeviceRun, test_name: str) -> None:
-    if run.options.key_store_path.exists():
+def _require_profile(run: SwbtRealDeviceRun, test_name: str) -> None:
+    if run.options.profile_path.exists():
         return
     run.record(
         test_name,
         "skip",
-        reason="pairing key store is missing; run test_swbt_pair_realdevice first",
-        key_store=str(run.options.key_store_path),
+        reason="pairing profile is missing; run test_swbt_pair_realdevice first",
+        profile_path=str(run.options.profile_path),
     )
-    pytest.skip("swbt key store is missing; run pair test first")
+    pytest.skip("swbt pairing profile is missing; run pair test first")
 
 
 def _supported_button(model: SwbtControllerModel) -> Button:

--- a/tests/integration/test_swbt_docs_examples.py
+++ b/tests/integration/test_swbt_docs_examples.py
@@ -12,7 +12,7 @@ def test_swbt_docs_examples_match_cli_parser() -> None:
         ("nyxpy swbt adapters", ["swbt", "adapters"]),
         ("nyxpy swbt adapters --json", ["swbt", "adapters", "--json"]),
         (
-            "nyxpy swbt pair --adapter usb:0 --controller-type pro-controller --key-store .nyxpy/swbt/pro-controller-bond.json",
+            "nyxpy swbt pair --adapter usb:0 --controller-type pro-controller --profile .nyxpy/swbt/pro-controller-profile.json",
             [
                 "swbt",
                 "pair",
@@ -20,12 +20,12 @@ def test_swbt_docs_examples_match_cli_parser() -> None:
                 "usb:0",
                 "--controller-type",
                 "pro-controller",
-                "--key-store",
-                ".nyxpy/swbt/pro-controller-bond.json",
+                "--profile",
+                ".nyxpy/swbt/pro-controller-profile.json",
             ],
         ),
         (
-            "nyxpy swbt reconnect --adapter usb:0 --controller-type pro-controller --key-store .nyxpy/swbt/pro-controller-bond.json",
+            "nyxpy swbt reconnect --adapter usb:0 --controller-type pro-controller --profile .nyxpy/swbt/pro-controller-profile.json",
             [
                 "swbt",
                 "reconnect",
@@ -33,12 +33,12 @@ def test_swbt_docs_examples_match_cli_parser() -> None:
                 "usb:0",
                 "--controller-type",
                 "pro-controller",
-                "--key-store",
-                ".nyxpy/swbt/pro-controller-bond.json",
+                "--profile",
+                ".nyxpy/swbt/pro-controller-profile.json",
             ],
         ),
         (
-            'nyxpy run sample_macro --controller swbt --swbt-adapter usb:0 --swbt-controller-type pro-controller --swbt-key-store .nyxpy/swbt/pro-controller-bond.json --capture "Capture Device"',
+            'nyxpy run sample_macro --controller swbt --swbt-adapter usb:0 --swbt-controller-type pro-controller --swbt-profile .nyxpy/swbt/pro-controller-profile.json --capture "Capture Device"',
             [
                 "run",
                 "sample_macro",
@@ -48,8 +48,8 @@ def test_swbt_docs_examples_match_cli_parser() -> None:
                 "usb:0",
                 "--swbt-controller-type",
                 "pro-controller",
-                "--swbt-key-store",
-                ".nyxpy/swbt/pro-controller-bond.json",
+                "--swbt-profile",
+                ".nyxpy/swbt/pro-controller-profile.json",
                 "--capture",
                 "Capture Device",
             ],

--- a/tests/integration/test_swbt_runtime_cli_integration.py
+++ b/tests/integration/test_swbt_runtime_cli_integration.py
@@ -39,7 +39,7 @@ def test_swbt_runtime_runs_press_and_imu_with_dummy_session(
     config = SwbtControllerConfig(
         model=resolve_controller_model("pro-controller"),
         adapter="dummy-adapter",
-        key_store_path=tmp_path / ".nyxpy" / "swbt" / "pro-controller-bond.json",
+        profile_path=tmp_path / ".nyxpy" / "swbt" / "pro-controller-profile.json",
     )
     builder = create_device_runtime_builder(
         project_root=tmp_path,

--- a/tests/unit/cli/test_main.py
+++ b/tests/unit/cli/test_main.py
@@ -259,7 +259,7 @@ def make_args():
     args.baud = None
     args.swbt_adapter = None
     args.swbt_controller_type = None
-    args.swbt_key_store = None
+    args.swbt_profile = None
     args.swbt_timeout = None
     args.macro_name = "Sample"
     args.silence = False
@@ -319,6 +319,47 @@ def test_cli_main_success(monkeypatch, tmp_path):
         exec_args={},
         logger=mock_logging.logger,
     )
+
+
+def test_cli_main_logs_legacy_swbt_profile_migration(monkeypatch, tmp_path):
+    args = make_args()
+    paths = patch_cli_workspace(monkeypatch, tmp_path)
+    paths.config_dir.mkdir()
+    (paths.config_dir / "global.toml").write_text(
+        "\n".join(
+            [
+                "[controller.swbt]",
+                'key_store_path = "legacy.json"',
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    mock_logging = MockLoggingComponents()
+
+    monkeypatch.setattr(
+        "nyxpy.cli.run_cli.configure_logging",
+        MagicMock(return_value=mock_logging),
+    )
+    monkeypatch.setattr(
+        "nyxpy.cli.run_cli.create_runtime_builder",
+        MagicMock(return_value=MagicMock()),
+    )
+    monkeypatch.setattr("nyxpy.cli.run_cli.parse_define_args", lambda args: {})
+    monkeypatch.setattr(
+        "nyxpy.cli.run_cli.execute_macro",
+        MagicMock(return_value=result(RunStatus.SUCCESS)),
+    )
+
+    assert cli_main(args) == 0
+    assert (
+        "user",
+        "WARNING",
+        "旧 swbt キーストア設定を削除しました。"
+        "新しいペアリングプロファイルで再ペアリングしてください。",
+        "CLI",
+        "configuration.migrated",
+    ) in mock_logging.logger.logs
 
 
 def test_cli_main_uses_3ds_default_baudrate(monkeypatch, tmp_path):

--- a/tests/unit/cli/test_swbt_cli.py
+++ b/tests/unit/cli/test_swbt_cli.py
@@ -98,7 +98,7 @@ def test_swbt_pair_cli_calls_factory_pair(tmp_path: Path) -> None:
             "swbt_command": "pair",
             "adapter": "usb:0",
             "controller_type": "pro-controller",
-            "key_store": tmp_path / "bond.json",
+            "profile": tmp_path / "profile.json",
             "timeout": 5.0,
         },
     )()
@@ -115,7 +115,7 @@ def test_swbt_pair_cli_calls_factory_pair(tmp_path: Path) -> None:
     assert factory.closed is True
     assert factory.calls[0][0] == "pair"
     assert factory.calls[0][1].adapter == "usb:0"
-    assert factory.calls[0][1].key_store_path == tmp_path / "bond.json"
+    assert factory.calls[0][1].profile_path == tmp_path / "profile.json"
     assert factory.calls[0][2] == 5.0
     assert stdout.getvalue().strip() == "swbt pair completed."
 
@@ -130,7 +130,7 @@ def test_swbt_reconnect_cli_calls_factory_reconnect(tmp_path: Path) -> None:
             "swbt_command": "reconnect",
             "adapter": "usb:0",
             "controller_type": "pro-controller",
-            "key_store": None,
+            "profile": None,
             "timeout": 6.0,
         },
     )()
@@ -160,7 +160,7 @@ def test_swbt_lifecycle_cli_canonicalizes_adapter_alias(tmp_path: Path) -> None:
             "swbt_command": "pair",
             "adapter": "hci0",
             "controller_type": "pro-controller",
-            "key_store": None,
+            "profile": None,
             "timeout": None,
         },
     )()
@@ -214,7 +214,7 @@ def test_swbt_lifecycle_cli_injects_diagnostics_and_closes_logging(
             "swbt_command": "pair",
             "adapter": "usb:0",
             "controller_type": "pro-controller",
-            "key_store": None,
+            "profile": None,
             "timeout": None,
         },
     )()
@@ -247,7 +247,7 @@ def test_swbt_lifecycle_cli_rejects_unselected_missing_and_ambiguous_adapter(
             "swbt_command": "pair",
             "adapter": None,
             "controller_type": "pro-controller",
-            "key_store": None,
+            "profile": None,
             "timeout": None,
         },
     )()
@@ -289,6 +289,19 @@ def test_swbt_disconnect_command_is_not_exposed() -> None:
         parse_arguments(["swbt", "disconnect"])
 
 
+@pytest.mark.parametrize(
+    "arguments",
+    [
+        ["swbt", "pair", "--key-store", "legacy.json"],
+        ["swbt", "reconnect", "--key-store", "legacy.json"],
+        ["run", "sample_macro", "--swbt-key-store", "legacy.json"],
+    ],
+)
+def test_legacy_swbt_profile_options_are_not_accepted(arguments: list[str]) -> None:
+    with pytest.raises(SystemExit):
+        parse_arguments(arguments)
+
+
 def test_swbt_cli_overrides_do_not_mutate_settings(tmp_path: Path) -> None:
     settings = SettingsStore(config_dir=tmp_path / ".nyxpy", strict_load=False)
     settings.set("controller.swbt.adapter", "settings-adapter")
@@ -301,7 +314,7 @@ def test_swbt_cli_overrides_do_not_mutate_settings(tmp_path: Path) -> None:
             "swbt_command": "pair",
             "adapter": "usb:0",
             "controller_type": "pro-controller",
-            "key_store": None,
+            "profile": None,
             "timeout": 2.0,
         },
     )()
@@ -321,3 +334,45 @@ def test_swbt_cli_overrides_do_not_mutate_settings(tmp_path: Path) -> None:
     assert factory.calls[0][1].model.settings_value == "pro-controller"
     assert settings.get("controller.swbt.adapter") == "settings-adapter"
     assert settings.get("controller.swbt.controller_type") == "joy-con-r"
+
+
+def test_swbt_cli_reports_legacy_profile_setting_migration(tmp_path: Path) -> None:
+    config_dir = tmp_path / ".nyxpy"
+    config_dir.mkdir()
+    (config_dir / "global.toml").write_text(
+        "\n".join(
+            [
+                "[controller.swbt]",
+                'key_store_path = "legacy.json"',
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    settings = SettingsStore(config_dir=config_dir)
+    output = io.StringIO()
+    args = type(
+        "Args",
+        (),
+        {
+            "swbt_command": "pair",
+            "adapter": "usb:0",
+            "controller_type": "pro-controller",
+            "profile": None,
+            "timeout": 2.0,
+        },
+    )()
+
+    assert (
+        cli_main(
+            args,
+            discovery_service=Discovery((adapter_view(),)),
+            controller_factory=RecordingFactory(),
+            settings_store=settings,
+            project_root=tmp_path,
+            stdout=output,
+        )
+        == 0
+    )
+
+    assert "再ペアリングしてください" in output.getvalue()

--- a/tests/unit/framework/hardware/swbt/test_config.py
+++ b/tests/unit/framework/hardware/swbt/test_config.py
@@ -17,11 +17,19 @@ from nyxpy.framework.core.macro.exceptions import ConfigurationError
 def test_swbt_dependency_declared_as_runtime_dependency() -> None:
     data = tomllib.loads(Path("pyproject.toml").read_text(encoding="utf-8"))
 
-    assert "swbt-python>=0.2.0,<0.3.0" in data["project"]["dependencies"]
+    assert "swbt-python==0.5.3" in data["project"]["dependencies"]
     assert "swbt" not in data["project"].get("optional-dependencies", {})
     assert any(
         marker.startswith("swbt:") for marker in data["tool"]["pytest"]["ini_options"]["markers"]
     )
+
+
+def test_swbt_lock_resolves_expected_swbt_and_bumble_versions() -> None:
+    data = tomllib.loads(Path("uv.lock").read_text(encoding="utf-8"))
+    locked_versions = {package["name"]: package["version"] for package in data["package"]}
+
+    assert locked_versions["swbt-python"] == "0.5.3"
+    assert locked_versions["bumble"] == "0.0.233"
 
 
 def test_supported_controller_models_returns_three_models_without_swbt_runtime_import(
@@ -46,20 +54,20 @@ def test_parse_controller_type_rejects_unknown_value() -> None:
     assert exc_info.value.code == "NYX_SWBT_CONTROLLER_TYPE_UNSUPPORTED"
 
 
-def test_swbt_config_resolves_default_key_store_per_controller_type() -> None:
+def test_swbt_config_resolves_default_profile_per_controller_type() -> None:
     base_dir = Path(".nyxpy") / "swbt"
 
     assert (
-        resolve_controller_model("pro-controller").default_key_store_path(base_dir)
-        == base_dir / "pro-controller-bond.json"
+        resolve_controller_model("pro-controller").default_profile_path(base_dir)
+        == base_dir / "pro-controller-profile.json"
     )
     assert (
-        resolve_controller_model("joy-con-l").default_key_store_path(base_dir)
-        == base_dir / "joy-con-l-bond.json"
+        resolve_controller_model("joy-con-l").default_profile_path(base_dir)
+        == base_dir / "joy-con-l-profile.json"
     )
     assert (
-        resolve_controller_model("joy-con-r").default_key_store_path(base_dir)
-        == base_dir / "joy-con-r-bond.json"
+        resolve_controller_model("joy-con-r").default_profile_path(base_dir)
+        == base_dir / "joy-con-r-profile.json"
     )
 
 

--- a/tests/unit/framework/hardware/swbt/test_errors.py
+++ b/tests/unit/framework/hardware/swbt/test_errors.py
@@ -1,0 +1,70 @@
+import pytest
+from swbt import (
+    AdapterIdentityRecoveryRequired,
+    InvalidKeyStoreError,
+    InvalidProfileError,
+    ProfileControllerMismatchError,
+)
+
+from nyxpy.framework.core.hardware.swbt.errors import (
+    map_swbt_exception,
+    swbt_user_error_message,
+)
+from nyxpy.framework.core.macro.exceptions import ConfigurationError
+
+
+@pytest.mark.parametrize(
+    ("error", "code"),
+    [
+        (FileNotFoundError("missing"), "NYX_SWBT_PROFILE_NOT_FOUND"),
+        (FileExistsError("exists"), "NYX_SWBT_PROFILE_ALREADY_EXISTS"),
+        (InvalidProfileError("schema v1"), "NYX_SWBT_PROFILE_INVALID"),
+        (
+            ProfileControllerMismatchError(
+                expected_controller_kind="pro-controller",
+                actual_controller_kind="joy-con-l",
+            ),
+            "NYX_SWBT_PROFILE_CONTROLLER_MISMATCH",
+        ),
+        (InvalidKeyStoreError("invalid key"), "NYX_SWBT_PROFILE_KEY_DATA_INVALID"),
+        (
+            AdapterIdentityRecoveryRequired(
+                target_address="02:00:00:00:00:01",
+                stage="reset",
+            ),
+            "NYX_SWBT_ADAPTER_IDENTITY_RECOVERY_REQUIRED",
+        ),
+    ],
+)
+def test_profile_errors_map_to_individual_nyx_codes(
+    error: BaseException,
+    code: str,
+) -> None:
+    mapped = map_swbt_exception(error, component="test")
+
+    assert mapped.code == code
+
+
+def test_adapter_identity_recovery_message_requests_usb_reconnect() -> None:
+    mapped = map_swbt_exception(
+        AdapterIdentityRecoveryRequired(
+            target_address="02:00:00:00:00:01",
+            stage="reset",
+        ),
+        component="test",
+    )
+
+    assert "unplug and reconnect the USB Bluetooth dongle" in str(mapped)
+
+
+def test_user_error_message_finds_profile_error_in_nested_cleanup_group() -> None:
+    profile_error = ConfigurationError(
+        "pairing profile uses an unsupported schema",
+        code="NYX_SWBT_PROFILE_INVALID",
+        component="test",
+    )
+    error = ExceptionGroup("connection and cleanup failed", [profile_error, RuntimeError("close")])
+
+    assert swbt_user_error_message(error) == (
+        "NYX_SWBT_PROFILE_INVALID: pairing profile uses an unsupported schema"
+    )

--- a/tests/unit/framework/hardware/swbt/test_factory.py
+++ b/tests/unit/framework/hardware/swbt/test_factory.py
@@ -95,7 +95,7 @@ def config(adapter: str = "usb:0") -> SwbtControllerConfig:
     return SwbtControllerConfig(
         model=model,
         adapter=adapter,
-        key_store_path=Path(".nyxpy/swbt/pro-controller-bond.json"),
+        profile_path=Path(".nyxpy/swbt/pro-controller-profile.json"),
     )
 
 
@@ -229,7 +229,7 @@ def test_factory_pair_discards_cached_dummy_session() -> None:
     assert failed_real.close_calls == 1
     assert dummy.close_calls == 1
     assert dummy.pair_calls == 0
-    assert next_real.open_calls == 1
+    assert next_real.open_calls == 0
     assert next_real.pair_calls == 1
 
 
@@ -275,7 +275,7 @@ def test_factory_discards_failed_pair_session() -> None:
     with pytest.raises(ConfigurationError):
         factory.pair(cfg, timeout_sec=1.0)
 
-    assert session.open_calls == 1
+    assert session.open_calls == 0
     assert session.pair_calls == 1
     assert session.close_calls == 1
     assert factory.status(cfg) is None
@@ -288,7 +288,7 @@ def test_factory_pair_reconnect_disconnect_and_status_are_explicit_operations() 
 
     factory.pair(cfg, timeout_sec=2.0)
     factory.reconnect(cfg, timeout_sec=3.0)
-    assert factory.status(cfg) == {"open_calls": 2}
+    assert factory.status(cfg) == {"open_calls": 1}
 
     factory.disconnect(cfg)
     factory.disconnect(cfg)
@@ -418,7 +418,7 @@ def test_factory_releases_previous_session_when_same_adapter_key_changes() -> No
     first_config = config()
     second_config = replace(
         first_config,
-        key_store_path=Path(".nyxpy/swbt/other-pro-controller-bond.json"),
+        profile_path=Path(".nyxpy/swbt/other-pro-controller-profile.json"),
     )
 
     first_port = factory.create(config=first_config, allow_dummy=False)

--- a/tests/unit/framework/hardware/swbt/test_realdevice_support.py
+++ b/tests/unit/framework/hardware/swbt/test_realdevice_support.py
@@ -22,7 +22,7 @@ def test_swbt_realdevice_options_from_environment(tmp_path: Path) -> None:
         "NYX_SWBT": "1",
         "NYX_SWBT_ADAPTER": "usb:0",
         "NYX_SWBT_CONTROLLER_TYPE": "joy-con-l",
-        "NYX_SWBT_KEY_STORE": str(tmp_path / "joy-con-l-test-bond.json"),
+        "NYX_SWBT_PROFILE": str(tmp_path / "joy-con-l-test-profile.json"),
         "NYX_SWBT_TIMEOUT": "7.5",
         "NYX_SWBT_EVIDENCE_DIR": str(tmp_path / "evidence"),
         "NYX_SWBT_OPERATOR_CONFIRMATION": "1",
@@ -35,7 +35,7 @@ def test_swbt_realdevice_options_from_environment(tmp_path: Path) -> None:
 
     assert options.adapter == "usb:0"
     assert options.controller_type == "joy-con-l"
-    assert options.key_store_path == tmp_path / "joy-con-l-test-bond.json"
+    assert options.profile_path == tmp_path / "joy-con-l-test-profile.json"
     assert options.evidence_dir == tmp_path / "evidence"
     assert options.timeout_sec == 7.5
     assert options.operator_confirmation is True
@@ -54,7 +54,7 @@ def test_swbt_realdevice_options_default_paths_are_controller_specific() -> None
 
     options = load_swbt_realdevice_options(env, now=datetime(2026, 7, 10, 1, 2, 3))
 
-    assert options.key_store_path == Path(".nyxpy/swbt/joy-con-r-test-bond.json")
+    assert options.profile_path == Path(".nyxpy/swbt/joy-con-r-test-profile.json")
     assert options.evidence_dir == Path("tmp/hardware/swbt/20260710T010203")
     assert options.timeout_sec == 30.0
     assert options.operator_confirmation is False
@@ -87,11 +87,11 @@ def test_swbt_realdevice_options_reject_invalid_operator_results() -> None:
 
 
 def test_swbt_evidence_writer_redacts_absolute_paths(tmp_path: Path) -> None:
-    key_store = tmp_path / "private" / "pro-controller-test-bond.json"
+    profile_path = tmp_path / "private" / "pro-controller-test-profile.json"
     options = SwbtRealDeviceOptions(
         adapter="usb:0",
         controller_type="pro-controller",
-        key_store_path=key_store,
+        profile_path=profile_path,
         evidence_dir=tmp_path / "evidence",
     )
     writer = SwbtEvidenceWriter(options.evidence_dir)
@@ -102,14 +102,14 @@ def test_swbt_evidence_writer_redacts_absolute_paths(tmp_path: Path) -> None:
             SwbtEvidenceResult(
                 test_name="test_swbt_pair_realdevice",
                 status="pass",
-                details={"key_store": str(key_store.name)},
+                details={"profile": str(profile_path.name)},
             )
         ],
     )
 
     summary = writer.summary_path.read_text(encoding="utf-8")
     assert str(tmp_path) not in summary
-    assert ".../pro-controller-test-bond.json" in summary
+    assert ".../pro-controller-test-profile.json" in summary
 
 
 def test_swbt_operator_confirmation_records_result(tmp_path: Path) -> None:
@@ -135,7 +135,7 @@ def test_resolve_operator_result_prefers_per_test_then_default_then_stdin(tmp_pa
     options = SwbtRealDeviceOptions(
         adapter="usb:0",
         controller_type="pro-controller",
-        key_store_path=tmp_path / "bond.json",
+        profile_path=tmp_path / "profile.json",
         evidence_dir=tmp_path / "evidence",
         operator_confirmation=True,
         operator_result="fail",
@@ -155,7 +155,7 @@ def test_resolve_operator_result_prefers_per_test_then_default_then_stdin(tmp_pa
     interactive_options = SwbtRealDeviceOptions(
         adapter="usb:0",
         controller_type="pro-controller",
-        key_store_path=tmp_path / "bond.json",
+        profile_path=tmp_path / "profile.json",
         evidence_dir=tmp_path / "evidence",
         operator_confirmation=True,
     )
@@ -176,7 +176,7 @@ def test_resolve_operator_result_does_not_treat_unavailable_stdin_as_pass(
     options = SwbtRealDeviceOptions(
         adapter="usb:0",
         controller_type="pro-controller",
-        key_store_path=tmp_path / "bond.json",
+        profile_path=tmp_path / "profile.json",
         evidence_dir=tmp_path / "evidence",
         operator_confirmation=True,
     )

--- a/tests/unit/framework/hardware/swbt/test_session.py
+++ b/tests/unit/framework/hardware/swbt/test_session.py
@@ -1,4 +1,6 @@
 import asyncio
+import json
+from dataclasses import replace
 from pathlib import Path
 from threading import Event, Thread
 
@@ -126,13 +128,44 @@ class CancellationAwareFakeSwbtController(AwaitableFakeSwbtController):
             raise
 
 
+class ReportingReadyFakeSwbtController(FakeSwbtController):
+    def __init__(self) -> None:
+        super().__init__()
+        self.status_calls = 0
+
+    def status(self) -> GamepadStatus:
+        self.calls.append(("status", None))
+        self.status_calls += 1
+        report_count = 15 if self.status_calls == 1 else 16
+        return GamepadStatus(
+            connection_state=self.connection_state,
+            report_counters={0x30: report_count},
+            last_subcommand_id=None,
+            raw_rumble=None,
+            last_error=None,
+        )
+
+
 def config() -> SwbtControllerConfig:
     model = resolve_controller_model("pro-controller")
     return SwbtControllerConfig(
         model=model,
         adapter="usb:0",
-        key_store_path=Path(".nyxpy/swbt/pro-controller-bond.json"),
+        profile_path=Path(".nyxpy/swbt/pro-controller-profile.json"),
     )
+
+
+def _capture_error(errors: list[BaseException], operation) -> None:
+    try:
+        operation()
+    except BaseException as exc:
+        errors.append(exc)
+
+
+@pytest.fixture(autouse=True)
+def existing_profile(monkeypatch) -> None:
+    """既存テストは作成済みprofileからのPair経路を検証する。"""
+    monkeypatch.setattr(SwbtControllerSession, "_profile_exists", lambda _self: True)
 
 
 def test_session_open_does_not_pair_or_reconnect() -> None:
@@ -144,6 +177,37 @@ def test_session_open_does_not_pair_or_reconnect() -> None:
 
     assert fake.calls == [("open", None)]
     assert not session.connected
+
+
+def test_session_pair_creates_profile_and_owns_returned_controller(monkeypatch) -> None:
+    fake = FakeSwbtController()
+    fake.connection_state = "connected"
+    calls: list[tuple[SwbtControllerConfig, float]] = []
+
+    async def create_profile(
+        profile_config: SwbtControllerConfig,
+        _writer,
+        timeout_sec: float,
+    ) -> FakeSwbtController:
+        calls.append((profile_config, timeout_sec))
+        return fake
+
+    session = SwbtControllerSession(
+        config(),
+        controller_factory=lambda _config, _writer: pytest.fail(
+            "normal controller construction must not run"
+        ),
+        profile_creator=create_profile,
+    )
+    monkeypatch.setattr(session, "_profile_exists", lambda: False)
+
+    session.pair(timeout_sec=12.0)
+
+    assert calls == [(session.config, 12.0)]
+    assert fake.calls == [("status", None)]
+    assert session.connected
+    session.close()
+    assert fake.closed
 
 
 def test_session_pair_cancels_pending_awaitable_without_waiting_for_timeout() -> None:
@@ -168,6 +232,58 @@ def test_session_pair_cancels_pending_awaitable_without_waiting_for_timeout() ->
     assert not thread.is_alive()
     assert len(errors) == 1
     assert getattr(errors[0], "code", None) == "NYX_SWBT_PAIR_CANCELLED"
+
+
+def test_session_retries_pair_with_profile_left_after_create_cancellation(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    profile_path = tmp_path / "pro-controller-profile.json"
+    profile_started = Event()
+
+    async def create_profile(
+        _config: SwbtControllerConfig,
+        _writer,
+        _timeout_sec: float,
+    ) -> object:
+        profile_path.write_text('{"schema_version": 2}', encoding="utf-8")
+        profile_started.set()
+        await asyncio.sleep(3600)
+        raise AssertionError("profile creation should be cancelled")
+
+    first = SwbtControllerSession(
+        replace(config(), profile_path=profile_path),
+        profile_creator=create_profile,
+    )
+    monkeypatch.setattr(first, "_profile_exists", profile_path.is_file)
+    cancellation_event = Event()
+    errors: list[BaseException] = []
+    thread = Thread(
+        target=lambda: _capture_error(
+            errors,
+            lambda: first.pair(
+                timeout_sec=30.0,
+                cancellation_event=cancellation_event,
+            ),
+        )
+    )
+    thread.start()
+    assert profile_started.wait(1.0)
+    cancellation_event.set()
+    thread.join(1.0)
+
+    assert getattr(errors[0], "code", None) == "NYX_SWBT_PAIR_CANCELLED"
+    assert profile_path.is_file()
+
+    fake = FakeSwbtController()
+    second = SwbtControllerSession(
+        replace(config(), profile_path=profile_path),
+        controller_factory=lambda _config, _writer: fake,
+    )
+    monkeypatch.setattr(second, "_profile_exists", profile_path.is_file)
+    second.pair(timeout_sec=5.0)
+
+    assert fake.calls[:3] == [("open", None), ("pair", 5.0), ("status", None)]
 
 
 def test_session_reconnect_cancels_after_awaitable_started() -> None:
@@ -212,6 +328,21 @@ def test_session_pair_reconnect_apply_status_and_close() -> None:
     assert ("reconnect", 20.0) in fake.calls
     assert fake.calls[-1] == ("close", True)
     assert fake.closed is True
+
+
+def test_session_waits_for_periodic_input_report_after_reconnect() -> None:
+    fake = ReportingReadyFakeSwbtController()
+    session = SwbtControllerSession(config(), controller_factory=lambda _config, _writer: fake)
+
+    session.reconnect(timeout_sec=1.0)
+
+    assert fake.status_calls == 2
+    assert fake.calls[:4] == [
+        ("open", None),
+        ("reconnect", 1.0),
+        ("status", None),
+        ("status", None),
+    ]
 
 
 def test_session_waits_for_awaitable_controller_methods() -> None:
@@ -381,7 +512,7 @@ def test_session_requires_adapter_before_open() -> None:
         SwbtControllerConfig(
             model=model,
             adapter=None,
-            key_store_path=Path(".nyxpy/swbt/pro-controller-bond.json"),
+            profile_path=Path(".nyxpy/swbt/pro-controller-profile.json"),
         )
     )
 
@@ -389,6 +520,65 @@ def test_session_requires_adapter_before_open() -> None:
         session.open()
 
     assert getattr(exc_info.value, "code", None) == "NYX_SWBT_ADAPTER_NOT_SELECTED"
+
+
+def test_session_reconnect_without_profile_reports_profile_not_found(tmp_path: Path) -> None:
+    profile_path = tmp_path / "missing-profile.json"
+    session = SwbtControllerSession(replace(config(), profile_path=profile_path))
+
+    with pytest.raises(Exception) as exc_info:
+        session.reconnect(timeout_sec=1.0)
+
+    assert getattr(exc_info.value, "code", None) == "NYX_SWBT_PROFILE_NOT_FOUND"
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"legacy": "key-store"},
+        {
+            "format": "swbt.profile",
+            "schema_version": 1,
+            "controller_kind": "pro",
+            "identity": {"kind": "adapter-default"},
+            "key_store": {"namespaces": {}},
+        },
+    ],
+)
+def test_session_rejects_legacy_and_schema_v1_profiles(
+    tmp_path: Path,
+    payload: dict[str, object],
+) -> None:
+    profile_path = tmp_path / "legacy.json"
+    profile_path.write_text(json.dumps(payload), encoding="utf-8")
+    session = SwbtControllerSession(replace(config(), profile_path=profile_path))
+
+    with pytest.raises(Exception) as exc_info:
+        session.open()
+
+    assert getattr(exc_info.value, "code", None) == "NYX_SWBT_PROFILE_INVALID"
+
+
+def test_session_rejects_profile_for_different_controller_type(tmp_path: Path) -> None:
+    profile_path = tmp_path / "joy-con-l-profile.json"
+    profile_path.write_text(
+        json.dumps(
+            {
+                "format": "swbt.profile",
+                "schema_version": 2,
+                "controller_kind": "joycon_l",
+                "identity": {"kind": "adapter-default"},
+                "key_store": {"namespaces": {}},
+            }
+        ),
+        encoding="utf-8",
+    )
+    session = SwbtControllerSession(replace(config(), profile_path=profile_path))
+
+    with pytest.raises(Exception) as exc_info:
+        session.open()
+
+    assert getattr(exc_info.value, "code", None) == ("NYX_SWBT_PROFILE_CONTROLLER_MISMATCH")
 
 
 def test_dummy_session_records_state_without_bluetooth_transport() -> None:

--- a/tests/unit/framework/io/test_controller_config.py
+++ b/tests/unit/framework/io/test_controller_config.py
@@ -43,7 +43,7 @@ def test_controller_config_rejects_legacy_serial_flat_keys() -> None:
     assert exc_info.value.code == "NYX_CONTROLLER_LEGACY_SERIAL_SETTINGS_UNSUPPORTED"
 
 
-def test_swbt_controller_config_resolves_model_and_default_key_store(tmp_path: Path) -> None:
+def test_swbt_controller_config_resolves_model_and_default_profile(tmp_path: Path) -> None:
     config = controller_config_from_settings(
         {
             "controller": {
@@ -62,7 +62,7 @@ def test_swbt_controller_config_resolves_model_and_default_key_store(tmp_path: P
     assert isinstance(config, SwbtControllerConfig)
     assert config.model.controller_type is SwbtControllerType.JOY_CON_L
     assert config.adapter is None
-    assert config.key_store_path == tmp_path / ".nyxpy" / "swbt" / "joy-con-l-bond.json"
+    assert config.profile_path == tmp_path / ".nyxpy" / "swbt" / "joy-con-l-profile.json"
     assert config.connect_timeout_sec == 12.0
     assert config.report_period_us is None
 
@@ -75,7 +75,7 @@ def test_swbt_controller_config_does_not_keep_controller_type_string() -> None:
                 "swbt": {
                     "controller_type": "pro-controller",
                     "adapter": "usb:0",
-                    "key_store_path": ".nyxpy/swbt/pro.json",
+                    "profile_path": ".nyxpy/swbt/pro.json",
                 },
             }
         }
@@ -85,17 +85,17 @@ def test_swbt_controller_config_does_not_keep_controller_type_string() -> None:
     assert not hasattr(config, "controller_type")
     assert config.model.controller_type is SwbtControllerType.PRO_CONTROLLER
     assert config.adapter == "usb:0"
-    assert config.key_store_path == Path(".nyxpy/swbt/pro.json")
+    assert config.profile_path == Path(".nyxpy/swbt/pro.json")
 
 
-def test_swbt_relative_key_store_is_resolved_from_workspace_root(tmp_path: Path) -> None:
+def test_swbt_relative_profile_is_resolved_from_workspace_root(tmp_path: Path) -> None:
     config = controller_config_from_settings(
         {
             "controller": {
                 "backend": "swbt",
                 "swbt": {
                     "adapter": "usb:0",
-                    "key_store_path": ".nyxpy/swbt/pro.json",
+                    "profile_path": ".nyxpy/swbt/pro.json",
                 },
             }
         },
@@ -103,7 +103,7 @@ def test_swbt_relative_key_store_is_resolved_from_workspace_root(tmp_path: Path)
     )
 
     assert isinstance(config, SwbtControllerConfig)
-    assert config.key_store_path == tmp_path / ".nyxpy" / "swbt" / "pro.json"
+    assert config.profile_path == tmp_path / ".nyxpy" / "swbt" / "pro.json"
 
 
 def test_controller_config_overrides_do_not_mutate_settings(tmp_path: Path) -> None:

--- a/tests/unit/framework/runtime/test_runtime_builder.py
+++ b/tests/unit/framework/runtime/test_runtime_builder.py
@@ -330,7 +330,7 @@ def test_make_controller_port_factory_selects_swbt(tmp_path: Path) -> None:
     swbt_config = SwbtControllerConfig(
         model=resolve_controller_model("pro-controller"),
         adapter="usb:0",
-        key_store_path=tmp_path / ".nyxpy" / "swbt" / "pro-controller-bond.json",
+        profile_path=tmp_path / ".nyxpy" / "swbt" / "pro-controller-profile.json",
         connect_timeout_sec=4.0,
     )
     builder = create_device_runtime_builder(
@@ -363,7 +363,7 @@ def test_run_swbt_does_not_resolve_serial_protocol(monkeypatch, tmp_path: Path) 
     swbt_config = SwbtControllerConfig(
         model=resolve_controller_model("pro-controller"),
         adapter="usb:0",
-        key_store_path=tmp_path / ".nyxpy" / "swbt" / "pro-controller-bond.json",
+        profile_path=tmp_path / ".nyxpy" / "swbt" / "pro-controller-profile.json",
     )
     builder = create_device_runtime_builder(
         project_root=tmp_path,
@@ -628,7 +628,7 @@ def test_swbt_gui_lifetime_controller_never_allows_dummy(tmp_path: Path) -> None
     config = SwbtControllerConfig(
         model=resolve_controller_model("pro-controller"),
         adapter="usb:0",
-        key_store_path=tmp_path / ".nyxpy" / "swbt" / "bond.json",
+        profile_path=tmp_path / ".nyxpy" / "swbt" / "profile.json",
     )
     builder = create_device_runtime_builder(
         project_root=tmp_path,

--- a/tests/unit/framework/settings/test_settings_schema.py
+++ b/tests/unit/framework/settings/test_settings_schema.py
@@ -75,6 +75,49 @@ def test_settings_store_get_set_supports_dotted_keys(tmp_path) -> None:
     assert store.get("controller.serial.baudrate") == 115200
 
 
+def test_settings_store_migrates_legacy_swbt_key_without_touching_old_file(tmp_path) -> None:
+    legacy_profile = tmp_path / "legacy-key-store.json"
+    legacy_profile.write_text('{"legacy": true}', encoding="utf-8")
+    config_path = tmp_path / "global.toml"
+    config_path.write_text(
+        "\n".join(
+            [
+                "[controller.swbt]",
+                'controller_type = "joy-con-l"',
+                f'key_store_path = "{legacy_profile.as_posix()}"',
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    store = SettingsStore(config_dir=tmp_path)
+
+    assert store.get("controller.swbt.profile_path") == (".nyxpy/swbt/joy-con-l-profile.json")
+    assert "key_store_path" not in store.data["controller"]["swbt"]
+    assert legacy_profile.read_text(encoding="utf-8") == '{"legacy": true}'
+    assert "key_store_path" not in config_path.read_text(encoding="utf-8")
+    assert store.migration_notices
+
+
+def test_settings_store_keeps_explicit_profile_when_removing_legacy_key(tmp_path) -> None:
+    (tmp_path / "global.toml").write_text(
+        "\n".join(
+            [
+                "[controller.swbt]",
+                'key_store_path = "legacy.json"',
+                'profile_path = "current-profile.json"',
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    store = SettingsStore(config_dir=tmp_path)
+
+    assert store.get("controller.swbt.profile_path") == "current-profile.json"
+
+
 def test_settings_store_rejects_invalid_schema_type(tmp_path) -> None:
     (tmp_path / "global.toml").write_text(
         '[controller.serial]\nbaudrate = "fast"\n',

--- a/uv.lock
+++ b/uv.lock
@@ -161,29 +161,27 @@ wheels = [
 
 [[package]]
 name = "bumble"
-version = "0.0.230"
+version = "0.0.233"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp", marker = "sys_platform != 'emscripten'" },
     { name = "click", marker = "sys_platform != 'emscripten'" },
     { name = "cryptography" },
-    { name = "grpcio", marker = "sys_platform != 'emscripten'" },
     { name = "humanize", marker = "sys_platform != 'emscripten'" },
     { name = "libusb-package", marker = "sys_platform != 'android' and sys_platform != 'emscripten'" },
     { name = "libusb1", marker = "sys_platform != 'emscripten'" },
     { name = "platformdirs", marker = "sys_platform != 'emscripten'" },
     { name = "prettytable", marker = "sys_platform != 'emscripten'" },
     { name = "prompt-toolkit", marker = "sys_platform != 'emscripten'" },
-    { name = "protobuf", marker = "sys_platform != 'emscripten'" },
     { name = "pyee" },
     { name = "pyserial", marker = "sys_platform != 'emscripten'" },
     { name = "pyserial-asyncio", marker = "sys_platform != 'emscripten'" },
     { name = "pyusb", marker = "sys_platform != 'emscripten'" },
     { name = "websockets", marker = "sys_platform != 'emscripten'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b0/96/cd23ffd3d86bfcf8ac9cb402e03c2a297ea88c9bcd6ab7c4afdd5bbc32f9/bumble-0.0.230.tar.gz", hash = "sha256:1064d45e8370fc2b1bb684c0efd59534407ea16c3a2811985ed50a886fa3b674", size = 2402123, upload-time = "2026-06-15T07:47:30.036Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7a/f6/cdf94a381181a712ee6959c0cba5973744410b19886ecb994977dcb2be4c/bumble-0.0.233.tar.gz", hash = "sha256:0883e2dc744f0b8228f5095f54bdf8df7f74e47d92bc5fd97ebfc2ee48630f54", size = 2406210, upload-time = "2026-07-15T10:16:26.202Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c1/a9/8115d7262fa5cc6c1f57fc8aec3ac1fc0ed7b1217942a49a9bfe530c4976/bumble-0.0.230-py3-none-any.whl", hash = "sha256:2210aa681a1d278794a6ee788d64e04cc72d4cb908689e383194bdf55d654c65", size = 695633, upload-time = "2026-06-15T07:47:28.495Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/c1/92d2ff77a857134a99b84f4c551ebd65b268dd357a8a2e5dc834c3e84699/bumble-0.0.233-py3-none-any.whl", hash = "sha256:dbeda4370507a0d55cf0fdf0c3b4b565f9793600454e24852e51baddd44c63f1", size = 700852, upload-time = "2026-07-15T10:16:24.797Z" },
 ]
 
 [[package]]
@@ -552,37 +550,6 @@ wheels = [
 ]
 
 [[package]]
-name = "grpcio"
-version = "1.83.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "typing-extensions", marker = "sys_platform != 'emscripten'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/0c/98/304898ac4e04e2d5e4e4c2eadc178b1f2a16d5f4bc2f91306c87d64680b9/grpcio-1.83.0.tar.gz", hash = "sha256:7674587248fbbb2ac6e4eecf83a8a0f3d91a928f941de571acfd3a2f007fbc24", size = 13428824, upload-time = "2026-07-23T15:20:37.759Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/15/2b/51e32514a4e9b715375c99721aadff0f24164cc2049b8269eda4de82a814/grpcio-1.83.0-cp312-cp312-linux_armv7l.whl", hash = "sha256:28f6c35ac8fcf10e4594f138e468f194360089dde40d126a7033e863fc479930", size = 6303167, upload-time = "2026-07-23T15:19:33.78Z" },
-    { url = "https://files.pythonhosted.org/packages/39/33/b5b50fc2c6fbe350e04814047bb2d409feec7b36ef8b170254c050e06bc0/grpcio-1.83.0-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:33898e6a28e4ae598f1577cb1c4fec2a15c033d0ec52b9b45a09610dd045b9da", size = 12160538, upload-time = "2026-07-23T15:19:35.958Z" },
-    { url = "https://files.pythonhosted.org/packages/7b/5f/734e72e7b9f79bcf0b2c270b8d3bca0e4ebb97a27a50d06240b145f6d41e/grpcio-1.83.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:6fb8a1dd0c6f0f931e69e9d0dc6d1c406ed2a44fa963414eafba07b7fb685d16", size = 6869310, upload-time = "2026-07-23T15:19:38.607Z" },
-    { url = "https://files.pythonhosted.org/packages/a4/17/a1735f215b2a5cd43c38b79eac072ad197e61be9829905b6b29550abd0db/grpcio-1.83.0-cp312-cp312-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:2b5e75c34842cd9c1b95285ca395c6a569664b81e3ffa6b714125922942abaaf", size = 7613472, upload-time = "2026-07-23T15:19:40.645Z" },
-    { url = "https://files.pythonhosted.org/packages/b2/78/c9e81f806ac704b6b145cb01628db398985b1f8dfdc10e23b55fb0902b3d/grpcio-1.83.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:aeb339838db07600481ef869507279b75326c75eac6d10f7afa62a0da1d2bcdd", size = 7040616, upload-time = "2026-07-23T15:19:42.349Z" },
-    { url = "https://files.pythonhosted.org/packages/9a/ba/94cd5af859876049d340480acbb61a959096c84b567f215534faa78d0424/grpcio-1.83.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:f47d62808b4c0a97b78bff88a6d4ca283a2a492b9a04a87d814af95ca3b9c19c", size = 7570491, upload-time = "2026-07-23T15:19:44.357Z" },
-    { url = "https://files.pythonhosted.org/packages/3e/15/108d30d5a5c964312ae8b9cb0e8cc5b3c1cc68d8f757cca52b3565534d26/grpcio-1.83.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:62003babc444a606dcd1f009cd16391ce23669ae4ad6ec267a873da7937a69f5", size = 8605036, upload-time = "2026-07-23T15:19:46.454Z" },
-    { url = "https://files.pythonhosted.org/packages/ea/23/3828ae13c3db8233d123ad612747665817b952d8a954f32390230b582336/grpcio-1.83.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:1aa567f8c3f19850ffd5d2858c9a8ea7c80f0db6c01186b71eb31e923ec984f5", size = 7981587, upload-time = "2026-07-23T15:19:48.913Z" },
-    { url = "https://files.pythonhosted.org/packages/17/5b/77af31228f55f55a2a5112bb0077ad0a1c4d23dbb0c2853a62475bbdcc14/grpcio-1.83.0-cp312-cp312-win32.whl", hash = "sha256:cb2906c61db4f9c64cc360054b5df70eeb81846228e9e56a4944bd415a63dadc", size = 4394004, upload-time = "2026-07-23T15:19:50.618Z" },
-    { url = "https://files.pythonhosted.org/packages/c0/da/f706e39550e7a3732ce2b9c5926107a93d74a802775b19b642a6df27dc96/grpcio-1.83.0-cp312-cp312-win_amd64.whl", hash = "sha256:1c699bbb20f143c8f2bff219de578aa2dc1f919399d67dc702b038b986ee62df", size = 5158525, upload-time = "2026-07-23T15:19:52.246Z" },
-    { url = "https://files.pythonhosted.org/packages/56/eb/135daaa713f32d33b8f99b4153b3f8dc3b2a124996ac15581bf9ebdad3c3/grpcio-1.83.0-cp313-cp313-linux_armv7l.whl", hash = "sha256:6662f3b1e07cc7493d437351860dc867bddc6a93c83ecf33bbfdaf0c217ab2d0", size = 6304480, upload-time = "2026-07-23T15:19:53.962Z" },
-    { url = "https://files.pythonhosted.org/packages/8f/a1/121806ce69f23138dabe06aa595b0e5f1ae051a37e4c1954eed7d692c800/grpcio-1.83.0-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:74fe6f9e8a35c7dbf32255ee154d15e3e5338a81ed39173d079d594d2e544cd1", size = 12154419, upload-time = "2026-07-23T15:19:56.3Z" },
-    { url = "https://files.pythonhosted.org/packages/b0/e8/d0389e09cd6b4c4d3089b92967ae4e3ffd64795bd349bf2f85cd6656d3da/grpcio-1.83.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:10b3fa0475eb572c9a81a6fe37fa16a9c500c0c91cfc148cac15692b7e3c2867", size = 6873200, upload-time = "2026-07-23T15:19:58.701Z" },
-    { url = "https://files.pythonhosted.org/packages/f8/51/f464c1d211fa50d5adbabe1b2e519948d99c13757052bfc9ea7afa28e284/grpcio-1.83.0-cp313-cp313-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:5f20a988480b0f28207f057f7f7ae1313393c3cef0adcfeae8248f9947eaf881", size = 7618811, upload-time = "2026-07-23T15:20:00.733Z" },
-    { url = "https://files.pythonhosted.org/packages/e8/c0/539fe0832f2dd6500a28f5263071623fb34e8d4867aec632ccf81bd21156/grpcio-1.83.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7bd82671b39065ba18cd536e9cd45b27ff649053f81ddd2c6a966d595067080f", size = 7042310, upload-time = "2026-07-23T15:20:02.675Z" },
-    { url = "https://files.pythonhosted.org/packages/8c/ca/ccf617d37ffa72567fa8e005ec7090c99da922799be2fb9847c8b21ca18c/grpcio-1.83.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:bc60215b5cb9fc8ca72942c498b551ac2305bd08f6ef8d4e3f0d21b64fbecd61", size = 7575412, upload-time = "2026-07-23T15:20:04.712Z" },
-    { url = "https://files.pythonhosted.org/packages/eb/b9/fd8d5245f823a8e0fd35d90e20ea3aa4acd47f8d5318fa8df307df52dec6/grpcio-1.83.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:f1c3e5689d4b90987b1d72022bcfe866a9a3dc66197484cf856d96b6150e7f45", size = 8604248, upload-time = "2026-07-23T15:20:06.77Z" },
-    { url = "https://files.pythonhosted.org/packages/14/1e/f37632fc11db72dfa4bba86c3a43e54358e53030df111ecae5e91a733ad6/grpcio-1.83.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:a21cb4eeeba124443f399be2e8b624943cde864dcbe588cb42e5c483a52a906c", size = 7977458, upload-time = "2026-07-23T15:20:09.109Z" },
-    { url = "https://files.pythonhosted.org/packages/93/b6/d70b69ae5c0cfc341b9ba474980e4ed99cbf05c0e4a14e9eee8cb73db0a5/grpcio-1.83.0-cp313-cp313-win32.whl", hash = "sha256:8fe04f1050a59f875601eb55d42b4f66946fe89817f967e34db1462ccd07dadf", size = 4393993, upload-time = "2026-07-23T15:20:11.017Z" },
-    { url = "https://files.pythonhosted.org/packages/0f/13/45d4cccb555cf4c476226979bf3d2fd0b0254216f7564c3a053e35117efc/grpcio-1.83.0-cp313-cp313-win_amd64.whl", hash = "sha256:6e01ecd9d8ef280abe1365138a4dc318f9a5287f4cb1b41d07816f796653f735", size = 5159650, upload-time = "2026-07-23T15:20:12.979Z" },
-]
-
-[[package]]
 name = "h11"
 version = "0.16.0"
 source = { registry = "https://pypi.org/simple" }
@@ -683,6 +650,15 @@ wheels = [
 ]
 
 [[package]]
+name = "importlib-resources"
+version = "7.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e4/06/b56dfa750b44e86157093bc8fca0ab81dccbf5260510de4eaf1cb69b5b99/importlib_resources-7.1.0.tar.gz", hash = "sha256:0722d4c6212489c530f2a145a34c0a7a3b4721bc96a15fada5930e2a0b760708", size = 44985, upload-time = "2026-04-12T16:36:09.232Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8a/db/55a262f3606bebcae07cc14095338471ad7c0bbcaa37707e6f0ee49725b7/importlib_resources-7.1.0-py3-none-any.whl", hash = "sha256:1bd7b48b4088eddb2cd16382150bb515af0bd2c70128194392725f82ad2c96a1", size = 37232, upload-time = "2026-04-12T16:36:08.219Z" },
+]
+
+[[package]]
 name = "iniconfig"
 version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -705,9 +681,21 @@ wheels = [
 
 [[package]]
 name = "libusb-package"
-version = "1.0.26.1"
+version = "1.0.26.4"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/46/eb/4640c50f990f0b7433803f3553a08bbdf8b0d2d121704297b6b4708579bc/libusb-package-1.0.26.1.tar.gz", hash = "sha256:5a586744a59e3870791c28f964568e211f5f44bb398ccb51b25f3565dd4666ad", size = 3267835, upload-time = "2022-12-18T21:50:45.117Z" }
+dependencies = [
+    { name = "importlib-resources", marker = "sys_platform != 'android' and sys_platform != 'emscripten'" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/01/34/fd042950325366cb8f01e1873cd87f8aa99e773586377a8e670d6127dc8e/libusb_package-1.0.26.4-py3-none-macosx_10_9_x86_64.whl", hash = "sha256:ce3711a82a2b4b9936a6268c9cbad794c34ae3b1b2c5cc9aeced8340db678668", size = 63859, upload-time = "2026-06-19T11:04:23.822Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/49/bcc1e79a0d86f3da7cc3494093b4973cb1c74852d7356ce533bb1bd58342/libusb_package-1.0.26.4-py3-none-macosx_11_0_arm64.whl", hash = "sha256:4ef4accbadd40f8a054b0298604555d8175ebd376a87978302a83d0311a0b116", size = 58009, upload-time = "2026-06-19T11:04:25.013Z" },
+    { url = "https://files.pythonhosted.org/packages/04/44/68c96f634d96edbfa792ff5f695a144ffddc146e581eaa9a25ab6d5c0f6d/libusb_package-1.0.26.4-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:41cf65507337277bd2a5b9ce3b4f4744214a3c42cdca7b31cade824b168f34cb", size = 70574, upload-time = "2026-06-19T11:04:25.881Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/d0/ef347f6a283c1bde984af5aae3ba71ebf612d022c0a3cd1458ae58cc3c66/libusb_package-1.0.26.4-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:44baf60d639f97e61d2091212295b9f34e7ca58082c355f5fab44ad46ac4595e", size = 70759, upload-time = "2026-06-19T11:04:26.745Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/bd/d4f95fa0dcb361a52db973dd449110abe29bd82c9f035fc5ed870940576d/libusb_package-1.0.26.4-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:7ce9d8754b3531b4562ed209a807d80b8b6b82b1a6191726be1b9e5478b36a25", size = 71583, upload-time = "2026-06-19T11:04:27.725Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/a0/8feafd54179c5c92b4d77adf43a91c8f13b45830d7e72c12707542309953/libusb_package-1.0.26.4-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:dad68fc57d3e0562c2bd705ab8cbafbf27047b86bff74643c01f084b00a48557", size = 71112, upload-time = "2026-06-19T11:04:28.546Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/c3/3e4a5891c8bec95ff856fadbffc84b8158703df7c09e7bd16d09f475d8f7/libusb_package-1.0.26.4-py3-none-win32.whl", hash = "sha256:9d1f5c925e11ecc9f0b9af888d45fd696fd96cf666b42694ee8c8628b5b4cd9a", size = 77716, upload-time = "2026-06-19T11:04:29.557Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/fc/8c42060a9acf016a6dcb0ca352c9c0d6a993e64eecb1c9869fb59bbb4702/libusb_package-1.0.26.4-py3-none-win_amd64.whl", hash = "sha256:cd8c1f5df3906444ba6eff82ef44a75515b0444b76bba8abf21cc8569637af63", size = 90665, upload-time = "2026-06-19T11:04:30.541Z" },
+]
 
 [[package]]
 name = "libusb1"
@@ -1094,7 +1082,7 @@ requires-dist = [
     { name = "pyside6", specifier = ">=6.11.0,<7.0.0" },
     { name = "requests", specifier = ">=2.34.0,<3.0.0" },
     { name = "setuptools", specifier = ">=82.0.1" },
-    { name = "swbt-python", specifier = ">=0.2.0,<0.3.0" },
+    { name = "swbt-python", specifier = "==0.5.3" },
     { name = "tomlkit", specifier = ">=0.15.1,<0.16.0" },
     { name = "windows-capture", marker = "sys_platform == 'win32' and extra == 'windows'", specifier = ">=2.0.0,<3.0.0" },
 ]
@@ -1341,8 +1329,8 @@ name = "ponkan-python"
 version = "0.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "libusb1" },
-    { name = "numpy" },
+    { name = "libusb1", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux') or (sys_platform != 'android' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'linux')" },
+    { name = "numpy", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux') or (sys_platform != 'android' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'linux')" },
     { name = "pyd3xx", marker = "sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/dc/16/e7da562982fd996f19957498182b9337f4f08e43e584bd73058f13725dc3/ponkan_python-0.2.0.tar.gz", hash = "sha256:08d01565a989265564fcfce77a7bdee995ed1ebf2eee6ee00c3948a1ad8de18a", size = 87727, upload-time = "2026-06-15T14:12:48.78Z" }
@@ -1658,11 +1646,11 @@ name = "pyobjc-framework-avfoundation"
 version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pyobjc-core" },
-    { name = "pyobjc-framework-cocoa" },
-    { name = "pyobjc-framework-coreaudio" },
-    { name = "pyobjc-framework-coremedia" },
-    { name = "pyobjc-framework-quartz" },
+    { name = "pyobjc-core", marker = "sys_platform == 'darwin'" },
+    { name = "pyobjc-framework-cocoa", marker = "sys_platform == 'darwin'" },
+    { name = "pyobjc-framework-coreaudio", marker = "sys_platform == 'darwin'" },
+    { name = "pyobjc-framework-coremedia", marker = "sys_platform == 'darwin'" },
+    { name = "pyobjc-framework-quartz", marker = "sys_platform == 'darwin'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/2e/26/7616f0bc8e4eaaba948cf5d220c8f55e0f54f617a2812392a82f19c30f39/pyobjc_framework_avfoundation-12.2.1.tar.gz", hash = "sha256:2735e4f1c345d2b533541577e292f3ad2f75d19200eff99f1a2db16d78b4f1a3", size = 410329, upload-time = "2026-06-19T16:19:52.413Z" }
 wheels = [
@@ -1676,7 +1664,7 @@ name = "pyobjc-framework-cocoa"
 version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pyobjc-core" },
+    { name = "pyobjc-core", marker = "sys_platform == 'darwin'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/51/34/fbe38a204643aa4e1b91391cdce07a34da565a69171ebcad08de7438a556/pyobjc_framework_cocoa-12.2.1.tar.gz", hash = "sha256:b94b37fe5730e5ae1fb0052912cd174e6ec329b0bfba4a012ae5db1014b5864b", size = 3125751, upload-time = "2026-06-19T16:20:05.159Z" }
 wheels = [
@@ -1690,8 +1678,8 @@ name = "pyobjc-framework-coreaudio"
 version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pyobjc-core" },
-    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-core", marker = "sys_platform == 'darwin'" },
+    { name = "pyobjc-framework-cocoa", marker = "sys_platform == 'darwin'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ad/df/f1d402bb7b437374f942bb19410a955a74291867c77a920d9c13887d9e48/pyobjc_framework_coreaudio-12.2.1.tar.gz", hash = "sha256:7dfbf1851523aed453af43a628e057d8950d6e020574aa497a2e4f559b6383c8", size = 78690, upload-time = "2026-06-19T16:20:10.586Z" }
 wheels = [
@@ -1705,8 +1693,8 @@ name = "pyobjc-framework-coremedia"
 version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pyobjc-core" },
-    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-core", marker = "sys_platform == 'darwin'" },
+    { name = "pyobjc-framework-cocoa", marker = "sys_platform == 'darwin'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/e3/79/f501d730a9c320e0b2b3916e95f57e66dd6736d210a1aa5b63eb6c43e605/pyobjc_framework_coremedia-12.2.1.tar.gz", hash = "sha256:71b45f7cd52bd997d836c15a0e1016db90815a219dc87fd20435a6f08b87df7b", size = 98252, upload-time = "2026-06-19T16:20:15.75Z" }
 wheels = [
@@ -1720,8 +1708,8 @@ name = "pyobjc-framework-quartz"
 version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pyobjc-core" },
-    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-core", marker = "sys_platform == 'darwin'" },
+    { name = "pyobjc-framework-cocoa", marker = "sys_platform == 'darwin'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/3b/f6/2a8b84dbf1fe7c04dd96ea73d991678d4e09a909f51971ecc51629bb2ab4/pyobjc_framework_quartz-12.2.1.tar.gz", hash = "sha256:b3b8b6f71e66147f8ff9e6213864cc8527e3a0b1ee90835b93ce221f4802d9b0", size = 3215521, upload-time = "2026-06-19T16:21:30.199Z" }
 wheels = [
@@ -2107,14 +2095,14 @@ wheels = [
 
 [[package]]
 name = "swbt-python"
-version = "0.2.0"
+version = "0.5.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "bumble" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/05/45/ee6ed3422d9e9ecd355cc3ae8f865bdb1647b1542ac33fce73f0caff08b1/swbt_python-0.2.0.tar.gz", hash = "sha256:7d3c4e1a57f112a46c3d39e9e34710c7f7846b8a14a33df5c1f7cd51365f130e", size = 398066, upload-time = "2026-07-08T14:46:39.404Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3d/a3/7218a82585e42fa9f5436a6de45c213ccd7b8de06614862ff0537c80ac92/swbt_python-0.5.3.tar.gz", hash = "sha256:507ebe03971b774fda7fce078a5ffd026d3af02882971e07d6da0a31214ad38a", size = 584292, upload-time = "2026-07-25T07:24:52.163Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/01/b9/60db67ae8c907d5b3debcf8a41ce128eaa74131ec14a5016c0e15b408ed9/swbt_python-0.2.0-py3-none-any.whl", hash = "sha256:c65583daf70b0123ac0733bedd8b982a11b32ed7c20f8f28e46130f8f9b1a3d7", size = 66394, upload-time = "2026-07-08T14:46:37.871Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/c1/165aa0eef20bc0fe8257473ac58fa22e1521560c773b0ce1b1504d5a58bf/swbt_python-0.5.3-py3-none-any.whl", hash = "sha256:ce1cbaccaae043490833500592d5395e5808e5a295f4981114c73e1de805a85a", size = 83482, upload-time = "2026-07-25T07:24:50.524Z" },
 ]
 
 [[package]]
@@ -2341,8 +2329,8 @@ name = "windows-capture"
 version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy" },
-    { name = "opencv-python" },
+    { name = "numpy", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux') or (sys_platform != 'android' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'linux')" },
+    { name = "opencv-python", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux') or (sys_platform != 'android' and sys_platform != 'darwin' and sys_platform != 'emscripten' and sys_platform != 'linux')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/7e/60/1acdf4a4bb625bf04e94afde8bdb60a06997e644c6be7befe413dc5215ed/windows_capture-2.0.0.tar.gz", hash = "sha256:f1d587c182afa06c060e36ba2bd4f216a8ed03f320f51d7b6d5c8a2759469956", size = 68942, upload-time = "2026-04-14T17:17:18.199Z" }
 wheels = [


### PR DESCRIPTION
## Summary

swbt-python を 0.5.3 に更新し、schema v2 pairing profile を用いる Pair / Reconnect と GUI・CLI 設定を実装する。
接続直後の周期 input report が始まる前に入力を送っていた問題を修正する。

## Related

- closes #195

## Changes

- 旧キーストアを廃止し、controller 種別ごとの schema v2 profile へ移行
- Pair / Reconnect 後、`report_counters[0x30]` の増加を確認してから入力を許可
- CLI、GUI、設定移行、原因別エラー表示を profile 契約へ更新
- Pro Controller、Joy-Con (L)/(R) の実機 Pair / Reconnect と入力・lifecycle 証跡を追加

## Commit Log

```
6260bc4 feat(swbt): swbt-python 0.5.3のprofile移行を完了
```

## Testing

```
uv run ruff check .
uv run ty check src/nyxpy --output-format concise --no-progress
uv run mkdocs build --strict
uv run pytest --basetemp C:\Users\train\AppData\Local\Temp\ProjectNyxIssue195FullPytest
# 871 passed, 20 skipped
```

実機では Pro Controller、Joy-Con (L)、Joy-Con (R) の Pair / Reconnect を確認した。Pro Controller は macro A、D-pad、左右 stick、16/33/50 ms 短押し、neutral、GUI lifecycle を確認した。IMU gyro 値の画面反映と D-pad 右上の右成分は観察画面の制約により未確認として記録した。

## Checklist

- [x] lint / format チェック通過
- [x] 既存テスト通過
- [x] コミット prefix が変更の動機と一致している
- [x] 新規・変更コードに対するテスト追加
- [x] 型チェック通過

## Review Notes

既存の別件未コミット差分はステージング・PRに含めていない。